### PR TITLE
feat: Implement TCP Connections Monitoring

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,6 +11,7 @@ trim_trailing_whitespace = true
 
 [*.{kt,kts}]
 ktlint_code_style = android_studio
+ktlint_disabled_rules=no-wildcard-imports
 
 [*.{cpp,h,hpp,cc,c}]
 indent_size = 2

--- a/app/src/main/java/com/aoscoremonitor/MainActivity.kt
+++ b/app/src/main/java/com/aoscoremonitor/MainActivity.kt
@@ -24,6 +24,7 @@ import com.aoscoremonitor.ui.screens.SystemInfoScreen
 import com.aoscoremonitor.ui.screens.WelcomeScreen
 import com.aoscoremonitor.ui.screens.jni.NativeSystemMonitorScreen
 import com.aoscoremonitor.ui.screens.jni.NetworkStatsScreen
+import com.aoscoremonitor.ui.screens.jni.TcpConnectionsScreen
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
 
 class MainActivity : ComponentActivity() {
@@ -55,6 +56,7 @@ class MainActivity : ComponentActivity() {
                                 onNavigateToHalInfo = { currentScreen = Screen.HalInfo },
                                 onNavigateToNativeSystemMonitor = { currentScreen = Screen.NativeSystemMonitor },
                                 onNavigateToNetworkStats = { currentScreen = Screen.NetworkStats },
+                                onNavigateToTcpConnections = { currentScreen = Screen.TcpConnections },
                                 modifier = Modifier.padding(innerPadding)
                             )
                         }
