### PR TITLE
feat: Add Network Stats

### DIFF
--- a/app/src/main/java/com/aoscoremonitor/MainActivity.kt
+++ b/app/src/main/java/com/aoscoremonitor/MainActivity.kt
@@ -23,6 +23,7 @@ import com.aoscoremonitor.ui.screens.SystemDiagnosticsScreen
 import com.aoscoremonitor.ui.screens.SystemInfoScreen
 import com.aoscoremonitor.ui.screens.WelcomeScreen
 import com.aoscoremonitor.ui.screens.jni.NativeSystemMonitorScreen
+import com.aoscoremonitor.ui.screens.jni.NetworkStatsScreen
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
 
 class MainActivity : ComponentActivity() {
@@ -53,6 +54,7 @@ class MainActivity : ComponentActivity() {
                                 onNavigateToFrameworkAnalysis = { currentScreen = Screen.FrameworkAnalysis },
                                 onNavigateToHalInfo = { currentScreen = Screen.HalInfo },
                                 onNavigateToNativeSystemMonitor = { currentScreen = Screen.NativeSystemMonitor },
+                                onNavigateToNetworkStats = { currentScreen = Screen.NetworkStats },
                                 modifier = Modifier.padding(innerPadding)
                             )
                         }
@@ -95,6 +97,12 @@ class MainActivity : ComponentActivity() {
                         }
                         Screen.NativeSystemMonitor -> {
                             NativeSystemMonitorScreen(
+                                onNavigateBack = { currentScreen = Screen.Welcome },
+                                modifier = Modifier.padding(innerPadding)
+                            )
+                        }
+                        Screen.NetworkStats -> {
+                            NetworkStatsScreen(
                                 onNavigateBack = { currentScreen = Screen.Welcome },
                                 modifier = Modifier.padding(innerPadding)
                             )

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeSystemMonitor.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeSystemMonitor.kt
@@ -3,12 +3,13 @@ package com.aoscoremonitor.diagnostics.jni
 import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.json.JSONObject
 
 class NativeSystemMonitor {
     companion object {
         private const val TAG = "NativeSystemMonitor"
 
-        // 　Roading the native library
+        // Loading the native library
         init {
             try {
                 System.loadLibrary("system_monitor")
@@ -23,6 +24,7 @@ class NativeSystemMonitor {
     external fun getCpuInfoNative(): String
     external fun getMemInfoNative(): String
     external fun getProcessInfoNative(pid: Int): String
+    external fun getNetworkStatsNative(): String
 
     suspend fun getCpuInfo(): Map<String, Long> = withContext(Dispatchers.IO) {
         val cpuInfo = mutableMapOf<String, Long>()
@@ -83,5 +85,97 @@ class NativeSystemMonitor {
             Log.e(TAG, "Error parsing process info", e)
         }
         processInfo
+    }
+
+    data class InterfaceStats(
+        val rxBytes: Long,
+        val rxPackets: Long,
+        val rxErrors: Long,
+        val rxDropped: Long,
+        val txBytes: Long,
+        val txPackets: Long,
+        val txErrors: Long,
+        val txDropped: Long
+    ) {
+        fun getFormattedRxBytes(): String = formatBytes(rxBytes)
+        fun getFormattedTxBytes(): String = formatBytes(txBytes)
+
+        private fun formatBytes(bytes: Long): String {
+            return when {
+                bytes < 1024 -> "$bytes B"
+                bytes < 1024 * 1024 -> "${bytes / 1024} KB"
+                bytes < 1024 * 1024 * 1024 -> "${bytes / (1024 * 1024)} MB"
+                else -> "${bytes / (1024 * 1024 * 1024)} GB"
+            }
+        }
+    }
+
+    suspend fun getNetworkStats(): Map<String, InterfaceStats> = withContext(Dispatchers.IO) {
+        val networkStats = mutableMapOf<String, InterfaceStats>()
+        try {
+            val jsonData = getNetworkStatsNative()
+            val jsonObject = JSONObject(jsonData)
+
+            val interfaceNames = jsonObject.keys()
+            while (interfaceNames.hasNext()) {
+                val interfaceName = interfaceNames.next()
+                val interfaceData = jsonObject.getJSONObject(interfaceName)
+
+                networkStats[interfaceName] = InterfaceStats(
+                    rxBytes = interfaceData.getLong("rx_bytes"),
+                    rxPackets = interfaceData.getLong("rx_packets"),
+                    rxErrors = interfaceData.getLong("rx_errors"),
+                    rxDropped = interfaceData.getLong("rx_dropped"),
+                    txBytes = interfaceData.getLong("tx_bytes"),
+                    txPackets = interfaceData.getLong("tx_packets"),
+                    txErrors = interfaceData.getLong("tx_errors"),
+                    txDropped = interfaceData.getLong("tx_dropped")
+                )
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing network stats", e)
+        }
+
+        // Use dummy data if data could not be obtained.
+        if (networkStats.isEmpty()) {
+            return@withContext getDummyNetworkStats()
+        }
+
+        networkStats
+    }
+
+    private fun getDummyNetworkStats(): Map<String, InterfaceStats> {
+        return mapOf(
+            "dummy:wlan0" to InterfaceStats(
+                rxBytes = 1024 * 1024 * 50, // 50 MB
+                rxPackets = 1500,
+                rxErrors = 2,
+                rxDropped = 0,
+                txBytes = 1024 * 1024 * 10, // 10 MB
+                txPackets = 800,
+                txErrors = 0,
+                txDropped = 1
+            ),
+            "dummy:eth0" to InterfaceStats(
+                rxBytes = 1024 * 1024 * 25, // 25 MB
+                rxPackets = 1200,
+                rxErrors = 1,
+                rxDropped = 0,
+                txBytes = 1024 * 1024 * 5, // 5 MB
+                txPackets = 600,
+                txErrors = 0,
+                txDropped = 0
+            ),
+            "dummy:rmnet0" to InterfaceStats(
+                rxBytes = 1024 * 1024 * 120, // 120 MB
+                rxPackets = 3500,
+                rxErrors = 5,
+                rxDropped = 2,
+                txBytes = 1024 * 1024 * 30, // 30 MB
+                txPackets = 2200,
+                txErrors = 1,
+                txDropped = 3
+            )
+        )
     }
 }

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/Screen.kt
@@ -8,5 +8,6 @@ enum class Screen {
     SecurityInfo,
     FrameworkAnalysis,
     HalInfo,
-    NativeSystemMonitor
+    NativeSystemMonitor,
+    NetworkStats
 }

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/WelcomeScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.NetworkCell
 import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Card
@@ -55,6 +56,7 @@ fun WelcomeScreen(
     onNavigateToFrameworkAnalysis: () -> Unit,
     onNavigateToHalInfo: () -> Unit,
     onNavigateToNativeSystemMonitor: () -> Unit,
+    onNavigateToNetworkStats: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var visible by remember { mutableStateOf(false) }
@@ -138,6 +140,12 @@ fun WelcomeScreen(
                 icon = Icons.Default.Memory,
                 color = MaterialTheme.colorScheme.tertiary,
                 onClick = onNavigateToNativeSystemMonitor
+            ),
+            MenuItem(
+                title = "Network Stats",
+                icon = Icons.Default.NetworkCell,
+                color = MaterialTheme.colorScheme.primary,
+                onClick = onNavigateToNetworkStats
             )
         )
 

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/NetworkStatsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/NetworkStatsScreen.kt
@@ -1,0 +1,231 @@
+package com.aoscoremonitor.ui.screens.jni
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.NetworkCell
+import androidx.compose.material.icons.filled.NetworkCheck
+import androidx.compose.material.icons.filled.SignalCellular4Bar
+import androidx.compose.material.icons.filled.Upload
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.aoscoremonitor.diagnostics.jni.NativeSystemMonitor
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NetworkStatsScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var networkStats by remember { mutableStateOf<Map<String, NativeSystemMonitor.InterfaceStats>>(emptyMap()) }
+    var refreshing by remember { mutableStateOf(false) }
+
+    val systemMonitor = remember { NativeSystemMonitor() }
+
+    // Update information periodically
+    LaunchedEffect(Unit) {
+        while (isActive) {
+            refreshing = true
+            networkStats = systemMonitor.getNetworkStats()
+            refreshing = false
+            delay(2000) // Update every 2 seconds
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Network Interface Statistics") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            if (networkStats.isEmpty()) {
+                EmptyNetworkStats(refreshing)
+            } else {
+                NetworkStatsList(networkStats)
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyNetworkStats(refreshing: Boolean) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.NetworkCell,
+            contentDescription = null,
+            modifier = Modifier.size(56.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Text(
+            text = if (refreshing) "Loading network statistics..." else "No network interfaces found",
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(top = 16.dp)
+        )
+    }
+}
+
+@Composable
+private fun NetworkStatsList(networkStats: Map<String, NativeSystemMonitor.InterfaceStats>) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        items(networkStats.entries.toList()) { (interfaceName, stats) ->
+            NetworkInterfaceCard(interfaceName, stats)
+        }
+    }
+}
+
+@Composable
+private fun NetworkInterfaceCard(interfaceName: String, stats: NativeSystemMonitor.InterfaceStats) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            // Interface Name Header
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Icon(
+                    imageVector = Icons.Default.SignalCellular4Bar,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(28.dp)
+                )
+                Text(
+                    text = interfaceName,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+
+            HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))
+
+            // Download Statistics
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(vertical = 4.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Download,
+                    contentDescription = "Received",
+                    tint = MaterialTheme.colorScheme.secondary,
+                    modifier = Modifier.size(20.dp)
+                )
+                Column(modifier = Modifier.padding(start = 8.dp)) {
+                    Text(
+                        text = "Received: ${stats.getFormattedRxBytes()}",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Text(
+                        text = "Packets: ${stats.rxPackets} (Errors: ${stats.rxErrors}, Dropped: ${stats.rxDropped})",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+
+            // Upload Statistics
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(vertical = 4.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Upload,
+                    contentDescription = "Transmitted",
+                    tint = MaterialTheme.colorScheme.tertiary,
+                    modifier = Modifier.size(20.dp)
+                )
+                Column(modifier = Modifier.padding(start = 8.dp)) {
+                    Text(
+                        text = "Transmitted: ${stats.getFormattedTxBytes()}",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Text(
+                        text = "Packets: ${stats.txPackets} (Errors: ${stats.txErrors}, Dropped: ${stats.txDropped})",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+            }
+
+            // Total transfer
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(top = 8.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.NetworkCheck,
+                    contentDescription = "Total",
+                    tint = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.size(20.dp)
+                )
+                Text(
+                    text = "Total Transfer: ${stats.getFormattedRxBytes()} received, ${stats.getFormattedTxBytes()} transmitted",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium,
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature to monitor network interface statistics in the AOS Core Monitor application. It includes changes to both the native code and the Android UI to support this functionality.

### New Feature: Network Interface Statistics

* Added a new JNI function `getNetworkStatsNative` to read and format network statistics from `/proc/net/dev` in the native code (`app/src/main/cpp/system_monitor.cpp`).
* Introduced a new `NetworkStatsScreen` in the Android UI to display network interface statistics (`app/src/main/java/com/aoscoremonitor/ui/screens/jni/NetworkStatsScreen.kt`).

### UI Updates

* Updated `MainActivity` to include navigation to the new `NetworkStatsScreen` (`app/src/main/java/com/aoscoremonitor/MainActivity.kt`). [[1]](diffhunk://#diff-cf7e8266a684f048f4d8d6d2ecbb70eb3bc3ffe138719df09886f4c3e15cf167R57) [[2]](diffhunk://#diff-cf7e8266a684f048f4d8d6d2ecbb70eb3bc3ffe138719df09886f4c3e15cf167R104-R109)
* Added a new menu item for navigating to the `NetworkStatsScreen` in the `WelcomeScreen` (`app/src/main/java/com/aoscoremonitor/ui/screens/WelcomeScreen.kt`).

### Data Handling

* Extended the `NativeSystemMonitor` class to include methods for fetching and parsing network statistics (`app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeSystemMonitor.kt`).
* Added a new data class `InterfaceStats` to represent network statistics in a structured format (`app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeSystemMonitor.kt`).

### Navigation and Enum Updates

* Updated the `Screen` enum to include the new `NetworkStats` screen (`app/src/main/java/com/aoscoremonitor/ui/navigation/Screen.kt`).

These changes collectively introduce the capability to monitor and display network interface statistics within the application, enhancing its diagnostic capabilities.…nterface statistics