@@ -103,6 +105,12 @@ class MainActivity : ComponentActivity() {
                         }
                         Screen.NetworkStats -> {
                             NetworkStatsScreen(
+                                onNavigateBack = { currentScreen = Screen.Welcome },
+                                modifier = Modifier.padding(innerPadding)
+                            )
+                        }
+                        Screen.TcpConnections -> {
+                            TcpConnectionsScreen(
                                 onNavigateBack = { currentScreen = Screen.Welcome },
                                 modifier = Modifier.padding(innerPadding)
                             )

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/Screen.kt
@@ -9,5 +9,6 @@ enum class Screen {
     FrameworkAnalysis,
     HalInfo,
     NativeSystemMonitor,
-    NetworkStats
+    NetworkStats,
+    TcpConnections
 }

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/WelcomeScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/WelcomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material.icons.filled.BarChart
+import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.List
 import androidx.compose.material.icons.filled.Memory
@@ -57,6 +58,7 @@ fun WelcomeScreen(
     onNavigateToHalInfo: () -> Unit,
     onNavigateToNativeSystemMonitor: () -> Unit,
     onNavigateToNetworkStats: () -> Unit,
+    onNavigateToTcpConnections: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var visible by remember { mutableStateOf(false) }
@@ -146,6 +148,12 @@ fun WelcomeScreen(
                 icon = Icons.Default.NetworkCell,
                 color = MaterialTheme.colorScheme.primary,
                 onClick = onNavigateToNetworkStats
+            ),
+            MenuItem(
+                title = "TCP Connections",
+                icon = Icons.Default.Cloud,
+                color = MaterialTheme.colorScheme.error,
+                onClick = onNavigateToTcpConnections
             )
         )
 

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/NetworkStatsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/NetworkStatsScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.filled.NetworkCell
 import androidx.compose.material.icons.filled.NetworkCheck
 import androidx.compose.material.icons.filled.SignalCellular4Bar
 import androidx.compose.material.icons.filled.Upload
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -119,11 +120,19 @@ private fun EmptyNetworkStats(refreshing: Boolean) {
 
 @Composable
 private fun NetworkStatsList(networkStats: Map<String, NativeSystemMonitor.InterfaceStats>) {
+    val isDummyData = networkStats.keys.any { it.startsWith("dummy:") }
+
     LazyColumn(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
     ) {
+        if (isDummyData) {
+            item {
+                DummyDataBanner()
+            }
+        }
+
         items(networkStats.entries.toList()) { (interfaceName, stats) ->
             NetworkInterfaceCard(interfaceName, stats)
         }
@@ -131,12 +140,53 @@ private fun NetworkStatsList(networkStats: Map<String, NativeSystemMonitor.Inter
 }
 
 @Composable
+private fun DummyDataBanner() {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(bottom = 16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.Warning,
+                contentDescription = "Warning",
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(24.dp)
+            )
+            Text(
+                text = "Displaying dummy network data",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(start = 8.dp)
+            )
+        }
+    }
+}
+
+@Composable
 private fun NetworkInterfaceCard(interfaceName: String, stats: NativeSystemMonitor.InterfaceStats) {
+    val isDummy = interfaceName.startsWith("dummy:")
+    val displayName = if (isDummy) interfaceName.substringAfter("dummy:") else interfaceName
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+        colors = if (isDummy) {
+            CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant)
+        } else {
+            CardDefaults.cardColors()
+        }
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             // Interface Name Header
@@ -150,12 +200,20 @@ private fun NetworkInterfaceCard(interfaceName: String, stats: NativeSystemMonit
                     tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(28.dp)
                 )
-                Text(
-                    text = interfaceName,
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(start = 8.dp)
-                )
+                Column(modifier = Modifier.padding(start = 8.dp)) {
+                    Text(
+                        text = displayName,
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.Bold
+                    )
+                    if (isDummy) {
+                        Text(
+                            text = "(Dummy Data)",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                }
             }
 
             HorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/TcpConnectionsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/TcpConnectionsScreen.kt
@@ -1,0 +1,210 @@
+package com.aoscoremonitor.ui.screens.jni
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.aoscoremonitor.diagnostics.jni.NativeSystemMonitor
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TcpConnectionsScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var tcpConnections by remember { mutableStateOf<List<NativeSystemMonitor.TcpConnection>>(emptyList()) }
+    var refreshing by remember { mutableStateOf(false) }
+
+    val systemMonitor = remember { NativeSystemMonitor() }
+
+    // Periodically update information
+    LaunchedEffect(Unit) {
+        while (isActive) {
+            refreshing = true
+            tcpConnections = systemMonitor.getTcpConnections()
+            refreshing = false
+            delay(3000) // Update every 3 seconds
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("TCP Connections") },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    titleContentColor = MaterialTheme.colorScheme.onPrimaryContainer
+                )
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            if (tcpConnections.isEmpty()) {
+                EmptyConnectionsView(refreshing)
+            } else {
+                ConnectionStatusSummary(tcpConnections)
+                TcpConnectionsList(tcpConnections)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConnectionStatusSummary(connections: List<NativeSystemMonitor.TcpConnection>) {
+    val established = connections.count { it.status == "ESTABLISHED" }
+    val listening = connections.count { it.status == "LISTEN" }
+    val waiting = connections.count { it.status == "TIME_WAIT" || it.status == "CLOSE_WAIT" }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(text = established.toString(), style = MaterialTheme.typography.titleLarge)
+                Text(text = "Established", style = MaterialTheme.typography.bodyMedium)
+            }
+
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(text = listening.toString(), style = MaterialTheme.typography.titleLarge)
+                Text(text = "Listening", style = MaterialTheme.typography.bodyMedium)
+            }
+
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(text = waiting.toString(), style = MaterialTheme.typography.titleLarge)
+                Text(text = "Waiting", style = MaterialTheme.typography.bodyMedium)
+            }
+
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(text = connections.size.toString(), style = MaterialTheme.typography.titleLarge)
+                Text(text = "Total", style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}
+
+@Composable
+private fun TcpConnectionsList(connections: List<NativeSystemMonitor.TcpConnection>) {
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp)
+    ) {
+        items(connections) { connection ->
+            TcpConnectionItem(connection)
+        }
+    }
+}
+
+@Composable
+private fun TcpConnectionItem(connection: NativeSystemMonitor.TcpConnection) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            // Status row
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                val (icon, color) = when (connection.status) {
+                    "ESTABLISHED" -> Icons.Default.CheckCircle to MaterialTheme.colorScheme.primary
+                    "LISTEN" -> Icons.Default.Hearing to MaterialTheme.colorScheme.tertiary
+                    "TIME_WAIT", "CLOSE_WAIT" -> Icons.Default.Timer to MaterialTheme.colorScheme.error
+                    else -> Icons.Default.Info to MaterialTheme.colorScheme.onSurface
+                }
+
+                Icon(
+                    imageVector = icon,
+                    contentDescription = connection.status,
+                    tint = color,
+                    modifier = Modifier.size(24.dp)
+                )
+
+                Text(
+                    text = connection.status,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = color,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+
+            // Address information
+            Text(
+                text = "Local: ${connection.getFormattedLocalAddress()}",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 8.dp)
+            )
+
+            Text(
+                text = "Remote: ${connection.getFormattedRemoteAddress()}",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+
+            // UID information (app identification)
+            Text(
+                text = "UID: ${connection.uid}",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun EmptyConnectionsView(refreshing: Boolean) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.CloudOff,
+            contentDescription = null,
+            modifier = Modifier.size(56.dp),
+            tint = MaterialTheme.colorScheme.primary
+        )
+        Text(
+            text = if (refreshing) "Loading TCP connections..." else "No active TCP connections found",
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.padding(top = 16.dp)
+        )
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature for monitoring TCP connections and includes various improvements and updates across multiple files. The most important changes include adding a new JNI function to retrieve TCP connection statistics, updating the UI to display these statistics, and enhancing the handling of dummy data.

### New Feature: TCP Connections Monitoring

* [`app/src/main/cpp/system_monitor.cpp`](diffhunk://#diff-66ea6b652cf044be30f9a3dafe64370e4f7b64a1322515df3232e7419cd2d596R160-R259): Added a new JNI function `Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getTcpConnectionsNative` to retrieve TCP connection statistics from `/proc/net/tcp` and return them in JSON format.
* [`app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeSystemMonitor.kt`](diffhunk://#diff-685960ebb5425a8022d5f1e2d895f7d010c7006a139c0d69d904a82e3334e2faR28): Added a new external function `getTcpConnectionsNative` and a corresponding data class `TcpConnection` to parse and format the TCP connection data. Also included a function to retrieve and parse the TCP connections. [[1]](diffhunk://#diff-685960ebb5425a8022d5f1e2d895f7d010c7006a139c0d69d904a82e3334e2faR28) [[2]](diffhunk://#diff-685960ebb5425a8022d5f1e2d895f7d010c7006a139c0d69d904a82e3334e2faR182-R283)
* [`app/src/main/java/com/aoscoremonitor/MainActivity.kt`](diffhunk://#diff-cf7e8266a684f048f4d8d6d2ecbb70eb3bc3ffe138719df09886f4c3e15cf167R27): Updated the navigation to include the new `TcpConnectionsScreen`. [[1]](diffhunk://#diff-cf7e8266a684f048f4d8d6d2ecbb70eb3bc3ffe138719df09886f4c3e15cf167R27) [[2]](diffhunk://#diff-cf7e8266a684f048f4d8d6d2ecbb70eb3bc3ffe138719df09886f4c3e15cf167R59) [[3]](diffhunk://#diff-cf7e8266a684f048f4d8d6d2ecbb70eb3bc3ffe138719df09886f4c3e15cf167R112-R117)
* [`app/src/main/java/com/aoscoremonitor/ui/navigation/Screen.kt`](diffhunk://#diff-7a8cf6d826321d302a9829f62c23e9b37d793256ac327334271ccc4dd70562d4L12-R13): Added a new screen type `TcpConnections` to the `Screen` enum.

### UI Updates

* [`app/src/main/java/com/aoscoremonitor/ui/screens/WelcomeScreen.kt`](diffhunk://#diff-763e9f5a1b1012447a837ac16ea2457d8e5904adec53695017d4f8ef2087d436R22): Added a new menu item for navigating to the TCP connections screen. [[1]](diffhunk://#diff-763e9f5a1b1012447a837ac16ea2457d8e5904adec53695017d4f8ef2087d436R22) [[2]](diffhunk://#diff-763e9f5a1b1012447a837ac16ea2457d8e5904adec53695017d4f8ef2087d436R61) [[3]](diffhunk://#diff-763e9f5a1b1012447a837ac16ea2457d8e5904adec53695017d4f8ef2087d436R151-R156)
* [`app/src/main/java/com/aoscoremonitor/ui/screens/jni/NetworkStatsScreen.kt`](diffhunk://#diff-ee3183893f3d970b8aa057b383b9029fca466ad8759e29351dfb4e2bacbbba59R18): Enhanced the UI to display a warning banner when showing dummy network data and updated the network interface card to indicate dummy data. [[1]](diffhunk://#diff-ee3183893f3d970b8aa057b383b9029fca466ad8759e29351dfb4e2bacbbba59R18) [[2]](diffhunk://#diff-ee3183893f3d970b8aa057b383b9029fca466ad8759e29351dfb4e2bacbbba59R123-R189) [[3]](diffhunk://#diff-ee3183893f3d970b8aa057b383b9029fca466ad8759e29351dfb4e2bacbbba59R203-R216)

### Code Style and Configuration

* [`.editorconfig`](diffhunk://#diff-0947e2727d6bad8cd0ac4122f5314bb5b04e337393075bc4b5ef143b17fcbd5bR14): Updated to disable the `no-wildcard-imports` rule for Kotlin files.