### PR TITLE
feat: add four native inspection screens and rebuild the native toolchain

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,6 +75,10 @@ dependencies {
     implementation(libs.androidx.material.icons.core)
     implementation(libs.androidx.material.icons.extended)
     testImplementation(libs.junit)
+    // The android.jar the unit tests compile against stubs org.json out with methods that throw,
+    // so the JSON the native collectors return could not be parsed off-device without a real
+    // implementation on the test classpath.
+    testImplementation(libs.org.json)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,11 +17,20 @@ ktlint {
 android {
     namespace = "com.aoscoremonitor"
     compileSdk = 37
-    ndkVersion = "27.1.12297006"
+
+    // r28 is the floor, not just a preference: earlier NDKs align a library's load segments for a
+    // 4 KB page, and such a library cannot be mapped on the 16 KB-page devices Android 15
+    // introduced. Every native reading in the app was unavailable there, reported as a missing
+    // symbol hash table rather than as an alignment problem. NativeInspectorTest catches a
+    // regression on any 16 KB device.
+    ndkVersion = "29.0.14206865"
 
     externalNativeBuild {
         cmake {
             path = file("src/main/cpp/CMakeLists.txt")
+            // Pinned rather than left to AGP's bundled 3.22.1, which predates Clang 17 and so has
+            // no flag mapping for C++23 — it fails the configure step rather than compiling.
+            version = "3.31.6"
         }
     }
 

--- a/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
+++ b/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
@@ -1,0 +1,77 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Checks that each native collector is wired to its JNI entry point and reads real data.
+ *
+ * The parsing tests cover the JSON contract off-device, but they cannot see a misspelled
+ * `Java_…` symbol: that surfaces as an [UnsatisfiedLinkError] the first time the screen opens, on
+ * a device, with the failure looking like an empty screen. Running the collectors for real is the
+ * only thing that catches it.
+ *
+ * The assertions stay to what holds on any Android device — a process always has an address space,
+ * a linker and a mount table — so that a device with a restrictive sysfs does not fail the suite
+ * for readings that are allowed to be missing.
+ */
+@RunWith(AndroidJUnit4::class)
+class NativeInspectorTest {
+
+    @Test
+    fun cpuInspectorReadsTopology() = runBlocking {
+        val snapshot = NativeCpuInspector().readStatic()
+
+        assertNotNull("CPU topology could not be read", snapshot)
+        assertTrue("No cores reported", snapshot!!.cores.isNotEmpty())
+        assertTrue("No configured core count", snapshot.configuredCores >= 1)
+        assertTrue("Page size looks wrong: ${snapshot.pageSize}", snapshot.pageSize >= 4096)
+    }
+
+    @Test
+    fun cpuInspectorReadsFrequencies() = runBlocking {
+        val cores = NativeCpuInspector().readFrequencies()
+
+        // The frequency itself may be denied by SELinux, but the core list is built from sysfs
+        // directory names, so it cannot be empty on a running device.
+        assertTrue("No cores reported", cores.isNotEmpty())
+    }
+
+    @Test
+    fun memoryInspectorReadsThisProcess() = runBlocking {
+        val snapshot = NativeMemoryInspector().read()
+
+        assertNotNull("Memory map could not be read", snapshot)
+        assertTrue("No mappings found", snapshot!!.totalRegions > 0)
+        assertNotNull("/proc/self smaps reported nothing", snapshot.rollup)
+        assertTrue("Resident size was zero", snapshot.rollup!!.rssKb > 0)
+        assertTrue("mallinfo2 reported nothing in use", (snapshot.malloc["in_use"] ?: 0) > 0)
+    }
+
+    @Test
+    fun moduleInspectorListsBionic() = runBlocking {
+        val snapshot = NativeModuleInspector().read()
+
+        assertNotNull("Module list could not be read", snapshot)
+        val names = snapshot!!.modules.map { it.fileName }
+        assertTrue("libc.so is not loaded, which cannot be: $names", names.contains("libc.so"))
+        assertTrue(
+            "The library under test is not in its own module list",
+            names.contains("libsystem_monitor.so")
+        )
+        assertTrue("No mapped size reported", snapshot.totalMappedSize > 0)
+    }
+
+    @Test
+    fun storageInspectorReadsTheMountTable() = runBlocking {
+        val mounts = NativeStorageInspector().read()
+
+        assertNotNull("Mount table could not be read", mounts)
+        assertTrue("No mounts reported", mounts!!.isNotEmpty())
+        assertTrue("/proc is not mounted, which cannot be", mounts.any { it.target == "/proc" })
+    }
+}

--- a/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
+++ b/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
@@ -41,6 +41,22 @@ class NativeInspectorTest {
         assertTrue("No cores reported", cores.isNotEmpty())
     }
 
+    /**
+     * A reading that is missing says why it is missing.
+     *
+     * Vacuous on a device that lets the app read every core's frequency, which this emulator does.
+     * It is the phones that deny `scaling_cur_freq` — the reason the field is nullable at all —
+     * where this has something to check.
+     */
+    @Test
+    fun aMissingFrequencyCarriesItsReason() = runBlocking {
+        val cores = NativeCpuInspector().readFrequencies()
+
+        cores.filter { it.curKhz == null }.forEach { core ->
+            assertNotNull("core ${core.id} reports no frequency and no reason", core.frequencyUnavailable)
+        }
+    }
+
     @Test
     fun memoryInspectorReadsThisProcess() = runBlocking {
         val snapshot = NativeMemoryInspector().read()

--- a/app/src/androidTest/java/com/aoscoremonitor/ui/navigation/MonitorNavigationTest.kt
+++ b/app/src/androidTest/java/com/aoscoremonitor/ui/navigation/MonitorNavigationTest.kt
@@ -6,9 +6,11 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso
+import androidx.test.espresso.NoActivityResumedException
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.aoscoremonitor.MainActivity
 import com.aoscoremonitor.R
+import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -49,6 +51,28 @@ class MonitorNavigationTest {
 
         awaitText(string(R.string.home_subtitle))
         composeRule.onNodeWithText(string(R.string.home_subtitle)).assertIsDisplayed()
+    }
+
+    /**
+     * Backing out past home leaves the app, rather than doing nothing.
+     *
+     * `MonitorNavHost` refuses to pop the last entry, because an empty back stack is what
+     * `NavDisplay` rejects with an IllegalArgumentException. The risk in that guard is the
+     * opposite failure — a root screen that swallows back and traps the user — so this pins that
+     * the press still finishes the activity. Espresso reports exactly that as
+     * [NoActivityResumedException].
+     *
+     * It is not a regression test for the crash itself: it passes with the guard removed, because
+     * NavDisplay stops routing back here once Home is the only entry.
+     */
+    @Test
+    fun backingOutPastHomeLeavesTheApp() {
+        openSystemInfo()
+
+        Espresso.pressBack()
+        awaitText(string(R.string.home_subtitle))
+
+        assertThrows(NoActivityResumedException::class.java) { Espresso.pressBack() }
     }
 
     private fun openSystemInfo() {

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,10 +1,11 @@
-cmake_minimum_required(VERSION 3.22.1)
+# 3.31 is the floor because of C++23: CMake releases that predate Clang 17 have no flag mapping
+# for the dialect and fail to configure rather than compile. AGP is told which CMake to use in
+# app/build.gradle.kts; this makes the requirement fail loudly if it is ever pointed at an older one.
+cmake_minimum_required(VERSION 3.31)
 
-# Set project name
-project(aoscoremonitor)
+# LANGUAGES CXX so that configuring does not go looking for a C compiler it will never use.
+project(aoscoremonitor LANGUAGES CXX)
 
-# Set C++ standard to C++23
-#
 # NDK r29 ships Clang 21, whose C++23 support is complete enough for everything here — the
 # collectors use string_view::contains, std::to_underlying and the starts_with/ends_with members
 # that replaced three hand-written helpers.
@@ -12,17 +13,12 @@ set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Create shared library (.so)
-#
 # One library rather than one per screen: every reading is loaded through the same
 # System.loadLibrary call on the Kotlin side, so splitting the sources keeps each collector
 # readable without adding a second thing that can fail to load.
 add_library(
-    # Library name
     system_monitor
-    # SHARED: specify the shared library type
     SHARED
-    # Source files
     native_util.cpp
     system_monitor.cpp
     cpu_info.cpp
@@ -31,16 +27,42 @@ add_library(
     storage_info.cpp
 )
 
-target_compile_options(system_monitor PRIVATE -Wall -Wextra -Wno-unused-parameter)
-
-# Find Android log library
-find_library(
-    log-lib
-    log
+# The conversion warnings are on because this code lives on the boundary between the kernel's
+# types and JSON's: /proc counters arrive as size_t or fsfilcnt64_t and leave as uint64_t, and a
+# silent narrowing there is a wrong reading rather than a crash. All of them are clean today.
+target_compile_options(system_monitor PRIVATE
+    -Wall
+    -Wextra
+    -Wshadow
+    -Wconversion
+    -Wsign-conversion
 )
 
-# Link libraries
-target_link_libraries(
-    system_monitor
-    ${log-lib}
+# Export only the JNI entry points.
+#
+# The library published 2,067 dynamic symbols where the runtime calls 10. Nearly all of them came
+# from libc++, which the NDK links statically by default: a static archive's symbols are exported
+# by whatever links it, so this library was re-publishing the whole standard library. That is a
+# correctness problem before it is a size one — those symbols sit in the process's global lookup
+# order, where they can bind another library's std:: calls to this copy of libc++.
+#
+# -fvisibility=hidden covers only the sources compiled here; --exclude-libs is what hides the
+# symbols that arrive from the static archives. --gc-sections then drops what nothing reaches.
+#
+# Measured on the release build, stripped: arm64 908,888 -> 450,088 bytes, armeabi-v7a 586,248 ->
+# 276,892, x86 843,980 -> 450,368, x86_64 894,040 -> 450,472 — about 1.6 MB across the four ABIs,
+# and 2,067 exported symbols down to exactly the 10 JNI entry points.
+#
+# Two further options were measured on top of this and are deliberately absent: thin LTO grew the
+# library to 481,320 bytes, and -fno-rtti changed nothing at all — this code has no dynamic_cast
+# or typeid for it to remove.
+target_compile_options(system_monitor PRIVATE
+    -fvisibility=hidden
+    -fvisibility-inlines-hidden
+    -ffunction-sections
+    -fdata-sections
 )
+target_link_options(system_monitor PRIVATE "-Wl,--gc-sections" "-Wl,--exclude-libs,ALL")
+
+# liblog comes from the NDK sysroot, so it needs no find_library lookup — naming it is enough.
+target_link_libraries(system_monitor PRIVATE log)

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -3,8 +3,12 @@ cmake_minimum_required(VERSION 3.22.1)
 # Set project name
 project(aoscoremonitor)
 
-# Set C++ standard to C++17
-set(CMAKE_CXX_STANDARD 17)
+# Set C++ standard to C++23
+#
+# NDK r29 ships Clang 21, whose C++23 support is complete enough for everything here — the
+# collectors use string_view::contains, std::to_underlying and the starts_with/ends_with members
+# that replaced three hand-written helpers.
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
@@ -28,17 +32,6 @@ add_library(
 )
 
 target_compile_options(system_monitor PRIVATE -Wall -Wextra -Wno-unused-parameter)
-
-# Align the load segments for a 16 KB page.
-#
-# Android 15 introduced devices — and emulator images — whose pages are 16 KB rather than 4 KB.
-# A library laid out for 4 KB pages cannot be mapped there, and the failure is not obvious from
-# the message the linker gives: it maps the segments at the wrong offsets and then reports the
-# symbol hash table as "empty/missing DT_HASH/DT_GNU_HASH". Every native reading in the app was
-# silently unavailable on such a device, with the screens falling back to sample data.
-#
-# NDK r28 makes this the default; this project builds against r27, which does not.
-target_link_options(system_monitor PRIVATE "-Wl,-z,max-page-size=16384")
 
 # Find Android log library
 find_library(

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -9,14 +9,36 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Create shared library (.so)
+#
+# One library rather than one per screen: every reading is loaded through the same
+# System.loadLibrary call on the Kotlin side, so splitting the sources keeps each collector
+# readable without adding a second thing that can fail to load.
 add_library(
     # Library name
     system_monitor
     # SHARED: specify the shared library type
     SHARED
     # Source files
+    native_util.cpp
     system_monitor.cpp
+    cpu_info.cpp
+    memory_map.cpp
+    elf_modules.cpp
+    storage_info.cpp
 )
+
+target_compile_options(system_monitor PRIVATE -Wall -Wextra -Wno-unused-parameter)
+
+# Align the load segments for a 16 KB page.
+#
+# Android 15 introduced devices — and emulator images — whose pages are 16 KB rather than 4 KB.
+# A library laid out for 4 KB pages cannot be mapped there, and the failure is not obvious from
+# the message the linker gives: it maps the segments at the wrong offsets and then reports the
+# symbol hash table as "empty/missing DT_HASH/DT_GNU_HASH". Every native reading in the app was
+# silently unavailable on such a device, with the screens falling back to sample data.
+#
+# NDK r28 makes this the default; this project builds against r27, which does not.
+target_link_options(system_monitor PRIVATE "-Wl,-z,max-page-size=16384")
 
 # Find Android log library
 find_library(

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -1,21 +1,16 @@
-# 3.31 is the floor because of C++23: CMake releases that predate Clang 17 have no flag mapping
-# for the dialect and fail to configure rather than compile. AGP is told which CMake to use in
-# app/build.gradle.kts; this makes the requirement fail loudly if it is ever pointed at an older one.
+# 3.31 or newer: earlier releases have no flag mapping for C++23 and fail to configure rather than
+# compile. Which CMake AGP runs is pinned in app/build.gradle.kts.
 cmake_minimum_required(VERSION 3.31)
 
-# LANGUAGES CXX so that configuring does not go looking for a C compiler it will never use.
+# LANGUAGES CXX so that configuring does not go looking for a C compiler this never uses.
 project(aoscoremonitor LANGUAGES CXX)
 
-# NDK r29 ships Clang 21, whose C++23 support is complete enough for everything here — the
-# collectors use string_view::contains, std::to_underlying and the starts_with/ends_with members
-# that replaced three hand-written helpers.
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-# One library rather than one per screen: every reading is loaded through the same
-# System.loadLibrary call on the Kotlin side, so splitting the sources keeps each collector
-# readable without adding a second thing that can fail to load.
+# One library rather than one per screen: every reading loads through the same System.loadLibrary
+# call, so splitting the sources adds no second thing that can fail to load.
 add_library(
     system_monitor
     SHARED
@@ -27,9 +22,9 @@ add_library(
     storage_info.cpp
 )
 
-# The conversion warnings are on because this code lives on the boundary between the kernel's
-# types and JSON's: /proc counters arrive as size_t or fsfilcnt64_t and leave as uint64_t, and a
-# silent narrowing there is a wrong reading rather than a crash. All of them are clean today.
+# The conversion warnings earn their place here: this code carries kernel counters — size_t,
+# fsfilcnt64_t — into JSON as uint64_t, where a silent narrowing is a wrong reading rather than a
+# crash.
 target_compile_options(system_monitor PRIVATE
     -Wall
     -Wextra
@@ -38,31 +33,12 @@ target_compile_options(system_monitor PRIVATE
     -Wsign-conversion
 )
 
-# Export only the JNI entry points.
-#
-# The library published 2,067 dynamic symbols where the runtime calls 10. Nearly all of them came
-# from libc++, which the NDK links statically by default: a static archive's symbols are exported
-# by whatever links it, so this library was re-publishing the whole standard library. That is a
-# correctness problem before it is a size one — those symbols sit in the process's global lookup
-# order, where they can bind another library's std:: calls to this copy of libc++.
-#
-# -fvisibility=hidden covers only the sources compiled here; --exclude-libs is what hides the
-# symbols that arrive from the static archives. --gc-sections then drops what nothing reaches.
-#
-# Measured on the release build, stripped: arm64 908,888 -> 450,088 bytes, armeabi-v7a 586,248 ->
-# 276,892, x86 843,980 -> 450,368, x86_64 894,040 -> 450,472 — about 1.6 MB across the four ABIs,
-# and 2,067 exported symbols down to exactly the 10 JNI entry points.
-#
-# Two further options were measured on top of this and are deliberately absent: thin LTO grew the
-# library to 481,320 bytes, and -fno-rtti changed nothing at all — this code has no dynamic_cast
-# or typeid for it to remove.
-target_compile_options(system_monitor PRIVATE
-    -fvisibility=hidden
-    -fvisibility-inlines-hidden
-    -ffunction-sections
-    -fdata-sections
-)
-target_link_options(system_monitor PRIVATE "-Wl,--gc-sections" "-Wl,--exclude-libs,ALL")
+# The NDK links libc++ statically, and a static archive's symbols are re-exported by whatever links
+# it, so without a version script this library publishes the whole standard library into the
+# process's global symbol lookup. libsystem_monitor.map.txt says what it exports instead.
+set(version_script "${CMAKE_CURRENT_SOURCE_DIR}/libsystem_monitor.map.txt")
+target_link_options(system_monitor PRIVATE "-Wl,--version-script=${version_script}")
+# Editing the script alone is a reason to relink.
+set_target_properties(system_monitor PROPERTIES LINK_DEPENDS "${version_script}")
 
-# liblog comes from the NDK sysroot, so it needs no find_library lookup — naming it is enough.
 target_link_libraries(system_monitor PRIVATE log)

--- a/app/src/main/cpp/cpu_info.cpp
+++ b/app/src/main/cpp/cpu_info.cpp
@@ -196,66 +196,70 @@ std::vector<std::string> IsaFeatures() {
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeCpuInspector_getCpuStaticNative(JNIEnv* env,
                                                                               jobject /* this */) {
-  JsonWriter writer;
-  writer.BeginObject();
-
-  const long configured = sysconf(_SC_NPROCESSORS_CONF);
-  const long online = sysconf(_SC_NPROCESSORS_ONLN);
-  writer.Field("configured", static_cast<uint64_t>(configured > 0 ? configured : 0));
-  writer.Field("online", static_cast<uint64_t>(online > 0 ? online : 0));
-  writer.Field("page_size", static_cast<uint64_t>(sysconf(_SC_PAGESIZE)));
-  writer.Field("clock_ticks", static_cast<uint64_t>(sysconf(_SC_CLK_TCK)));
-
-  utsname system_name = {};
-  if (uname(&system_name) == 0) {
-    writer.Field("machine", system_name.machine);
-    writer.Field("kernel_release", system_name.release);
-  }
-
-  writer.Key("cores").BeginArray();
-  for (const int id : PresentCpus()) {
-    const std::string dir = CpuDir(id);
+  return aoscm::ReturnJson(env, [] {
+    JsonWriter writer;
     writer.BeginObject();
-    writer.Field("id", static_cast<uint64_t>(id));
-    writer.FieldIfSet("core_id", ReadUint64(dir + "/topology/core_id"));
-    writer.FieldIfSet("package_id", ReadUint64(dir + "/topology/physical_package_id"));
-    writer.FieldIfSet("min_khz", ReadUint64(dir + "/cpufreq/cpuinfo_min_freq"));
-    writer.FieldIfSet("max_khz", ReadUint64(dir + "/cpufreq/cpuinfo_max_freq"));
+
+    const long configured = sysconf(_SC_NPROCESSORS_CONF);
+    const long online = sysconf(_SC_NPROCESSORS_ONLN);
+    writer.Field("configured", static_cast<uint64_t>(configured > 0 ? configured : 0));
+    writer.Field("online", static_cast<uint64_t>(online > 0 ? online : 0));
+    writer.Field("page_size", static_cast<uint64_t>(sysconf(_SC_PAGESIZE)));
+    writer.Field("clock_ticks", static_cast<uint64_t>(sysconf(_SC_CLK_TCK)));
+
+    utsname system_name = {};
+    if (uname(&system_name) == 0) {
+      writer.Field("machine", system_name.machine);
+      writer.Field("kernel_release", system_name.release);
+    }
+
+    writer.Key("cores").BeginArray();
+    for (const int id : PresentCpus()) {
+      const std::string dir = CpuDir(id);
+      writer.BeginObject();
+      writer.Field("id", static_cast<uint64_t>(id));
+      writer.FieldIfSet("core_id", ReadUint64(dir + "/topology/core_id"));
+      writer.FieldIfSet("package_id", ReadUint64(dir + "/topology/physical_package_id"));
+      writer.FieldIfSet("min_khz", ReadUint64(dir + "/cpufreq/cpuinfo_min_freq"));
+      writer.FieldIfSet("max_khz", ReadUint64(dir + "/cpufreq/cpuinfo_max_freq"));
+      writer.EndObject();
+    }
+    writer.EndArray();
+
+    writer.Key("features").BeginArray();
+    for (const std::string& feature : IsaFeatures()) {
+      writer.Value(feature);
+    }
+    writer.EndArray();
+
     writer.EndObject();
-  }
-  writer.EndArray();
-
-  writer.Key("features").BeginArray();
-  for (const std::string& feature : IsaFeatures()) {
-    writer.Value(feature);
-  }
-  writer.EndArray();
-
-  writer.EndObject();
-  return env->NewStringUTF(writer.Take().c_str());
+    return writer.Take();
+  });
 }
 
 /** The part that moves: which cores are up, how fast they are running, and under which governor. */
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeCpuInspector_getCpuFrequenciesNative(
     JNIEnv* env, jobject /* this */) {
-  JsonWriter writer;
-  writer.BeginObject();
-  writer.Key("cores").BeginArray();
-
-  for (const int id : PresentCpus()) {
-    const std::string dir = CpuDir(id);
+  return aoscm::ReturnJson(env, [] {
+    JsonWriter writer;
     writer.BeginObject();
-    writer.Field("id", static_cast<uint64_t>(id));
-    writer.Field("online", IsOnline(id));
-    // scaling_cur_freq is denied to apps on some devices and absent for an offline core; the key
-    // is then left out and the screen says so rather than showing a stale or zero frequency.
-    writer.FieldIfSet("cur_khz", ReadUint64(dir + "/cpufreq/scaling_cur_freq"));
-    writer.FieldIfSet("governor", ReadTrimmedLine(dir + "/cpufreq/scaling_governor"));
-    writer.EndObject();
-  }
+    writer.Key("cores").BeginArray();
 
-  writer.EndArray();
-  writer.EndObject();
-  return env->NewStringUTF(writer.Take().c_str());
+    for (const int id : PresentCpus()) {
+      const std::string dir = CpuDir(id);
+      writer.BeginObject();
+      writer.Field("id", static_cast<uint64_t>(id));
+      writer.Field("online", IsOnline(id));
+      // scaling_cur_freq is denied to apps on some devices and absent for an offline core; the key
+      // is then left out and the screen says so rather than showing a stale or zero frequency.
+      writer.FieldIfSet("cur_khz", ReadUint64(dir + "/cpufreq/scaling_cur_freq"));
+      writer.FieldIfSet("governor", ReadTrimmedLine(dir + "/cpufreq/scaling_governor"));
+      writer.EndObject();
+    }
+
+    writer.EndArray();
+    writer.EndObject();
+    return writer.Take();
+  });
 }

--- a/app/src/main/cpp/cpu_info.cpp
+++ b/app/src/main/cpp/cpu_info.cpp
@@ -1,0 +1,243 @@
+#include <jni.h>
+#include <sys/auxv.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "native_util.h"
+
+#if defined(__aarch64__) || defined(__arm__)
+#include <asm/hwcap.h>
+#endif
+
+namespace {
+
+using aoscm::JsonWriter;
+using aoscm::ReadTrimmedLine;
+using aoscm::ReadUint64;
+
+std::string CpuDir(int id) {
+  return "/sys/devices/system/cpu/cpu" + std::to_string(id);
+}
+
+/**
+ * The CPU ids the kernel knows about, from `/sys/devices/system/cpu/present`.
+ *
+ * Read rather than derived from `sysconf(_SC_NPROCESSORS_CONF)` because the ids are what name the
+ * sysfs directories, and on a big.LITTLE device with cores offline the two need not agree. The
+ * format is a range list such as `0-7` or `0-3,6-7`.
+ */
+std::vector<int> PresentCpus() {
+  std::vector<int> ids;
+  const std::optional<std::string> present = ReadTrimmedLine("/sys/devices/system/cpu/present");
+
+  if (present.has_value()) {
+    size_t position = 0;
+    while (position < present->size()) {
+      const size_t comma = present->find(',', position);
+      const std::string range = present->substr(
+          position, comma == std::string::npos ? std::string::npos : comma - position);
+      const size_t dash = range.find('-');
+      const int first = std::atoi(range.c_str());
+      const int last = (dash == std::string::npos) ? first : std::atoi(range.c_str() + dash + 1);
+      for (int id = first; id <= last && id - first < 1024; ++id) {
+        ids.push_back(id);
+      }
+      if (comma == std::string::npos) {
+        break;
+      }
+      position = comma + 1;
+    }
+  }
+
+  if (ids.empty()) {
+    const long configured = sysconf(_SC_NPROCESSORS_CONF);
+    for (long id = 0; id < configured; ++id) {
+      ids.push_back(static_cast<int>(id));
+    }
+  }
+  return ids;
+}
+
+/**
+ * Whether a core is currently running.
+ *
+ * cpu0 has no `online` attribute on most kernels because it cannot be taken offline; a missing
+ * file therefore means online, not unknown.
+ */
+bool IsOnline(int id) {
+  const std::optional<uint64_t> online = ReadUint64(CpuDir(id) + "/online");
+  return online.value_or(1) != 0;
+}
+
+/**
+ * The instruction set extensions the kernel advertises for this CPU.
+ *
+ * Taken from the ELF auxiliary vector rather than parsed out of `/proc/cpuinfo`: the auxv is
+ * always readable, whereas /proc/cpuinfo's `Features` line is absent on some arm64 kernels and
+ * the whole file is filtered for apps on others.
+ */
+std::vector<std::string> IsaFeatures() {
+  std::vector<std::string> features;
+
+#if defined(__aarch64__) || defined(__arm__)
+  const unsigned long hwcap = getauxval(AT_HWCAP);
+  const unsigned long hwcap2 = getauxval(AT_HWCAP2);
+#define AOSCM_CAP(caps, mask, label) \
+  do {                               \
+    if (((caps) & (mask)) != 0) {    \
+      features.emplace_back(label);  \
+    }                                \
+  } while (0)
+#endif
+
+#if defined(__aarch64__)
+  AOSCM_CAP(hwcap, HWCAP_FP, "fp");
+  AOSCM_CAP(hwcap, HWCAP_ASIMD, "asimd");
+  AOSCM_CAP(hwcap, HWCAP_AES, "aes");
+  AOSCM_CAP(hwcap, HWCAP_PMULL, "pmull");
+  AOSCM_CAP(hwcap, HWCAP_SHA1, "sha1");
+  AOSCM_CAP(hwcap, HWCAP_SHA2, "sha2");
+  AOSCM_CAP(hwcap, HWCAP_SHA3, "sha3");
+  AOSCM_CAP(hwcap, HWCAP_SHA512, "sha512");
+  AOSCM_CAP(hwcap, HWCAP_CRC32, "crc32");
+  AOSCM_CAP(hwcap, HWCAP_ATOMICS, "atomics");
+  AOSCM_CAP(hwcap, HWCAP_FPHP, "fphp");
+  AOSCM_CAP(hwcap, HWCAP_ASIMDHP, "asimdhp");
+  AOSCM_CAP(hwcap, HWCAP_ASIMDRDM, "asimdrdm");
+  AOSCM_CAP(hwcap, HWCAP_ASIMDDP, "asimddp");
+  AOSCM_CAP(hwcap, HWCAP_ASIMDFHM, "asimdfhm");
+  AOSCM_CAP(hwcap, HWCAP_JSCVT, "jscvt");
+  AOSCM_CAP(hwcap, HWCAP_FCMA, "fcma");
+  AOSCM_CAP(hwcap, HWCAP_LRCPC, "lrcpc");
+  AOSCM_CAP(hwcap, HWCAP_DCPOP, "dcpop");
+  AOSCM_CAP(hwcap, HWCAP_SVE, "sve");
+  AOSCM_CAP(hwcap, HWCAP_DIT, "dit");
+  AOSCM_CAP(hwcap, HWCAP_FLAGM, "flagm");
+  AOSCM_CAP(hwcap, HWCAP_SSBS, "ssbs");
+  AOSCM_CAP(hwcap, HWCAP_PACA, "paca");
+  AOSCM_CAP(hwcap2, HWCAP2_SVE2, "sve2");
+  AOSCM_CAP(hwcap2, HWCAP2_I8MM, "i8mm");
+  AOSCM_CAP(hwcap2, HWCAP2_BF16, "bf16");
+  AOSCM_CAP(hwcap2, HWCAP2_RNG, "rng");
+  AOSCM_CAP(hwcap2, HWCAP2_BTI, "bti");
+  AOSCM_CAP(hwcap2, HWCAP2_MTE, "mte");
+  AOSCM_CAP(hwcap2, HWCAP2_ECV, "ecv");
+#elif defined(__arm__)
+  AOSCM_CAP(hwcap, HWCAP_NEON, "neon");
+  AOSCM_CAP(hwcap, HWCAP_VFP, "vfp");
+  AOSCM_CAP(hwcap, HWCAP_VFPv3, "vfpv3");
+  AOSCM_CAP(hwcap, HWCAP_VFPv4, "vfpv4");
+  AOSCM_CAP(hwcap, HWCAP_IDIVA, "idiva");
+  AOSCM_CAP(hwcap, HWCAP_IDIVT, "idivt");
+  AOSCM_CAP(hwcap, HWCAP_LPAE, "lpae");
+  AOSCM_CAP(hwcap, HWCAP_ASIMDHP, "asimdhp");
+  AOSCM_CAP(hwcap, HWCAP_ASIMDDP, "asimddp");
+  AOSCM_CAP(hwcap2, HWCAP2_AES, "aes");
+  AOSCM_CAP(hwcap2, HWCAP2_PMULL, "pmull");
+  AOSCM_CAP(hwcap2, HWCAP2_SHA1, "sha1");
+  AOSCM_CAP(hwcap2, HWCAP2_SHA2, "sha2");
+  AOSCM_CAP(hwcap2, HWCAP2_CRC32, "crc32");
+#elif defined(__i386__) || defined(__x86_64__)
+  // x86 kernels put almost nothing in AT_HWCAP, so the emulator would otherwise show an empty
+  // list. The compiler builtin reads CPUID instead, which is what the auxv stands in for on ARM.
+  // The builtin only takes a literal, so the features are named one by one rather than looped
+  // over a table.
+#define AOSCM_X86(feature)                 \
+  do {                                     \
+    if (__builtin_cpu_supports(feature)) { \
+      features.emplace_back(feature);      \
+    }                                      \
+  } while (0)
+  AOSCM_X86("sse4.2");
+  AOSCM_X86("aes");
+  AOSCM_X86("popcnt");
+  AOSCM_X86("avx");
+  AOSCM_X86("avx2");
+  AOSCM_X86("fma");
+  AOSCM_X86("bmi");
+  AOSCM_X86("bmi2");
+  AOSCM_X86("avx512f");
+#undef AOSCM_X86
+#endif
+
+#if defined(__aarch64__) || defined(__arm__)
+#undef AOSCM_CAP
+#endif
+
+  return features;
+}
+
+}  // namespace
+
+/** Everything about the CPU that does not change while the app runs. */
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_aoscoremonitor_diagnostics_jni_NativeCpuInspector_getCpuStaticNative(JNIEnv* env,
+                                                                              jobject /* this */) {
+  JsonWriter writer;
+  writer.BeginObject();
+
+  const long configured = sysconf(_SC_NPROCESSORS_CONF);
+  const long online = sysconf(_SC_NPROCESSORS_ONLN);
+  writer.Field("configured", static_cast<uint64_t>(configured > 0 ? configured : 0));
+  writer.Field("online", static_cast<uint64_t>(online > 0 ? online : 0));
+  writer.Field("page_size", static_cast<uint64_t>(sysconf(_SC_PAGESIZE)));
+  writer.Field("clock_ticks", static_cast<uint64_t>(sysconf(_SC_CLK_TCK)));
+
+  utsname system_name = {};
+  if (uname(&system_name) == 0) {
+    writer.Field("machine", system_name.machine);
+    writer.Field("kernel_release", system_name.release);
+  }
+
+  writer.Key("cores").BeginArray();
+  for (const int id : PresentCpus()) {
+    const std::string dir = CpuDir(id);
+    writer.BeginObject();
+    writer.Field("id", static_cast<uint64_t>(id));
+    writer.FieldIfSet("core_id", ReadUint64(dir + "/topology/core_id"));
+    writer.FieldIfSet("package_id", ReadUint64(dir + "/topology/physical_package_id"));
+    writer.FieldIfSet("min_khz", ReadUint64(dir + "/cpufreq/cpuinfo_min_freq"));
+    writer.FieldIfSet("max_khz", ReadUint64(dir + "/cpufreq/cpuinfo_max_freq"));
+    writer.EndObject();
+  }
+  writer.EndArray();
+
+  writer.Key("features").BeginArray();
+  for (const std::string& feature : IsaFeatures()) {
+    writer.Value(feature);
+  }
+  writer.EndArray();
+
+  writer.EndObject();
+  return env->NewStringUTF(writer.Take().c_str());
+}
+
+/** The part that moves: which cores are up, how fast they are running, and under which governor. */
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_aoscoremonitor_diagnostics_jni_NativeCpuInspector_getCpuFrequenciesNative(
+    JNIEnv* env, jobject /* this */) {
+  JsonWriter writer;
+  writer.BeginObject();
+  writer.Key("cores").BeginArray();
+
+  for (const int id : PresentCpus()) {
+    const std::string dir = CpuDir(id);
+    writer.BeginObject();
+    writer.Field("id", static_cast<uint64_t>(id));
+    writer.Field("online", IsOnline(id));
+    // scaling_cur_freq is denied to apps on some devices and absent for an offline core; the key
+    // is then left out and the screen says so rather than showing a stale or zero frequency.
+    writer.FieldIfSet("cur_khz", ReadUint64(dir + "/cpufreq/scaling_cur_freq"));
+    writer.FieldIfSet("governor", ReadTrimmedLine(dir + "/cpufreq/scaling_governor"));
+    writer.EndObject();
+  }
+
+  writer.EndArray();
+  writer.EndObject();
+  return env->NewStringUTF(writer.Take().c_str());
+}

--- a/app/src/main/cpp/cpu_info.cpp
+++ b/app/src/main/cpp/cpu_info.cpp
@@ -19,6 +19,7 @@
 namespace {
 
 using aoscm::JsonWriter;
+using aoscm::Reading;
 using aoscm::ReadTrimmedLine;
 using aoscm::ReadUint64;
 
@@ -47,7 +48,7 @@ std::optional<int> ParseInt(std::string_view text) {
  */
 std::vector<int> PresentCpus() {
   std::vector<int> ids;
-  const std::optional<std::string> present = ReadTrimmedLine("/sys/devices/system/cpu/present");
+  const Reading<std::string> present = ReadTrimmedLine("/sys/devices/system/cpu/present");
 
   if (present.has_value()) {
     std::string_view remaining(*present);
@@ -88,7 +89,7 @@ std::vector<int> PresentCpus() {
  * file therefore means online, not unknown.
  */
 bool IsOnline(int id) {
-  const std::optional<uint64_t> online = ReadUint64(CpuDir(id) + "/online");
+  const Reading<uint64_t> online = ReadUint64(CpuDir(id) + "/online");
   return online.value_or(1) != 0;
 }
 
@@ -251,9 +252,15 @@ Java_com_aoscoremonitor_diagnostics_jni_NativeCpuInspector_getCpuFrequenciesNati
       writer.BeginObject();
       writer.Field("id", static_cast<uint64_t>(id));
       writer.Field("online", IsOnline(id));
-      // scaling_cur_freq is denied to apps on some devices and absent for an offline core; the key
-      // is then left out and the screen says so rather than showing a stale or zero frequency.
-      writer.FieldIfSet("cur_khz", ReadUint64(dir + "/cpufreq/scaling_cur_freq"));
+
+      // scaling_cur_freq is denied to apps on some devices and missing entirely on others. The
+      // screen says which rather than showing a stale or zero frequency.
+      const Reading<uint64_t> current = ReadUint64(dir + "/cpufreq/scaling_cur_freq");
+      writer.FieldIfSet("cur_khz", current);
+      if (!current.has_value()) {
+        writer.Field("cur_khz_unavailable", aoscm::DescribeFailure(current.error()));
+      }
+
       writer.FieldIfSet("governor", ReadTrimmedLine(dir + "/cpufreq/scaling_governor"));
       writer.EndObject();
     }

--- a/app/src/main/cpp/cpu_info.cpp
+++ b/app/src/main/cpp/cpu_info.cpp
@@ -3,9 +3,11 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 
-#include <cstdlib>
+#include <charconv>
 #include <optional>
 #include <string>
+#include <string_view>
+#include <system_error>
 #include <vector>
 
 #include "native_util.h"
@@ -20,8 +22,20 @@ using aoscm::JsonWriter;
 using aoscm::ReadTrimmedLine;
 using aoscm::ReadUint64;
 
+/** A guard against a malformed `present` range asking for millions of directory reads. */
+constexpr int kMaxCoresPerRange = 1024;
+
 std::string CpuDir(int id) {
   return "/sys/devices/system/cpu/cpu" + std::to_string(id);
+}
+
+std::optional<int> ParseInt(std::string_view text) {
+  int value = 0;
+  const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), value);
+  if (error != std::errc() || end == text.data()) {
+    return std::nullopt;
+  }
+  return value;
 }
 
 /**
@@ -36,21 +50,25 @@ std::vector<int> PresentCpus() {
   const std::optional<std::string> present = ReadTrimmedLine("/sys/devices/system/cpu/present");
 
   if (present.has_value()) {
-    size_t position = 0;
-    while (position < present->size()) {
-      const size_t comma = present->find(',', position);
-      const std::string range = present->substr(
-          position, comma == std::string::npos ? std::string::npos : comma - position);
+    std::string_view remaining(*present);
+    while (!remaining.empty()) {
+      const size_t comma = remaining.find(',');
+      const std::string_view range = remaining.substr(0, comma);
       const size_t dash = range.find('-');
-      const int first = std::atoi(range.c_str());
-      const int last = (dash == std::string::npos) ? first : std::atoi(range.c_str() + dash + 1);
-      for (int id = first; id <= last && id - first < 1024; ++id) {
-        ids.push_back(id);
+
+      const std::optional<int> first = ParseInt(range.substr(0, dash));
+      const std::optional<int> last =
+          (dash == std::string_view::npos) ? first : ParseInt(range.substr(dash + 1));
+      if (first.has_value() && last.has_value()) {
+        for (int id = *first; id <= *last && id - *first < kMaxCoresPerRange; ++id) {
+          ids.push_back(id);
+        }
       }
-      if (comma == std::string::npos) {
+
+      if (comma == std::string_view::npos) {
         break;
       }
-      position = comma + 1;
+      remaining.remove_prefix(comma + 1);
     }
   }
 

--- a/app/src/main/cpp/elf_modules.cpp
+++ b/app/src/main/cpp/elf_modules.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -78,8 +79,12 @@ std::string ReadBuildId(const ElfW(Phdr) & header, ElfW(Addr) base) {
  * program headers and copying what they say. Anything else — JNI calls, building the JSON — waits
  * until the walk is over. `dlpi_name` points into the linker's own storage and is copied for the
  * same reason.
+ *
+ * `noexcept` because the caller is C: the copies below allocate, and an exception leaving here
+ * would unwind through the linker's frames while it holds that lock. Terminating is not a good
+ * outcome, but it is a defined one.
  */
-int CollectModule(dl_phdr_info* info, size_t size, void* data) {
+int CollectModule(dl_phdr_info* info, size_t size, void* data) noexcept {
   auto* collector = static_cast<Collector*>(data);
 
   // dlpi_adds and dlpi_subs were added after the original struct, so they are only there when the
@@ -97,8 +102,9 @@ int CollectModule(dl_phdr_info* info, size_t size, void* data) {
 
   uint64_t lowest = UINT64_MAX;
   uint64_t highest = 0;
-  for (size_t i = 0; i < info->dlpi_phnum; ++i) {
-    const ElfW(Phdr) & header = info->dlpi_phdr[i];
+  // A pointer and a count are what the linker hands over; a span is what the loop should see.
+  const std::span headers(info->dlpi_phdr, info->dlpi_phnum);
+  for (const ElfW(Phdr) & header : headers) {
     switch (header.p_type) {
       case PT_LOAD:
         lowest = std::min<uint64_t>(lowest, header.p_vaddr);
@@ -140,32 +146,34 @@ int CollectModule(dl_phdr_info* info, size_t size, void* data) {
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeModuleInspector_getLoadedModulesNative(
     JNIEnv* env, jobject /* this */) {
-  Collector collector;
-  dl_iterate_phdr(CollectModule, &collector);
+  return aoscm::ReturnJson(env, [] {
+    Collector collector;
+    dl_iterate_phdr(CollectModule, &collector);
 
-  JsonWriter writer;
-  writer.BeginObject();
-  if (collector.counts_valid) {
-    writer.Field("adds", static_cast<uint64_t>(collector.adds));
-    writer.Field("subs", static_cast<uint64_t>(collector.subs));
-  }
-
-  writer.Key("modules").BeginArray();
-  for (const Module& module : collector.modules) {
+    JsonWriter writer;
     writer.BeginObject();
-    writer.Field("path", module.path);
-    writer.FieldHex("base", module.base);
-    writer.Field("mapped_size", module.mapped_size);
-    writer.Field("segment_count", module.segment_count);
-    writer.Field("relro", module.has_relro);
-    writer.Field("tls", module.has_tls);
-    if (!module.build_id.empty()) {
-      writer.Field("build_id", module.build_id);
+    if (collector.counts_valid) {
+      writer.Field("adds", static_cast<uint64_t>(collector.adds));
+      writer.Field("subs", static_cast<uint64_t>(collector.subs));
     }
-    writer.EndObject();
-  }
-  writer.EndArray();
 
-  writer.EndObject();
-  return env->NewStringUTF(writer.Take().c_str());
+    writer.Key("modules").BeginArray();
+    for (const Module& module : collector.modules) {
+      writer.BeginObject();
+      writer.Field("path", module.path);
+      writer.FieldHex("base", module.base);
+      writer.Field("mapped_size", module.mapped_size);
+      writer.Field("segment_count", module.segment_count);
+      writer.Field("relro", module.has_relro);
+      writer.Field("tls", module.has_tls);
+      if (!module.build_id.empty()) {
+        writer.Field("build_id", module.build_id);
+      }
+      writer.EndObject();
+    }
+    writer.EndArray();
+
+    writer.EndObject();
+    return writer.Take();
+  });
 }

--- a/app/src/main/cpp/elf_modules.cpp
+++ b/app/src/main/cpp/elf_modules.cpp
@@ -16,11 +16,6 @@ using aoscm::JsonWriter;
 
 constexpr char kHexDigits[] = "0123456789abcdef";
 
-struct Segment {
-  std::string flags;
-  uint64_t memsz = 0;
-};
-
 struct Module {
   std::string path;
   uint64_t base = 0;
@@ -28,8 +23,7 @@ struct Module {
   std::string build_id;
   bool has_relro = false;
   bool has_tls = false;
-  size_t phnum = 0;
-  std::vector<Segment> segments;
+  uint64_t segment_count = 0;
 };
 
 struct Collector {
@@ -38,20 +32,6 @@ struct Collector {
   unsigned long long subs = 0;
   bool counts_valid = false;
 };
-
-std::string DescribeFlags(uint32_t flags) {
-  std::string described(3, '-');
-  if ((flags & PF_R) != 0) {
-    described[0] = 'r';
-  }
-  if ((flags & PF_W) != 0) {
-    described[1] = 'w';
-  }
-  if ((flags & PF_X) != 0) {
-    described[2] = 'x';
-  }
-  return described;
-}
 
 /**
  * Pulls the GNU build id out of a `PT_NOTE` segment.
@@ -114,7 +94,6 @@ int CollectModule(dl_phdr_info* info, size_t size, void* data) {
   Module module;
   module.path = (info->dlpi_name != nullptr) ? info->dlpi_name : "";
   module.base = static_cast<uint64_t>(info->dlpi_addr);
-  module.phnum = info->dlpi_phnum;
 
   uint64_t lowest = UINT64_MAX;
   uint64_t highest = 0;
@@ -124,7 +103,7 @@ int CollectModule(dl_phdr_info* info, size_t size, void* data) {
       case PT_LOAD:
         lowest = std::min<uint64_t>(lowest, header.p_vaddr);
         highest = std::max<uint64_t>(highest, header.p_vaddr + header.p_memsz);
-        module.segments.push_back({DescribeFlags(header.p_flags), header.p_memsz});
+        module.segment_count += 1;
         break;
       case PT_NOTE:
         if (module.build_id.empty()) {
@@ -177,20 +156,12 @@ Java_com_aoscoremonitor_diagnostics_jni_NativeModuleInspector_getLoadedModulesNa
     writer.Field("path", module.path);
     writer.FieldHex("base", module.base);
     writer.Field("mapped_size", module.mapped_size);
-    writer.Field("phnum", static_cast<uint64_t>(module.phnum));
+    writer.Field("segment_count", module.segment_count);
     writer.Field("relro", module.has_relro);
     writer.Field("tls", module.has_tls);
     if (!module.build_id.empty()) {
       writer.Field("build_id", module.build_id);
     }
-    writer.Key("segments").BeginArray();
-    for (const Segment& segment : module.segments) {
-      writer.BeginObject();
-      writer.Field("flags", segment.flags);
-      writer.Field("memsz", segment.memsz);
-      writer.EndObject();
-    }
-    writer.EndArray();
     writer.EndObject();
   }
   writer.EndArray();

--- a/app/src/main/cpp/elf_modules.cpp
+++ b/app/src/main/cpp/elf_modules.cpp
@@ -1,0 +1,200 @@
+#include <elf.h>
+#include <jni.h>
+#include <link.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "native_util.h"
+
+namespace {
+
+using aoscm::JsonWriter;
+
+constexpr char kHexDigits[] = "0123456789abcdef";
+
+struct Segment {
+  std::string flags;
+  uint64_t memsz = 0;
+};
+
+struct Module {
+  std::string path;
+  uint64_t base = 0;
+  uint64_t mapped_size = 0;
+  std::string build_id;
+  bool has_relro = false;
+  bool has_tls = false;
+  size_t phnum = 0;
+  std::vector<Segment> segments;
+};
+
+struct Collector {
+  std::vector<Module> modules;
+  unsigned long long adds = 0;
+  unsigned long long subs = 0;
+  bool counts_valid = false;
+};
+
+std::string DescribeFlags(uint32_t flags) {
+  std::string described(3, '-');
+  if ((flags & PF_R) != 0) {
+    described[0] = 'r';
+  }
+  if ((flags & PF_W) != 0) {
+    described[1] = 'w';
+  }
+  if ((flags & PF_X) != 0) {
+    described[2] = 'x';
+  }
+  return described;
+}
+
+/**
+ * Pulls the GNU build id out of a `PT_NOTE` segment.
+ *
+ * The build id is what ties a loaded library back to the symbols the platform build produced, and
+ * nothing outside the ELF headers carries it — it is exactly the kind of reading that has to be
+ * taken here rather than from the Java side.
+ *
+ * Notes are a packed sequence of `Nhdr`, name, and descriptor, each padded to four bytes.
+ */
+std::string ReadBuildId(const ElfW(Phdr) & header, ElfW(Addr) base) {
+  const auto* cursor = reinterpret_cast<const unsigned char*>(base + header.p_vaddr);
+  const unsigned char* const end = cursor + header.p_memsz;
+
+  while (cursor + sizeof(ElfW(Nhdr)) <= end) {
+    const auto* note = reinterpret_cast<const ElfW(Nhdr)*>(cursor);
+    const size_t name_size = (note->n_namesz + 3) & ~3u;
+    const size_t desc_size = (note->n_descsz + 3) & ~3u;
+    const unsigned char* const name = cursor + sizeof(ElfW(Nhdr));
+    const unsigned char* const descriptor = name + name_size;
+
+    if (descriptor + desc_size > end) {
+      break;
+    }
+    if (note->n_type == NT_GNU_BUILD_ID && note->n_namesz == 4 &&
+        std::equal(name, name + 4, reinterpret_cast<const unsigned char*>("GNU"))) {
+      std::string hex;
+      hex.reserve(note->n_descsz * 2);
+      for (size_t i = 0; i < note->n_descsz; ++i) {
+        hex.push_back(kHexDigits[descriptor[i] >> 4]);
+        hex.push_back(kHexDigits[descriptor[i] & 0xF]);
+      }
+      return hex;
+    }
+    cursor = descriptor + desc_size;
+  }
+  return std::string();
+}
+
+/**
+ * Records one loaded object.
+ *
+ * The linker holds its own lock across this callback, so the work here stays to reading the
+ * program headers and copying what they say. Anything else — JNI calls, building the JSON — waits
+ * until the walk is over. `dlpi_name` points into the linker's own storage and is copied for the
+ * same reason.
+ */
+int CollectModule(dl_phdr_info* info, size_t size, void* data) {
+  auto* collector = static_cast<Collector*>(data);
+
+  // dlpi_adds and dlpi_subs were added after the original struct, so they are only there when the
+  // linker says the struct is big enough to hold them.
+  if (!collector->counts_valid &&
+      size >= offsetof(dl_phdr_info, dlpi_subs) + sizeof(info->dlpi_subs)) {
+    collector->adds = info->dlpi_adds;
+    collector->subs = info->dlpi_subs;
+    collector->counts_valid = true;
+  }
+
+  Module module;
+  module.path = (info->dlpi_name != nullptr) ? info->dlpi_name : "";
+  module.base = static_cast<uint64_t>(info->dlpi_addr);
+  module.phnum = info->dlpi_phnum;
+
+  uint64_t lowest = UINT64_MAX;
+  uint64_t highest = 0;
+  for (size_t i = 0; i < info->dlpi_phnum; ++i) {
+    const ElfW(Phdr) & header = info->dlpi_phdr[i];
+    switch (header.p_type) {
+      case PT_LOAD:
+        lowest = std::min<uint64_t>(lowest, header.p_vaddr);
+        highest = std::max<uint64_t>(highest, header.p_vaddr + header.p_memsz);
+        module.segments.push_back({DescribeFlags(header.p_flags), header.p_memsz});
+        break;
+      case PT_NOTE:
+        if (module.build_id.empty()) {
+          module.build_id = ReadBuildId(header, info->dlpi_addr);
+        }
+        break;
+      case PT_GNU_RELRO:
+        module.has_relro = true;
+        break;
+      case PT_TLS:
+        module.has_tls = true;
+        break;
+      default:
+        break;
+    }
+  }
+  if (lowest != UINT64_MAX) {
+    module.mapped_size = highest - lowest;
+  }
+
+  collector->modules.push_back(std::move(module));
+  return 0;
+}
+
+}  // namespace
+
+/**
+ * Every shared object the dynamic linker has loaded into this process.
+ *
+ * There is no Java equivalent: the linker publishes this through `dl_iterate_phdr` and nowhere
+ * else, so the list — with each object's load address, mapped size and build id — can only be
+ * taken from native code.
+ */
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_aoscoremonitor_diagnostics_jni_NativeModuleInspector_getLoadedModulesNative(
+    JNIEnv* env, jobject /* this */) {
+  Collector collector;
+  dl_iterate_phdr(CollectModule, &collector);
+
+  JsonWriter writer;
+  writer.BeginObject();
+  if (collector.counts_valid) {
+    writer.Field("adds", static_cast<uint64_t>(collector.adds));
+    writer.Field("subs", static_cast<uint64_t>(collector.subs));
+  }
+
+  writer.Key("modules").BeginArray();
+  for (const Module& module : collector.modules) {
+    writer.BeginObject();
+    writer.Field("path", module.path);
+    writer.FieldHex("base", module.base);
+    writer.Field("mapped_size", module.mapped_size);
+    writer.Field("phnum", static_cast<uint64_t>(module.phnum));
+    writer.Field("relro", module.has_relro);
+    writer.Field("tls", module.has_tls);
+    if (!module.build_id.empty()) {
+      writer.Field("build_id", module.build_id);
+    }
+    writer.Key("segments").BeginArray();
+    for (const Segment& segment : module.segments) {
+      writer.BeginObject();
+      writer.Field("flags", segment.flags);
+      writer.Field("memsz", segment.memsz);
+      writer.EndObject();
+    }
+    writer.EndArray();
+    writer.EndObject();
+  }
+  writer.EndArray();
+
+  writer.EndObject();
+  return env->NewStringUTF(writer.Take().c_str());
+}

--- a/app/src/main/cpp/libsystem_monitor.map.txt
+++ b/app/src/main/cpp/libsystem_monitor.map.txt
@@ -1,0 +1,18 @@
+# The library's ABI: the JNI entry points, and nothing else.
+#
+# Everything else is local because the NDK links libc++ statically, and a static archive's symbols
+# are re-exported by whatever links it — otherwise this library publishes the standard library into
+# the process's global symbol lookup, where it can bind another library's std:: calls to this copy.
+#
+# The pattern matches the Java package the native methods are bound to, so adding a method, or a
+# class under the same package, needs no change here.
+#
+# Getting the pattern wrong fails quietly: the linker does not warn about a wildcard that matches no
+# symbol, so the library links, exports nothing, and throws UnsatisfiedLinkError on the first call
+# into it. NativeInspectorTest makes that call.
+LIBSYSTEM_MONITOR {
+  global:
+    Java_com_aoscoremonitor_diagnostics_jni_*;
+  local:
+    *;
+};

--- a/app/src/main/cpp/memory_map.cpp
+++ b/app/src/main/cpp/memory_map.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "native_util.h"
@@ -35,42 +36,35 @@ enum class Category {
   kCount,
 };
 
-constexpr std::array<const char*, static_cast<size_t>(Category::kCount)> kCategoryKeys = {
+constexpr std::array<const char*, std::to_underlying(Category::kCount)> kCategoryKeys = {
     "native_lib", "art", "dalvik", "native_heap", "stack", "anon", "other",
 };
-
-bool EndsWith(std::string_view text, std::string_view suffix) {
-  return text.size() >= suffix.size() &&
-         text.compare(text.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
-bool StartsWith(std::string_view text, std::string_view prefix) {
-  return text.size() >= prefix.size() && text.compare(0, prefix.size(), prefix) == 0;
-}
 
 Category Classify(std::string_view path) {
   if (path.empty()) {
     return Category::kAnon;
   }
-  if (StartsWith(path, "[stack") || StartsWith(path, "[anon:stack_and_tls")) {
+  if (path.starts_with("[stack") || path.starts_with("[anon:stack_and_tls")) {
     return Category::kStack;
   }
-  if (path == "[heap]" || StartsWith(path, "[anon:libc_malloc") ||
-      StartsWith(path, "[anon:scudo") || StartsWith(path, "[anon:GWP-ASan")) {
+  if (path == "[heap]" || path.starts_with("[anon:libc_malloc") ||
+      path.starts_with("[anon:scudo") || path.starts_with("[anon:GWP-ASan")) {
     return Category::kNativeHeap;
   }
-  if (path.find("dalvik") != std::string_view::npos) {
+  if (path.contains("dalvik")) {
     return Category::kDalvik;
   }
-  if (EndsWith(path, ".so") || path.find(".so ") != std::string_view::npos) {
+  // A deleted file keeps its name and gains a " (deleted)" suffix, so a library is matched at
+  // either the end of the path or before that marker.
+  if (path.ends_with(".so") || path.contains(".so ")) {
     return Category::kNativeLib;
   }
-  if (EndsWith(path, ".art") || EndsWith(path, ".oat") || EndsWith(path, ".odex") ||
-      EndsWith(path, ".vdex") || EndsWith(path, ".dex") || EndsWith(path, ".jar") ||
-      EndsWith(path, ".apk")) {
+  if (path.ends_with(".art") || path.ends_with(".oat") || path.ends_with(".odex") ||
+      path.ends_with(".vdex") || path.ends_with(".dex") || path.ends_with(".jar") ||
+      path.ends_with(".apk")) {
     return Category::kArt;
   }
-  if (StartsWith(path, "[")) {
+  if (path.starts_with("[")) {
     return Category::kAnon;
   }
   return Category::kOther;
@@ -85,7 +79,7 @@ struct MapsSummary {
   uint64_t total_regions = 0;
   uint64_t reserved_regions = 0;
   uint64_t reserved_kb = 0;
-  std::array<CategoryTotals, static_cast<size_t>(Category::kCount)> categories = {};
+  std::array<CategoryTotals, std::to_underlying(Category::kCount)> categories = {};
 };
 
 /**
@@ -151,7 +145,7 @@ MapsSummary SummarizeMaps() {
             ? std::string_view(line).substr(position)
             : std::string_view();
 
-    auto& totals = summary.categories[static_cast<size_t>(Classify(path))];
+    auto& totals = summary.categories[std::to_underlying(Classify(path))];
     totals.count += 1;
     totals.size_kb += (end - start) / 1024;
   }

--- a/app/src/main/cpp/memory_map.cpp
+++ b/app/src/main/cpp/memory_map.cpp
@@ -1,0 +1,324 @@
+#include <jni.h>
+#include <malloc.h>
+#include <sys/resource.h>
+
+#include <array>
+#include <cstdlib>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "native_util.h"
+
+namespace {
+
+using aoscm::JsonWriter;
+
+/**
+ * What a mapping is for, decided from the path the kernel prints for it.
+ *
+ * The keys are stable identifiers rather than labels: the display names live in strings.xml so
+ * that renaming a category — or translating it — does not mean rebuilding the native library.
+ * The order here is the order the screen lists them in.
+ */
+enum class Category {
+  kNativeLib,
+  kArt,
+  kDalvik,
+  kNativeHeap,
+  kStack,
+  kAnon,
+  kOther,
+  kCount,
+};
+
+constexpr std::array<const char*, static_cast<size_t>(Category::kCount)> kCategoryKeys = {
+    "native_lib", "art", "dalvik", "native_heap", "stack", "anon", "other",
+};
+
+bool EndsWith(std::string_view text, std::string_view suffix) {
+  return text.size() >= suffix.size() &&
+         text.compare(text.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+bool StartsWith(std::string_view text, std::string_view prefix) {
+  return text.size() >= prefix.size() && text.compare(0, prefix.size(), prefix) == 0;
+}
+
+Category Classify(std::string_view path) {
+  if (path.empty()) {
+    return Category::kAnon;
+  }
+  if (StartsWith(path, "[stack") || StartsWith(path, "[anon:stack_and_tls")) {
+    return Category::kStack;
+  }
+  if (path == "[heap]" || StartsWith(path, "[anon:libc_malloc") ||
+      StartsWith(path, "[anon:scudo") || StartsWith(path, "[anon:GWP-ASan")) {
+    return Category::kNativeHeap;
+  }
+  if (path.find("dalvik") != std::string_view::npos) {
+    return Category::kDalvik;
+  }
+  if (EndsWith(path, ".so") || path.find(".so ") != std::string_view::npos) {
+    return Category::kNativeLib;
+  }
+  if (EndsWith(path, ".art") || EndsWith(path, ".oat") || EndsWith(path, ".odex") ||
+      EndsWith(path, ".vdex") || EndsWith(path, ".dex") || EndsWith(path, ".jar") ||
+      EndsWith(path, ".apk")) {
+    return Category::kArt;
+  }
+  if (StartsWith(path, "[")) {
+    return Category::kAnon;
+  }
+  return Category::kOther;
+}
+
+struct CategoryTotals {
+  uint64_t count = 0;
+  uint64_t size_kb = 0;
+};
+
+struct MapsSummary {
+  uint64_t total_regions = 0;
+  uint64_t reserved_regions = 0;
+  uint64_t reserved_kb = 0;
+  std::array<CategoryTotals, static_cast<size_t>(Category::kCount)> categories = {};
+};
+
+/**
+ * Walks `/proc/self/maps` and totals the address space by category.
+ *
+ * Every line is `start-end perms offset dev inode [path]`, and the path may contain spaces, so it
+ * is taken as the remainder of the line rather than as a whitespace-delimited field.
+ *
+ * Mappings with no access at all are counted apart from the rest. Four fifths of a 64-bit
+ * Android process's address space is exactly that — the CFI shadow, WebView's reservation and
+ * Scudo's primary reserve, all mapped `---p` so that nothing else can take the range. Folding
+ * them into the category totals put 8 GB of "native heap" at the top of a screen describing a
+ * process holding 100 MB, which is true of the address space and says nothing about the memory.
+ */
+MapsSummary SummarizeMaps() {
+  MapsSummary summary;
+  std::ifstream maps("/proc/self/maps");
+  if (!maps.is_open()) {
+    return summary;
+  }
+
+  std::string line;
+  while (std::getline(maps, line)) {
+    const size_t dash = line.find('-');
+    const size_t space = line.find(' ');
+    if (dash == std::string::npos || space == std::string::npos || dash > space) {
+      continue;
+    }
+
+    const uint64_t start = std::strtoull(line.c_str(), nullptr, 16);
+    const uint64_t end = std::strtoull(line.c_str() + dash + 1, nullptr, 16);
+    if (end <= start) {
+      continue;
+    }
+
+    summary.total_regions += 1;
+
+    // The permissions are the fixed-width field straight after the address range.
+    const std::string_view permissions = std::string_view(line).substr(space + 1, 4);
+    const bool accessible =
+        permissions.size() == 4 &&
+        (permissions[0] == 'r' || permissions[1] == 'w' || permissions[2] == 'x');
+    if (!accessible) {
+      summary.reserved_regions += 1;
+      summary.reserved_kb += (end - start) / 1024;
+      continue;
+    }
+
+    // Five whitespace-separated fields precede the path; whatever follows them is the path,
+    // spaces included.
+    size_t position = 0;
+    int fields = 0;
+    while (fields < 5 && position < line.size()) {
+      position = line.find(' ', position);
+      if (position == std::string::npos) {
+        break;
+      }
+      position = line.find_first_not_of(' ', position);
+      ++fields;
+    }
+    const std::string_view path =
+        (fields == 5 && position != std::string::npos && position < line.size())
+            ? std::string_view(line).substr(position)
+            : std::string_view();
+
+    auto& totals = summary.categories[static_cast<size_t>(Classify(path))];
+    totals.count += 1;
+    totals.size_kb += (end - start) / 1024;
+  }
+  return summary;
+}
+
+/** The smaps counters worth showing, in the order the screen shows them. */
+constexpr std::array<const char*, 8> kRollupKeys = {
+    "Rss",          "Pss",          "Private_Clean", "Private_Dirty",
+    "Shared_Clean", "Shared_Dirty", "Swap",          "SwapPss",
+};
+
+/** The JSON key each smaps counter is published under. */
+constexpr std::array<const char*, 8> kRollupJsonKeys = {
+    "rss_kb",          "pss_kb",          "private_clean_kb", "private_dirty_kb",
+    "shared_clean_kb", "shared_dirty_kb", "swap_kb",          "swap_pss_kb",
+};
+
+struct Rollup {
+  bool present = false;
+  bool from_rollup_file = false;
+  std::array<uint64_t, kRollupKeys.size()> values = {};
+};
+
+/**
+ * Totals the per-mapping counters in a smaps-formatted file.
+ *
+ * `/proc/self/smaps_rollup` is the kernel doing this sum itself and is one short read; it needs
+ * kernel 4.14, so `/proc/self/smaps` — hundreds of mappings, each with twenty counter lines —
+ * remains as the fallback. Both files have the same `Key:  value kB` shape, so one parser covers
+ * them and only the cost differs.
+ */
+Rollup ReadSmaps(const char* path, bool is_rollup_file) {
+  Rollup rollup;
+  std::ifstream file(path);
+  if (!file.is_open()) {
+    return rollup;
+  }
+
+  std::string line;
+  while (std::getline(file, line)) {
+    const size_t colon = line.find(':');
+    if (colon == std::string::npos) {
+      continue;
+    }
+    const std::string_view key = std::string_view(line).substr(0, colon);
+    for (size_t i = 0; i < kRollupKeys.size(); ++i) {
+      if (key == kRollupKeys[i]) {
+        rollup.values[i] += std::strtoull(line.c_str() + colon + 1, nullptr, 10);
+        rollup.present = true;
+        break;
+      }
+    }
+  }
+  rollup.from_rollup_file = is_rollup_file && rollup.present;
+  return rollup;
+}
+
+/** The `/proc/self/status` lines the screen shows, in order. */
+constexpr std::array<const char*, 6> kStatusKeys = {
+    "VmSize", "VmRSS", "VmHWM", "VmSwap", "Threads", "FDSize",
+};
+
+void WriteStatus(JsonWriter* writer) {
+  std::ifstream status("/proc/self/status");
+  if (!status.is_open()) {
+    return;
+  }
+
+  writer->Key("status").BeginObject();
+  std::string line;
+  while (std::getline(status, line)) {
+    const size_t colon = line.find(':');
+    if (colon == std::string::npos) {
+      continue;
+    }
+    const std::string key = line.substr(0, colon);
+    for (const char* wanted : kStatusKeys) {
+      if (key == wanted) {
+        const size_t value_start = line.find_first_not_of(" \t", colon + 1);
+        if (value_start != std::string::npos) {
+          writer->Field(key, std::string_view(line).substr(value_start));
+        }
+        break;
+      }
+    }
+  }
+  writer->EndObject();
+}
+
+void WriteLimit(JsonWriter* writer, const char* key, int resource) {
+  rlimit limit = {};
+  if (getrlimit(resource, &limit) != 0 || limit.rlim_cur == RLIM_INFINITY) {
+    // An unlimited resource is left out rather than published as a sentinel, so the screen has
+    // nothing to misreport as a very large number.
+    return;
+  }
+  writer->Field(key, static_cast<uint64_t>(limit.rlim_cur));
+}
+
+}  // namespace
+
+/**
+ * The app's own address space.
+ *
+ * Everything here comes from `/proc/self`, which a process can always read regardless of SELinux
+ * policy — unlike the system-wide counters the older native screen reads, this never falls back
+ * to sample data.
+ */
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_aoscoremonitor_diagnostics_jni_NativeMemoryInspector_getMemoryMapNative(
+    JNIEnv* env, jobject /* this */) {
+  JsonWriter writer;
+  writer.BeginObject();
+
+  Rollup rollup = ReadSmaps("/proc/self/smaps_rollup", true);
+  if (!rollup.present) {
+    rollup = ReadSmaps("/proc/self/smaps", false);
+  }
+  if (rollup.present) {
+    writer.Key("rollup").BeginObject();
+    for (size_t i = 0; i < kRollupJsonKeys.size(); ++i) {
+      writer.Field(kRollupJsonKeys[i], rollup.values[i]);
+    }
+    writer.Field("from_rollup_file", rollup.from_rollup_file);
+    writer.EndObject();
+  }
+
+  WriteStatus(&writer);
+
+  const MapsSummary maps = SummarizeMaps();
+  writer.Key("regions").BeginObject();
+  writer.Field("total", maps.total_regions);
+  writer.Field("reserved_count", maps.reserved_regions);
+  writer.Field("reserved_kb", maps.reserved_kb);
+  writer.Key("categories").BeginArray();
+  for (size_t i = 0; i < kCategoryKeys.size(); ++i) {
+    if (maps.categories[i].count == 0) {
+      continue;
+    }
+    writer.BeginObject();
+    writer.Field("key", kCategoryKeys[i]);
+    writer.Field("count", maps.categories[i].count);
+    writer.Field("size_kb", maps.categories[i].size_kb);
+    writer.EndObject();
+  }
+  writer.EndArray();
+  writer.EndObject();
+
+  const struct mallinfo2 heap = mallinfo2();
+  writer.Key("malloc").BeginObject();
+  writer.Field("arena", static_cast<uint64_t>(heap.arena));
+  writer.Field("in_use", static_cast<uint64_t>(heap.uordblks));
+  writer.Field("free", static_cast<uint64_t>(heap.fordblks));
+  writer.Field("free_chunks", static_cast<uint64_t>(heap.ordblks));
+  writer.Field("mmapped", static_cast<uint64_t>(heap.hblkhd));
+  writer.Field("peak", static_cast<uint64_t>(heap.usmblks));
+  writer.Field("releasable", static_cast<uint64_t>(heap.keepcost));
+  writer.EndObject();
+
+  writer.Key("limits").BeginObject();
+  WriteLimit(&writer, "address_space", RLIMIT_AS);
+  WriteLimit(&writer, "data", RLIMIT_DATA);
+  WriteLimit(&writer, "stack", RLIMIT_STACK);
+  WriteLimit(&writer, "open_files", RLIMIT_NOFILE);
+  writer.EndObject();
+
+  writer.EndObject();
+  return env->NewStringUTF(writer.Take().c_str());
+}

--- a/app/src/main/cpp/memory_map.cpp
+++ b/app/src/main/cpp/memory_map.cpp
@@ -258,61 +258,63 @@ void WriteLimit(JsonWriter* writer, const char* key, int resource) {
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeMemoryInspector_getMemoryMapNative(
     JNIEnv* env, jobject /* this */) {
-  JsonWriter writer;
-  writer.BeginObject();
-
-  Rollup rollup = ReadSmaps("/proc/self/smaps_rollup", true);
-  if (!rollup.present) {
-    rollup = ReadSmaps("/proc/self/smaps", false);
-  }
-  if (rollup.present) {
-    writer.Key("rollup").BeginObject();
-    for (size_t i = 0; i < kRollupJsonKeys.size(); ++i) {
-      writer.Field(kRollupJsonKeys[i], rollup.values[i]);
-    }
-    writer.Field("from_rollup_file", rollup.from_rollup_file);
-    writer.EndObject();
-  }
-
-  WriteStatus(&writer);
-
-  const MapsSummary maps = SummarizeMaps();
-  writer.Key("regions").BeginObject();
-  writer.Field("total", maps.total_regions);
-  writer.Field("reserved_count", maps.reserved_regions);
-  writer.Field("reserved_kb", maps.reserved_kb);
-  writer.Key("categories").BeginArray();
-  for (size_t i = 0; i < kCategoryKeys.size(); ++i) {
-    if (maps.categories[i].count == 0) {
-      continue;
-    }
+  return aoscm::ReturnJson(env, [] {
+    JsonWriter writer;
     writer.BeginObject();
-    writer.Field("key", kCategoryKeys[i]);
-    writer.Field("count", maps.categories[i].count);
-    writer.Field("size_kb", maps.categories[i].size_kb);
+
+    Rollup rollup = ReadSmaps("/proc/self/smaps_rollup", true);
+    if (!rollup.present) {
+      rollup = ReadSmaps("/proc/self/smaps", false);
+    }
+    if (rollup.present) {
+      writer.Key("rollup").BeginObject();
+      for (size_t i = 0; i < kRollupJsonKeys.size(); ++i) {
+        writer.Field(kRollupJsonKeys[i], rollup.values[i]);
+      }
+      writer.Field("from_rollup_file", rollup.from_rollup_file);
+      writer.EndObject();
+    }
+
+    WriteStatus(&writer);
+
+    const MapsSummary maps = SummarizeMaps();
+    writer.Key("regions").BeginObject();
+    writer.Field("total", maps.total_regions);
+    writer.Field("reserved_count", maps.reserved_regions);
+    writer.Field("reserved_kb", maps.reserved_kb);
+    writer.Key("categories").BeginArray();
+    for (size_t i = 0; i < kCategoryKeys.size(); ++i) {
+      if (maps.categories[i].count == 0) {
+        continue;
+      }
+      writer.BeginObject();
+      writer.Field("key", kCategoryKeys[i]);
+      writer.Field("count", maps.categories[i].count);
+      writer.Field("size_kb", maps.categories[i].size_kb);
+      writer.EndObject();
+    }
+    writer.EndArray();
     writer.EndObject();
-  }
-  writer.EndArray();
-  writer.EndObject();
 
-  const struct mallinfo2 heap = mallinfo2();
-  writer.Key("malloc").BeginObject();
-  writer.Field("arena", static_cast<uint64_t>(heap.arena));
-  writer.Field("in_use", static_cast<uint64_t>(heap.uordblks));
-  writer.Field("free", static_cast<uint64_t>(heap.fordblks));
-  writer.Field("free_chunks", static_cast<uint64_t>(heap.ordblks));
-  writer.Field("mmapped", static_cast<uint64_t>(heap.hblkhd));
-  writer.Field("peak", static_cast<uint64_t>(heap.usmblks));
-  writer.Field("releasable", static_cast<uint64_t>(heap.keepcost));
-  writer.EndObject();
+    const struct mallinfo2 heap = mallinfo2();
+    writer.Key("malloc").BeginObject();
+    writer.Field("arena", static_cast<uint64_t>(heap.arena));
+    writer.Field("in_use", static_cast<uint64_t>(heap.uordblks));
+    writer.Field("free", static_cast<uint64_t>(heap.fordblks));
+    writer.Field("free_chunks", static_cast<uint64_t>(heap.ordblks));
+    writer.Field("mmapped", static_cast<uint64_t>(heap.hblkhd));
+    writer.Field("peak", static_cast<uint64_t>(heap.usmblks));
+    writer.Field("releasable", static_cast<uint64_t>(heap.keepcost));
+    writer.EndObject();
 
-  writer.Key("limits").BeginObject();
-  WriteLimit(&writer, "address_space", RLIMIT_AS);
-  WriteLimit(&writer, "data", RLIMIT_DATA);
-  WriteLimit(&writer, "stack", RLIMIT_STACK);
-  WriteLimit(&writer, "open_files", RLIMIT_NOFILE);
-  writer.EndObject();
+    writer.Key("limits").BeginObject();
+    WriteLimit(&writer, "address_space", RLIMIT_AS);
+    WriteLimit(&writer, "data", RLIMIT_DATA);
+    WriteLimit(&writer, "stack", RLIMIT_STACK);
+    WriteLimit(&writer, "open_files", RLIMIT_NOFILE);
+    writer.EndObject();
 
-  writer.EndObject();
-  return env->NewStringUTF(writer.Take().c_str());
+    writer.EndObject();
+    return writer.Take();
+  });
 }

--- a/app/src/main/cpp/memory_map.cpp
+++ b/app/src/main/cpp/memory_map.cpp
@@ -5,12 +5,9 @@
 #include <array>
 #include <cstdlib>
 #include <fstream>
-#include <optional>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <utility>
-#include <vector>
 
 #include "native_util.h"
 
@@ -24,8 +21,11 @@ using aoscm::JsonWriter;
  * The keys are stable identifiers rather than labels: the display names live in strings.xml so
  * that renaming a category — or translating it — does not mean rebuilding the native library.
  * The order here is the order the screen lists them in.
+ *
+ * The underlying type is `size_t` because every use is an array index; leaving it `int` costs a
+ * signedness conversion at each one.
  */
-enum class Category {
+enum class Category : size_t {
   kNativeLib,
   kArt,
   kDalvik,

--- a/app/src/main/cpp/native_util.cpp
+++ b/app/src/main/cpp/native_util.cpp
@@ -1,10 +1,11 @@
 #include "native_util.h"
 
 #include <android/log.h>
+#include <fcntl.h>
+#include <unistd.h>
 
+#include <cerrno>
 #include <charconv>
-#include <fstream>
-#include <sstream>
 #include <system_error>
 
 namespace aoscm {
@@ -70,20 +71,53 @@ void AppendUtf16Escape(std::string* out, uint32_t unit) {
   }
 }
 
-/** Reads a whole file. Used only to back ReadTrimmedLine — nothing outside needs raw contents. */
-std::optional<std::string> ReadFile(const std::string& path) {
-  std::ifstream file(path, std::ios::in | std::ios::binary);
-  if (!file.is_open()) {
-    return std::nullopt;
+/** Closes the descriptor however the scope is left. */
+class ScopedFd {
+ public:
+  explicit ScopedFd(int fd) : fd_(fd) {}
+  ~ScopedFd() {
+    if (fd_ >= 0) {
+      ::close(fd_);
+    }
   }
-  std::stringstream contents;
-  contents << file.rdbuf();
-  // A sysfs attribute can open and then fail on read — an offline CPU's cpufreq node does exactly
-  // that — so an unreadable file must not come back as an empty string.
-  if (file.bad()) {
-    return std::nullopt;
+  ScopedFd(const ScopedFd&) = delete;
+  ScopedFd& operator=(const ScopedFd&) = delete;
+
+  [[nodiscard]] int get() const { return fd_; }
+  [[nodiscard]] bool valid() const { return fd_ >= 0; }
+
+ private:
+  int fd_;
+};
+
+/**
+ * Reads a whole file, or reports the errno that stopped it.
+ *
+ * open and read rather than ifstream: the standard says nothing about errno after a stream fails,
+ * and reporting which failure it was is the whole point here. Sysfs also reports a file size it
+ * does not have, so the length has to come from reading to the end.
+ */
+Reading<std::string> ReadFile(const std::string& path) {
+  const ScopedFd file(::open(path.c_str(), O_RDONLY | O_CLOEXEC));
+  if (!file.valid()) {
+    return std::unexpected(errno);
   }
-  return contents.str();
+
+  std::string contents;
+  char buffer[4096];
+  while (true) {
+    const ssize_t count = ::read(file.get(), buffer, sizeof(buffer));
+    if (count < 0) {
+      if (errno == EINTR) {
+        continue;
+      }
+      return std::unexpected(errno);
+    }
+    if (count == 0) {
+      return contents;
+    }
+    contents.append(buffer, static_cast<size_t>(count));
+  }
 }
 
 }  // namespace
@@ -92,22 +126,37 @@ void LogCollectorFailure(const char* what) {
   __android_log_print(ANDROID_LOG_ERROR, "NativeCollector", "Collector failed: %s", what);
 }
 
-std::optional<std::string> ReadTrimmedLine(const std::string& path) {
-  const std::optional<std::string> contents = ReadFile(path);
-  if (!contents.has_value()) {
-    return std::nullopt;
+std::string_view DescribeFailure(int error) {
+  switch (error) {
+    case EACCES:
+    case EPERM:
+      return "denied";
+    case ENOENT:
+    case ENODEV:
+    case ENXIO:
+      return "absent";
+    default:
+      return "error";
   }
-  const std::string trimmed = Trim(*contents);
+}
+
+Reading<std::string> ReadTrimmedLine(const std::string& path) {
+  const Reading<std::string> contents = ReadFile(path);
+  if (!contents.has_value()) {
+    return std::unexpected(contents.error());
+  }
+  std::string trimmed = Trim(*contents);
   if (trimmed.empty()) {
-    return std::nullopt;
+    // The file opened and held nothing, which is not the same as being refused.
+    return std::unexpected(ENODATA);
   }
   return trimmed;
 }
 
-std::optional<uint64_t> ReadUint64(const std::string& path) {
-  const std::optional<std::string> line = ReadTrimmedLine(path);
+Reading<uint64_t> ReadUint64(const std::string& path) {
+  const Reading<std::string> line = ReadTrimmedLine(path);
   if (!line.has_value()) {
-    return std::nullopt;
+    return std::unexpected(line.error());
   }
   // from_chars rather than strtoull: it reports an overflow through its own result instead of
   // through errno, and it cannot read past the end of the string it was given.
@@ -115,7 +164,7 @@ std::optional<uint64_t> ReadUint64(const std::string& path) {
   const char* const first = line->data();
   const auto [end, error] = std::from_chars(first, first + line->size(), value);
   if (error != std::errc() || end == first) {
-    return std::nullopt;
+    return std::unexpected(EINVAL);
   }
   return value;
 }
@@ -278,14 +327,14 @@ JsonWriter& JsonWriter::FieldHex(std::string_view key, uint64_t value) {
   return Key(key).ValueHex(value);
 }
 
-JsonWriter& JsonWriter::FieldIfSet(std::string_view key, const std::optional<uint64_t>& value) {
+JsonWriter& JsonWriter::FieldIfSet(std::string_view key, const Reading<uint64_t>& value) {
   if (value.has_value()) {
     Field(key, *value);
   }
   return *this;
 }
 
-JsonWriter& JsonWriter::FieldIfSet(std::string_view key, const std::optional<std::string>& value) {
+JsonWriter& JsonWriter::FieldIfSet(std::string_view key, const Reading<std::string>& value) {
   if (value.has_value()) {
     Field(key, *value);
   }

--- a/app/src/main/cpp/native_util.cpp
+++ b/app/src/main/cpp/native_util.cpp
@@ -1,10 +1,10 @@
 #include "native_util.h"
 
-#include <cerrno>
+#include <charconv>
 #include <cstdio>
-#include <cstdlib>
 #include <fstream>
 #include <sstream>
+#include <system_error>
 
 namespace aoscm {
 namespace {
@@ -103,13 +103,15 @@ std::optional<uint64_t> ReadUint64(const std::string& path) {
   if (!line.has_value()) {
     return std::nullopt;
   }
-  errno = 0;
-  char* end = nullptr;
-  const unsigned long long parsed = std::strtoull(line->c_str(), &end, 10);
-  if (errno != 0 || end == line->c_str()) {
+  // from_chars rather than strtoull: it reports an overflow through its own result instead of
+  // through errno, and it cannot read past the end of the string it was given.
+  uint64_t value = 0;
+  const char* const first = line->data();
+  const auto [end, error] = std::from_chars(first, first + line->size(), value);
+  if (error != std::errc() || end == first) {
     return std::nullopt;
   }
-  return static_cast<uint64_t>(parsed);
+  return value;
 }
 
 void JsonWriter::Separate() {

--- a/app/src/main/cpp/native_util.cpp
+++ b/app/src/main/cpp/native_util.cpp
@@ -69,8 +69,7 @@ void AppendUtf16Escape(std::string* out, uint32_t unit) {
   }
 }
 
-}  // namespace
-
+/** Reads a whole file. Used only to back ReadTrimmedLine — nothing outside needs raw contents. */
 std::optional<std::string> ReadFile(const std::string& path) {
   std::ifstream file(path, std::ios::in | std::ios::binary);
   if (!file.is_open()) {
@@ -85,6 +84,8 @@ std::optional<std::string> ReadFile(const std::string& path) {
   }
   return contents.str();
 }
+
+}  // namespace
 
 std::optional<std::string> ReadTrimmedLine(const std::string& path) {
   const std::optional<std::string> contents = ReadFile(path);

--- a/app/src/main/cpp/native_util.cpp
+++ b/app/src/main/cpp/native_util.cpp
@@ -1,7 +1,8 @@
 #include "native_util.h"
 
+#include <android/log.h>
+
 #include <charconv>
-#include <cstdio>
 #include <fstream>
 #include <sstream>
 #include <system_error>
@@ -86,6 +87,10 @@ std::optional<std::string> ReadFile(const std::string& path) {
 }
 
 }  // namespace
+
+void LogCollectorFailure(const char* what) {
+  __android_log_print(ANDROID_LOG_ERROR, "NativeCollector", "Collector failed: %s", what);
+}
 
 std::optional<std::string> ReadTrimmedLine(const std::string& path) {
   const std::optional<std::string> contents = ReadFile(path);
@@ -241,10 +246,16 @@ JsonWriter& JsonWriter::Value(const char* value) {
   return Value(value == nullptr ? std::string_view() : std::string_view(value));
 }
 
+// to_chars rather than std::format: libc++ is linked statically here, so one format call pulls
+// the whole formatting machinery into the library — measured at 210 KB per ABI.
 JsonWriter& JsonWriter::ValueHex(uint64_t value) {
-  char buffer[32];
-  std::snprintf(buffer, sizeof(buffer), "0x%llx", static_cast<unsigned long long>(value));
-  return Value(std::string_view(buffer));
+  // 16 digits is the widest a uint64_t reaches in base 16, so to_chars cannot run out of room.
+  char digits[16];
+  const auto [end, error] = std::to_chars(digits, digits + sizeof(digits), value, 16);
+  if (error != std::errc()) {
+    return Value("0x0");
+  }
+  return Value("0x" + std::string(digits, end));
 }
 
 JsonWriter& JsonWriter::Field(std::string_view key, std::string_view value) {

--- a/app/src/main/cpp/native_util.cpp
+++ b/app/src/main/cpp/native_util.cpp
@@ -1,0 +1,288 @@
+#include "native_util.h"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+
+namespace aoscm {
+namespace {
+
+constexpr char kHexDigits[] = "0123456789abcdef";
+
+std::string Trim(const std::string& text) {
+  const size_t first = text.find_first_not_of(" \t\n\r");
+  if (first == std::string::npos) {
+    return std::string();
+  }
+  const size_t last = text.find_last_not_of(" \t\n\r");
+  return text.substr(first, last - first + 1);
+}
+
+/**
+ * Length of the UTF-8 sequence starting at `bytes`, or 0 when it is not a valid one.
+ *
+ * The ranges are RFC 3629's, so overlong encodings and encoded surrogates are rejected rather
+ * than passed through to the JVM.
+ */
+size_t Utf8SequenceLength(const unsigned char* bytes, size_t available) {
+  const unsigned char lead = bytes[0];
+  size_t length;
+  unsigned char min_second;
+  unsigned char max_second;
+
+  if (lead >= 0xC2 && lead <= 0xDF) {
+    length = 2;
+    min_second = 0x80;
+    max_second = 0xBF;
+  } else if (lead >= 0xE0 && lead <= 0xEF) {
+    length = 3;
+    min_second = (lead == 0xE0) ? 0xA0 : 0x80;
+    max_second = (lead == 0xED) ? 0x9F : 0xBF;
+  } else if (lead >= 0xF0 && lead <= 0xF4) {
+    length = 4;
+    min_second = (lead == 0xF0) ? 0x90 : 0x80;
+    max_second = (lead == 0xF4) ? 0x8F : 0xBF;
+  } else {
+    return 0;
+  }
+
+  if (available < length) {
+    return 0;
+  }
+  if (bytes[1] < min_second || bytes[1] > max_second) {
+    return 0;
+  }
+  for (size_t i = 2; i < length; ++i) {
+    if (bytes[i] < 0x80 || bytes[i] > 0xBF) {
+      return 0;
+    }
+  }
+  return length;
+}
+
+void AppendUtf16Escape(std::string* out, uint32_t unit) {
+  out->append("\\u");
+  for (int shift = 12; shift >= 0; shift -= 4) {
+    out->push_back(kHexDigits[(unit >> shift) & 0xF]);
+  }
+}
+
+}  // namespace
+
+std::optional<std::string> ReadFile(const std::string& path) {
+  std::ifstream file(path, std::ios::in | std::ios::binary);
+  if (!file.is_open()) {
+    return std::nullopt;
+  }
+  std::stringstream contents;
+  contents << file.rdbuf();
+  // A sysfs attribute can open and then fail on read — an offline CPU's cpufreq node does exactly
+  // that — so an unreadable file must not come back as an empty string.
+  if (file.bad()) {
+    return std::nullopt;
+  }
+  return contents.str();
+}
+
+std::optional<std::string> ReadTrimmedLine(const std::string& path) {
+  const std::optional<std::string> contents = ReadFile(path);
+  if (!contents.has_value()) {
+    return std::nullopt;
+  }
+  const std::string trimmed = Trim(*contents);
+  if (trimmed.empty()) {
+    return std::nullopt;
+  }
+  return trimmed;
+}
+
+std::optional<uint64_t> ReadUint64(const std::string& path) {
+  const std::optional<std::string> line = ReadTrimmedLine(path);
+  if (!line.has_value()) {
+    return std::nullopt;
+  }
+  errno = 0;
+  char* end = nullptr;
+  const unsigned long long parsed = std::strtoull(line->c_str(), &end, 10);
+  if (errno != 0 || end == line->c_str()) {
+    return std::nullopt;
+  }
+  return static_cast<uint64_t>(parsed);
+}
+
+void JsonWriter::Separate() {
+  if (needs_comma_) {
+    out_.push_back(',');
+  }
+  needs_comma_ = false;
+}
+
+void JsonWriter::AppendEscaped(std::string_view value) {
+  const auto* bytes = reinterpret_cast<const unsigned char*>(value.data());
+  const size_t size = value.size();
+
+  for (size_t i = 0; i < size;) {
+    const unsigned char byte = bytes[i];
+    if (byte < 0x80) {
+      switch (byte) {
+        case '"':
+          out_.append("\\\"");
+          break;
+        case '\\':
+          out_.append("\\\\");
+          break;
+        case '\n':
+          out_.append("\\n");
+          break;
+        case '\r':
+          out_.append("\\r");
+          break;
+        case '\t':
+          out_.append("\\t");
+          break;
+        default:
+          if (byte < 0x20) {
+            AppendUtf16Escape(&out_, byte);
+          } else {
+            out_.push_back(static_cast<char>(byte));
+          }
+          break;
+      }
+      ++i;
+      continue;
+    }
+
+    const size_t length = Utf8SequenceLength(bytes + i, size - i);
+    if (length == 0) {
+      // A path is a byte string, so it need not be text at all. Replacing the byte keeps the
+      // document decodable instead of handing the JVM something it cannot represent.
+      out_.push_back('?');
+      ++i;
+      continue;
+    }
+    if (length == 4) {
+      // Escaped as a surrogate pair: the JVM's modified UTF-8 has no four-byte form, and passing
+      // one to NewStringUTF is undefined.
+      const uint32_t code_point = (static_cast<uint32_t>(bytes[i] & 0x07) << 18) |
+                                  (static_cast<uint32_t>(bytes[i + 1] & 0x3F) << 12) |
+                                  (static_cast<uint32_t>(bytes[i + 2] & 0x3F) << 6) |
+                                  static_cast<uint32_t>(bytes[i + 3] & 0x3F);
+      const uint32_t offset = code_point - 0x10000;
+      AppendUtf16Escape(&out_, 0xD800 + (offset >> 10));
+      AppendUtf16Escape(&out_, 0xDC00 + (offset & 0x3FF));
+    } else {
+      out_.append(value.substr(i, length));
+    }
+    i += length;
+  }
+}
+
+JsonWriter& JsonWriter::BeginObject() {
+  Separate();
+  out_.push_back('{');
+  return *this;
+}
+
+JsonWriter& JsonWriter::EndObject() {
+  out_.push_back('}');
+  needs_comma_ = true;
+  return *this;
+}
+
+JsonWriter& JsonWriter::BeginArray() {
+  Separate();
+  out_.push_back('[');
+  return *this;
+}
+
+JsonWriter& JsonWriter::EndArray() {
+  out_.push_back(']');
+  needs_comma_ = true;
+  return *this;
+}
+
+JsonWriter& JsonWriter::Key(std::string_view key) {
+  Separate();
+  out_.push_back('"');
+  AppendEscaped(key);
+  out_.append("\":");
+  return *this;
+}
+
+JsonWriter& JsonWriter::Value(std::string_view value) {
+  Separate();
+  out_.push_back('"');
+  AppendEscaped(value);
+  out_.push_back('"');
+  needs_comma_ = true;
+  return *this;
+}
+
+JsonWriter& JsonWriter::Value(uint64_t value) {
+  Separate();
+  out_.append(std::to_string(value));
+  needs_comma_ = true;
+  return *this;
+}
+
+JsonWriter& JsonWriter::Value(bool value) {
+  Separate();
+  out_.append(value ? "true" : "false");
+  needs_comma_ = true;
+  return *this;
+}
+
+JsonWriter& JsonWriter::Value(const char* value) {
+  return Value(value == nullptr ? std::string_view() : std::string_view(value));
+}
+
+JsonWriter& JsonWriter::ValueHex(uint64_t value) {
+  char buffer[32];
+  std::snprintf(buffer, sizeof(buffer), "0x%llx", static_cast<unsigned long long>(value));
+  return Value(std::string_view(buffer));
+}
+
+JsonWriter& JsonWriter::Field(std::string_view key, std::string_view value) {
+  return Key(key).Value(value);
+}
+
+JsonWriter& JsonWriter::Field(std::string_view key, uint64_t value) {
+  return Key(key).Value(value);
+}
+
+JsonWriter& JsonWriter::Field(std::string_view key, bool value) {
+  return Key(key).Value(value);
+}
+
+JsonWriter& JsonWriter::Field(std::string_view key, const char* value) {
+  return Key(key).Value(value);
+}
+
+JsonWriter& JsonWriter::FieldHex(std::string_view key, uint64_t value) {
+  return Key(key).ValueHex(value);
+}
+
+JsonWriter& JsonWriter::FieldIfSet(std::string_view key, const std::optional<uint64_t>& value) {
+  if (value.has_value()) {
+    Field(key, *value);
+  }
+  return *this;
+}
+
+JsonWriter& JsonWriter::FieldIfSet(std::string_view key, const std::optional<std::string>& value) {
+  if (value.has_value()) {
+    Field(key, *value);
+  }
+  return *this;
+}
+
+std::string JsonWriter::Take() {
+  std::string result;
+  result.swap(out_);
+  needs_comma_ = false;
+  return result;
+}
+
+}  // namespace aoscm

--- a/app/src/main/cpp/native_util.h
+++ b/app/src/main/cpp/native_util.h
@@ -1,0 +1,89 @@
+#ifndef AOSCM_NATIVE_UTIL_H_
+#define AOSCM_NATIVE_UTIL_H_
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace aoscm {
+
+/**
+ * Reads a whole file, or nothing at all.
+ *
+ * Sysfs and procfs reads fail routinely from the app sandbox — SELinux denies some paths outright,
+ * and others exist only on some kernels. Returning an empty optional keeps "could not read" apart
+ * from "read a zero", which matters because the screens present the two differently: a missing
+ * reading is shown as unavailable rather than as 0.
+ */
+std::optional<std::string> ReadFile(const std::string& path);
+
+/** Reads the first line of a file with surrounding whitespace removed. */
+std::optional<std::string> ReadTrimmedLine(const std::string& path);
+
+/** Reads a file holding a single decimal number, as sysfs counters do. */
+std::optional<uint64_t> ReadUint64(const std::string& path);
+
+/**
+ * Builds JSON for the JNI boundary.
+ *
+ * The existing collectors assemble their JSON by concatenating strings, which holds only as long
+ * as no value contains a quote or a backslash. The readings added here are mount options and
+ * filesystem paths — arbitrary bytes from the kernel — so they need real escaping. This also
+ * validates UTF-8 as it goes: `NewStringUTF` has undefined behaviour on malformed input, and a
+ * path is not guaranteed to be valid UTF-8.
+ *
+ * Structure is the caller's responsibility; the writer only tracks where a comma belongs.
+ */
+class JsonWriter {
+ public:
+  JsonWriter& BeginObject();
+  JsonWriter& EndObject();
+  JsonWriter& BeginArray();
+  JsonWriter& EndArray();
+
+  JsonWriter& Key(std::string_view key);
+
+  JsonWriter& Value(std::string_view value);
+  JsonWriter& Value(uint64_t value);
+  JsonWriter& Value(bool value);
+  /**
+   * Keeps a C string a string.
+   *
+   * Without it, `const char*` converts to `bool` by a standard conversion and to `string_view`
+   * only by a user-defined one, so overload resolution silently picks the boolean overload and
+   * `uname().machine` is written as `true`.
+   */
+  JsonWriter& Value(const char* value);
+  /** Writes an address as a `"0x…"` string: JSON numbers cannot hold a 64-bit pointer exactly. */
+  JsonWriter& ValueHex(uint64_t value);
+
+  JsonWriter& Field(std::string_view key, std::string_view value);
+  JsonWriter& Field(std::string_view key, uint64_t value);
+  JsonWriter& Field(std::string_view key, bool value);
+  /** See [Value(const char*)] — the same overload trap applies here. */
+  JsonWriter& Field(std::string_view key, const char* value);
+  JsonWriter& FieldHex(std::string_view key, uint64_t value);
+
+  /**
+   * Writes the field only when the reading was taken.
+   *
+   * Absent keys, rather than nulls or zeros, are how an unavailable reading crosses to Kotlin.
+   */
+  JsonWriter& FieldIfSet(std::string_view key, const std::optional<uint64_t>& value);
+  JsonWriter& FieldIfSet(std::string_view key, const std::optional<std::string>& value);
+
+  /** Hands over the finished document. The writer is empty afterwards. */
+  std::string Take();
+
+ private:
+  void Separate();
+  void AppendEscaped(std::string_view value);
+
+  std::string out_;
+  bool needs_comma_ = false;
+};
+
+}  // namespace aoscm
+
+#endif  // AOSCM_NATIVE_UTIL_H_

--- a/app/src/main/cpp/native_util.h
+++ b/app/src/main/cpp/native_util.h
@@ -9,16 +9,13 @@
 namespace aoscm {
 
 /**
- * Reads a whole file, or nothing at all.
+ * Reads the first line of a file with surrounding whitespace removed, or nothing at all.
  *
  * Sysfs and procfs reads fail routinely from the app sandbox — SELinux denies some paths outright,
  * and others exist only on some kernels. Returning an empty optional keeps "could not read" apart
  * from "read a zero", which matters because the screens present the two differently: a missing
  * reading is shown as unavailable rather than as 0.
  */
-std::optional<std::string> ReadFile(const std::string& path);
-
-/** Reads the first line of a file with surrounding whitespace removed. */
 std::optional<std::string> ReadTrimmedLine(const std::string& path);
 
 /** Reads a file holding a single decimal number, as sysfs counters do. */
@@ -55,14 +52,12 @@ class JsonWriter {
    * `uname().machine` is written as `true`.
    */
   JsonWriter& Value(const char* value);
-  /** Writes an address as a `"0x…"` string: JSON numbers cannot hold a 64-bit pointer exactly. */
-  JsonWriter& ValueHex(uint64_t value);
-
   JsonWriter& Field(std::string_view key, std::string_view value);
   JsonWriter& Field(std::string_view key, uint64_t value);
   JsonWriter& Field(std::string_view key, bool value);
   /** See [Value(const char*)] — the same overload trap applies here. */
   JsonWriter& Field(std::string_view key, const char* value);
+  /** Writes an address as a `"0x…"` string: JSON numbers cannot hold a 64-bit pointer exactly. */
   JsonWriter& FieldHex(std::string_view key, uint64_t value);
 
   /**
@@ -77,6 +72,7 @@ class JsonWriter {
   std::string Take();
 
  private:
+  JsonWriter& ValueHex(uint64_t value);
   void Separate();
   void AppendEscaped(std::string_view value);
 

--- a/app/src/main/cpp/native_util.h
+++ b/app/src/main/cpp/native_util.h
@@ -5,7 +5,7 @@
 
 #include <cstdint>
 #include <exception>
-#include <optional>
+#include <expected>
 #include <string>
 #include <string_view>
 
@@ -36,17 +36,30 @@ jstring ReturnJson(JNIEnv* env, Collect collect) noexcept {
 }
 
 /**
- * Reads the first line of a file with surrounding whitespace removed, or nothing at all.
+ * A reading, or the errno that stopped it.
  *
- * Sysfs and procfs reads fail routinely from the app sandbox — SELinux denies some paths outright,
- * and others exist only on some kernels. Returning an empty optional keeps "could not read" apart
- * from "read a zero", which matters because the screens present the two differently: a missing
- * reading is shown as unavailable rather than as 0.
+ * Sysfs and procfs reads fail routinely from the app sandbox, and the two common reasons mean
+ * different things to whoever is reading the screen: SELinux refusing a path is a property of the
+ * sandbox, while a path that does not exist is a property of the kernel. An optional could say
+ * only that the value was missing, so the reason was thrown away at the point it was known.
  */
-[[nodiscard]] std::optional<std::string> ReadTrimmedLine(const std::string& path);
+template <typename T>
+using Reading = std::expected<T, int>;
+
+/** Reads the first line of a file with surrounding whitespace removed. */
+[[nodiscard]] Reading<std::string> ReadTrimmedLine(const std::string& path);
 
 /** Reads a file holding a single decimal number, as sysfs counters do. */
-[[nodiscard]] std::optional<uint64_t> ReadUint64(const std::string& path);
+[[nodiscard]] Reading<uint64_t> ReadUint64(const std::string& path);
+
+/**
+ * Why a reading is missing, in the three words the screens distinguish.
+ *
+ * Returns "denied", "absent" or "error". The errno itself does not cross to Kotlin: a number would
+ * push the decision of what it means out to the UI layer, which is further from the syscall than
+ * this is, and the wording belongs in strings.xml either way.
+ */
+[[nodiscard]] std::string_view DescribeFailure(int error);
 
 /**
  * Builds JSON for the JNI boundary.
@@ -92,8 +105,8 @@ class JsonWriter {
    *
    * Absent keys, rather than nulls or zeros, are how an unavailable reading crosses to Kotlin.
    */
-  JsonWriter& FieldIfSet(std::string_view key, const std::optional<uint64_t>& value);
-  JsonWriter& FieldIfSet(std::string_view key, const std::optional<std::string>& value);
+  JsonWriter& FieldIfSet(std::string_view key, const Reading<uint64_t>& value);
+  JsonWriter& FieldIfSet(std::string_view key, const Reading<std::string>& value);
 
   /** Hands over the finished document. The writer is empty afterwards. */
   [[nodiscard]] std::string Take();

--- a/app/src/main/cpp/native_util.h
+++ b/app/src/main/cpp/native_util.h
@@ -1,12 +1,39 @@
 #ifndef AOSCM_NATIVE_UTIL_H_
 #define AOSCM_NATIVE_UTIL_H_
 
+#include <jni.h>
+
 #include <cstdint>
+#include <exception>
 #include <optional>
 #include <string>
 #include <string_view>
 
 namespace aoscm {
+
+/** Records why a collector produced nothing. Not shown to the user; logcat is where it lands. */
+void LogCollectorFailure(const char* what);
+
+/**
+ * Runs a collector and hands its JSON to the JVM, containing anything it throws.
+ *
+ * "C++ exceptions ... must not be thrown across the JNI transition boundary from C++ code to
+ * managed code" — every collector here builds strings and vectors, any of which can throw
+ * std::bad_alloc, and none of these entry points is otherwise in a position to stop one. An empty
+ * object is returned instead, which each parser turns into the same "no reading" the screens
+ * already handle.
+ */
+template <typename Collect>
+jstring ReturnJson(JNIEnv* env, Collect collect) noexcept {
+  try {
+    return env->NewStringUTF(collect().c_str());
+  } catch (const std::exception& failure) {
+    LogCollectorFailure(failure.what());
+  } catch (...) {
+    LogCollectorFailure("unknown exception");
+  }
+  return env->NewStringUTF("{}");
+}
 
 /**
  * Reads the first line of a file with surrounding whitespace removed, or nothing at all.
@@ -16,10 +43,10 @@ namespace aoscm {
  * from "read a zero", which matters because the screens present the two differently: a missing
  * reading is shown as unavailable rather than as 0.
  */
-std::optional<std::string> ReadTrimmedLine(const std::string& path);
+[[nodiscard]] std::optional<std::string> ReadTrimmedLine(const std::string& path);
 
 /** Reads a file holding a single decimal number, as sysfs counters do. */
-std::optional<uint64_t> ReadUint64(const std::string& path);
+[[nodiscard]] std::optional<uint64_t> ReadUint64(const std::string& path);
 
 /**
  * Builds JSON for the JNI boundary.
@@ -69,7 +96,7 @@ class JsonWriter {
   JsonWriter& FieldIfSet(std::string_view key, const std::optional<std::string>& value);
 
   /** Hands over the finished document. The writer is empty afterwards. */
-  std::string Take();
+  [[nodiscard]] std::string Take();
 
  private:
   JsonWriter& ValueHex(uint64_t value);

--- a/app/src/main/cpp/storage_info.cpp
+++ b/app/src/main/cpp/storage_info.cpp
@@ -3,8 +3,6 @@
 #include <sys/statvfs.h>
 
 #include <cstdio>
-#include <cstring>
-#include <string>
 #include <string_view>
 
 #include "native_util.h"
@@ -35,7 +33,6 @@ void WriteUsage(JsonWriter* writer, const char* target) {
   // interchangeable with it, though on most Android filesystems the two happen to agree.
   const uint64_t unit = usage.f_frsize != 0 ? usage.f_frsize : usage.f_bsize;
   writer->Field("statvfs_ok", true);
-  writer->Field("block_size", unit);
   writer->Field("total_bytes", static_cast<uint64_t>(usage.f_blocks) * unit);
   writer->Field("free_bytes", static_cast<uint64_t>(usage.f_bfree) * unit);
   writer->Field("available_bytes", static_cast<uint64_t>(usage.f_bavail) * unit);

--- a/app/src/main/cpp/storage_info.cpp
+++ b/app/src/main/cpp/storage_info.cpp
@@ -3,6 +3,8 @@
 #include <sys/statvfs.h>
 
 #include <cstdio>
+#include <memory>
+#include <string>
 #include <string_view>
 
 #include "native_util.h"
@@ -10,6 +12,9 @@
 namespace {
 
 using aoscm::JsonWriter;
+
+/** Closes the mount table however the scope is left, exception included. */
+using MountTable = std::unique_ptr<FILE, decltype([](FILE* table) { endmntent(table); })>;
 
 /** Whether the mount was made read-only, which is the first option the kernel lists. */
 bool IsReadOnly(const char* options) {
@@ -60,30 +65,30 @@ void WriteUsage(JsonWriter* writer, const char* target) {
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeStorageInspector_getMountsNative(JNIEnv* env,
                                                                                jobject /* this */) {
-  JsonWriter writer;
-  writer.BeginObject();
-  writer.Key("mounts").BeginArray();
+  return aoscm::ReturnJson(env, [] {
+    JsonWriter writer;
+    writer.BeginObject();
+    writer.Key("mounts").BeginArray();
 
-  FILE* mounts = setmntent("/proc/self/mounts", "r");
-  if (mounts != nullptr) {
-    struct mntent entry = {};
-    char buffer[4096];
-    // The reentrant form: the plain getmntent() hands back a pointer to shared storage, which is
-    // a hazard worth avoiding in a library that any thread may call.
-    while (getmntent_r(mounts, &entry, buffer, sizeof(buffer)) != nullptr) {
-      writer.BeginObject();
-      writer.Field("source", entry.mnt_fsname);
-      writer.Field("target", entry.mnt_dir);
-      writer.Field("fs_type", entry.mnt_type);
-      writer.Field("options", entry.mnt_opts);
-      writer.Field("readonly", IsReadOnly(entry.mnt_opts));
-      WriteUsage(&writer, entry.mnt_dir);
-      writer.EndObject();
+    if (const MountTable mounts{setmntent("/proc/self/mounts", "r")}) {
+      struct mntent entry = {};
+      char buffer[4096];
+      // The reentrant form: the plain getmntent() hands back a pointer to shared storage, which is
+      // a hazard worth avoiding in a library that any thread may call.
+      while (getmntent_r(mounts.get(), &entry, buffer, sizeof(buffer)) != nullptr) {
+        writer.BeginObject();
+        writer.Field("source", entry.mnt_fsname);
+        writer.Field("target", entry.mnt_dir);
+        writer.Field("fs_type", entry.mnt_type);
+        writer.Field("options", entry.mnt_opts);
+        writer.Field("readonly", IsReadOnly(entry.mnt_opts));
+        WriteUsage(&writer, entry.mnt_dir);
+        writer.EndObject();
+      }
     }
-    endmntent(mounts);
-  }
 
-  writer.EndArray();
-  writer.EndObject();
-  return env->NewStringUTF(writer.Take().c_str());
+    writer.EndArray();
+    writer.EndObject();
+    return writer.Take();
+  });
 }

--- a/app/src/main/cpp/storage_info.cpp
+++ b/app/src/main/cpp/storage_info.cpp
@@ -19,7 +19,7 @@ bool IsReadOnly(const char* options) {
     return false;
   }
   const std::string_view text(options);
-  return text == "ro" || text.compare(0, 3, "ro,") == 0;
+  return text == "ro" || text.starts_with("ro,");
 }
 
 void WriteUsage(JsonWriter* writer, const char* target) {

--- a/app/src/main/cpp/storage_info.cpp
+++ b/app/src/main/cpp/storage_info.cpp
@@ -2,6 +2,7 @@
 #include <mntent.h>
 #include <sys/statvfs.h>
 
+#include <cerrno>
 #include <cstdio>
 #include <memory>
 #include <string>
@@ -29,8 +30,9 @@ void WriteUsage(JsonWriter* writer, const char* target) {
   struct statvfs64 usage = {};
   if (statvfs64(target, &usage) != 0) {
     // Denied or gone: /proc, /sys and most of /mnt answer this way for an app. The mount is still
-    // listed — knowing it exists is part of the picture — just without its capacity.
+    // listed — knowing it exists is part of the picture — with the reason in place of a capacity.
     writer->Field("statvfs_ok", false);
+    writer->Field("statvfs_unavailable", aoscm::DescribeFailure(errno));
     return;
   }
 

--- a/app/src/main/cpp/storage_info.cpp
+++ b/app/src/main/cpp/storage_info.cpp
@@ -1,0 +1,92 @@
+#include <jni.h>
+#include <mntent.h>
+#include <sys/statvfs.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+#include "native_util.h"
+
+namespace {
+
+using aoscm::JsonWriter;
+
+/** Whether the mount was made read-only, which is the first option the kernel lists. */
+bool IsReadOnly(const char* options) {
+  if (options == nullptr) {
+    return false;
+  }
+  const std::string_view text(options);
+  return text == "ro" || text.compare(0, 3, "ro,") == 0;
+}
+
+void WriteUsage(JsonWriter* writer, const char* target) {
+  struct statvfs64 usage = {};
+  if (statvfs64(target, &usage) != 0) {
+    // Denied or gone: /proc, /sys and most of /mnt answer this way for an app. The mount is still
+    // listed — knowing it exists is part of the picture — just without its capacity.
+    writer->Field("statvfs_ok", false);
+    return;
+  }
+
+  // f_frsize is the unit f_blocks counts in; f_bsize is the preferred I/O size and is not
+  // interchangeable with it, though on most Android filesystems the two happen to agree.
+  const uint64_t unit = usage.f_frsize != 0 ? usage.f_frsize : usage.f_bsize;
+  writer->Field("statvfs_ok", true);
+  writer->Field("block_size", unit);
+  writer->Field("total_bytes", static_cast<uint64_t>(usage.f_blocks) * unit);
+  writer->Field("free_bytes", static_cast<uint64_t>(usage.f_bfree) * unit);
+  writer->Field("available_bytes", static_cast<uint64_t>(usage.f_bavail) * unit);
+
+  // A filesystem with no fixed inode table — erofs and f2fs among them — answers with every bit
+  // set rather than with a count. Published as a number it reaches the screen as
+  // "18446744073709551615 free", so it is left out instead: the count is genuinely unknown.
+  const auto inodes_total = static_cast<uint64_t>(usage.f_files);
+  const auto inodes_free = static_cast<uint64_t>(usage.f_ffree);
+  if (inodes_total != 0 && inodes_total != UINT64_MAX && inodes_free <= inodes_total) {
+    writer->Field("inodes_total", inodes_total);
+    writer->Field("inodes_free", inodes_free);
+  }
+}
+
+}  // namespace
+
+/**
+ * Every filesystem mounted in this process's mount namespace, with the space each has left.
+ *
+ * `/proc/self/mounts` describes the caller's own namespace, so it stays readable where the
+ * system-wide /proc files this app also reads do not. Android gives each app a partly private
+ * namespace, so this is the view the app itself sees rather than the device's.
+ */
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_aoscoremonitor_diagnostics_jni_NativeStorageInspector_getMountsNative(JNIEnv* env,
+                                                                               jobject /* this */) {
+  JsonWriter writer;
+  writer.BeginObject();
+  writer.Key("mounts").BeginArray();
+
+  FILE* mounts = setmntent("/proc/self/mounts", "r");
+  if (mounts != nullptr) {
+    struct mntent entry = {};
+    char buffer[4096];
+    // The reentrant form: the plain getmntent() hands back a pointer to shared storage, which is
+    // a hazard worth avoiding in a library that any thread may call.
+    while (getmntent_r(mounts, &entry, buffer, sizeof(buffer)) != nullptr) {
+      writer.BeginObject();
+      writer.Field("source", entry.mnt_fsname);
+      writer.Field("target", entry.mnt_dir);
+      writer.Field("fs_type", entry.mnt_type);
+      writer.Field("options", entry.mnt_opts);
+      writer.Field("readonly", IsReadOnly(entry.mnt_opts));
+      WriteUsage(&writer, entry.mnt_dir);
+      writer.EndObject();
+    }
+    endmntent(mounts);
+  }
+
+  writer.EndArray();
+  writer.EndObject();
+  return env->NewStringUTF(writer.Take().c_str());
+}

--- a/app/src/main/cpp/system_monitor.cpp
+++ b/app/src/main/cpp/system_monitor.cpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <vector>
 
+#include "native_util.h"
+
 #define LOG_TAG "NativeSystemMonitor"
 #define LOGI(...) __android_log_print(ANDROID_LOG_INFO, LOG_TAG, __VA_ARGS__)
 #define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, __VA_ARGS__)
@@ -15,49 +17,53 @@
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getCpuInfoNative(JNIEnv* env,
                                                                              jobject /* this */) {
-  std::ifstream stat_file("/proc/stat");
-  std::string line;
-  std::string result;
+  return aoscm::ReturnJson(env, [] {
+    std::ifstream stat_file("/proc/stat");
+    std::string line;
+    std::string result;
 
-  if (!stat_file.is_open()) {
-    LOGE("Failed to open /proc/stat");
-    return env->NewStringUTF("Error: Failed to read CPU information");
-  }
+    if (!stat_file.is_open()) {
+      LOGE("Failed to open /proc/stat");
+      return std::string("Error: Failed to read CPU information");
+    }
 
-  // Get the first line (total CPU information)
-  if (std::getline(stat_file, line)) {
-    result = line;
-  }
+    // Get the first line (total CPU information)
+    if (std::getline(stat_file, line)) {
+      result = line;
+    }
 
-  stat_file.close();
-  LOGI("Read CPU info: %s", result.c_str());
+    stat_file.close();
+    LOGI("Read CPU info: %s", result.c_str());
 
-  return env->NewStringUTF(result.c_str());
+    return result;
+  });
 }
 
 // Function to get memory information
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getMemInfoNative(JNIEnv* env,
                                                                              jobject /* this */) {
-  std::ifstream meminfo_file("/proc/meminfo");
-  std::string line;
-  std::stringstream result;
+  return aoscm::ReturnJson(env, [] {
+    std::ifstream meminfo_file("/proc/meminfo");
+    std::string line;
+    std::stringstream result;
 
-  if (!meminfo_file.is_open()) {
-    LOGE("Failed to open /proc/meminfo");
-    return env->NewStringUTF("Error: Failed to read memory information");
-  }
+    if (!meminfo_file.is_open()) {
+      LOGE("Failed to open /proc/meminfo");
+      return std::string("Error: Failed to read memory information");
+    }
 
-  // Get the first few lines (main memory information)
-  int lines_to_read = 5;
-  while (lines_to_read-- > 0 && std::getline(meminfo_file, line)) {
-    result << line << "\n";
-  }
+    // Get the first few lines (main memory information)
+    int lines_to_read = 5;
+    while (lines_to_read-- > 0 && std::getline(meminfo_file, line)) {
+      result << line << "\n";
+    }
 
-  meminfo_file.close();
-  LOGI("Read memory info");
+    meminfo_file.close();
+    LOGI("Read memory info");
 
-  return env->NewStringUTF(result.str().c_str());
+    return result.str();
+  });
 }
 
 // Function to get process information
@@ -65,195 +71,201 @@ extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getProcessInfoNative(JNIEnv* env,
                                                                                  jobject /* this */,
                                                                                  jint pid) {
-  std::stringstream path;
-  path << "/proc/" << pid << "/status";
+  return aoscm::ReturnJson(env, [pid] {
+    std::stringstream path;
+    path << "/proc/" << pid << "/status";
 
-  std::ifstream status_file(path.str());
-  std::string line;
-  std::stringstream result;
+    std::ifstream status_file(path.str());
+    std::string line;
+    std::stringstream result;
 
-  if (!status_file.is_open()) {
-    LOGE("Failed to open %s", path.str().c_str());
-    return env->NewStringUTF("Error: Process not found or permission denied");
-  }
+    if (!status_file.is_open()) {
+      LOGE("Failed to open %s", path.str().c_str());
+      return std::string("Error: Process not found or permission denied");
+    }
 
-  // Read contents of the status file
-  while (std::getline(status_file, line)) {
-    result << line << "\n";
-  }
+    // Read contents of the status file
+    while (std::getline(status_file, line)) {
+      result << line << "\n";
+    }
 
-  status_file.close();
-  LOGI("Read process info for PID: %d", pid);
+    status_file.close();
+    LOGI("Read process info for PID: %d", pid);
 
-  return env->NewStringUTF(result.str().c_str());
+    return result.str();
+  });
 }
 
 // Function to get network interface statistics
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getNetworkStatsNative(
     JNIEnv* env, jobject /* this */) {
-  std::ifstream net_dev_file("/proc/net/dev");
-  std::string line;
-  std::stringstream result;
-  std::string json = "{";
-  bool first_interface = true;
+  return aoscm::ReturnJson(env, [] {
+    std::ifstream net_dev_file("/proc/net/dev");
+    std::string line;
+    std::stringstream result;
+    std::string json = "{";
+    bool first_interface = true;
 
-  if (!net_dev_file.is_open()) {
-    LOGE("Failed to open /proc/net/dev");
-    return env->NewStringUTF("Error: Failed to read network statistics");
-  }
-
-  // Skip header lines (first two lines)
-  std::getline(net_dev_file, line);  // Skip header line 1
-  std::getline(net_dev_file, line);  // Skip header line 2
-
-  // Process each network interface
-  while (std::getline(net_dev_file, line)) {
-    std::stringstream line_stream(line);
-    std::string interface_name;
-
-    // Extract interface name (format: "  interface_name: stats...")
-    std::getline(line_stream, interface_name, ':');
-    interface_name = interface_name.substr(interface_name.find_first_not_of(" \t"));
-
-    // Skip loopback interface
-    if (interface_name == "lo") {
-      continue;
+    if (!net_dev_file.is_open()) {
+      LOGE("Failed to open /proc/net/dev");
+      return std::string("Error: Failed to read network statistics");
     }
 
-    // Read stats (in order):
-    // rx_bytes rx_packets rx_errs rx_drop rx_fifo rx_frame rx_compressed rx_multicast
-    // tx_bytes tx_packets tx_errs tx_drop tx_fifo tx_colls tx_carrier tx_compressed
-    unsigned long long rx_bytes, rx_packets, rx_errs, rx_drop;
-    unsigned long long tx_bytes, tx_packets, tx_errs, tx_drop;
+    // Skip header lines (first two lines)
+    std::getline(net_dev_file, line);  // Skip header line 1
+    std::getline(net_dev_file, line);  // Skip header line 2
 
-    line_stream >> rx_bytes >> rx_packets >> rx_errs >> rx_drop;
-    // Skip 4 fields
-    unsigned long long skip;
-    line_stream >> skip >> skip >> skip >> skip;
-    line_stream >> tx_bytes >> tx_packets >> tx_errs >> tx_drop;
+    // Process each network interface
+    while (std::getline(net_dev_file, line)) {
+      std::stringstream line_stream(line);
+      std::string interface_name;
 
-    // Format as JSON
-    if (!first_interface) {
-      json += ",";
+      // Extract interface name (format: "  interface_name: stats...")
+      std::getline(line_stream, interface_name, ':');
+      interface_name = interface_name.substr(interface_name.find_first_not_of(" \t"));
+
+      // Skip loopback interface
+      if (interface_name == "lo") {
+        continue;
+      }
+
+      // Read stats (in order):
+      // rx_bytes rx_packets rx_errs rx_drop rx_fifo rx_frame rx_compressed rx_multicast
+      // tx_bytes tx_packets tx_errs tx_drop tx_fifo tx_colls tx_carrier tx_compressed
+      unsigned long long rx_bytes, rx_packets, rx_errs, rx_drop;
+      unsigned long long tx_bytes, tx_packets, tx_errs, tx_drop;
+
+      line_stream >> rx_bytes >> rx_packets >> rx_errs >> rx_drop;
+      // Skip 4 fields
+      unsigned long long skip;
+      line_stream >> skip >> skip >> skip >> skip;
+      line_stream >> tx_bytes >> tx_packets >> tx_errs >> tx_drop;
+
+      // Format as JSON
+      if (!first_interface) {
+        json += ",";
+      }
+      first_interface = false;
+
+      json += "\"" + interface_name + "\":{";
+      json += "\"rx_bytes\":" + std::to_string(rx_bytes) + ",";
+      json += "\"rx_packets\":" + std::to_string(rx_packets) + ",";
+      json += "\"rx_errors\":" + std::to_string(rx_errs) + ",";
+      json += "\"rx_dropped\":" + std::to_string(rx_drop) + ",";
+      json += "\"tx_bytes\":" + std::to_string(tx_bytes) + ",";
+      json += "\"tx_packets\":" + std::to_string(tx_packets) + ",";
+      json += "\"tx_errors\":" + std::to_string(tx_errs) + ",";
+      json += "\"tx_dropped\":" + std::to_string(tx_drop);
+      json += "}";
     }
-    first_interface = false;
 
-    json += "\"" + interface_name + "\":{";
-    json += "\"rx_bytes\":" + std::to_string(rx_bytes) + ",";
-    json += "\"rx_packets\":" + std::to_string(rx_packets) + ",";
-    json += "\"rx_errors\":" + std::to_string(rx_errs) + ",";
-    json += "\"rx_dropped\":" + std::to_string(rx_drop) + ",";
-    json += "\"tx_bytes\":" + std::to_string(tx_bytes) + ",";
-    json += "\"tx_packets\":" + std::to_string(tx_packets) + ",";
-    json += "\"tx_errors\":" + std::to_string(tx_errs) + ",";
-    json += "\"tx_dropped\":" + std::to_string(tx_drop);
     json += "}";
-  }
+    net_dev_file.close();
+    LOGI("Read network interface statistics");
 
-  json += "}";
-  net_dev_file.close();
-  LOGI("Read network interface statistics");
-
-  return env->NewStringUTF(json.c_str());
+    return json;
+  });
 }
 
 // Function to retrieve TCP connection statistics
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getTcpConnectionsNative(
     JNIEnv* env, jobject /* this */) {
-  std::ifstream tcp_file("/proc/net/tcp");
-  std::string line;
-  std::string json = "{\"connections\":[";
-  bool first_connection = true;
+  return aoscm::ReturnJson(env, [] {
+    std::ifstream tcp_file("/proc/net/tcp");
+    std::string line;
+    std::string json = "{\"connections\":[";
+    bool first_connection = true;
 
-  if (!tcp_file.is_open()) {
-    LOGE("Failed to open /proc/net/tcp - Permission denied or file not available");
-    // Get detailed error information
-    char error_msg[256];
-    strerror_r(errno, error_msg, sizeof(error_msg));
-    std::string error_string = "Error: Failed to read TCP connection information. Reason: ";
-    error_string += error_msg;
-    return env->NewStringUTF(error_string.c_str());
-  }
-
-  // Skip header line
-  std::getline(tcp_file, line);
-
-  // Process each TCP connection information
-  while (std::getline(tcp_file, line)) {
-    std::stringstream line_stream(line);
-    std::string sl, local_address, remote_address, status, tx_queue, rx_queue, tr, tm_when,
-        retrnsmt, uid_str, timeout, inode, rest;
-
-    line_stream >> sl >> local_address >> remote_address >> status >> tx_queue >> rx_queue >> tr >>
-        tm_when >> retrnsmt >> uid_str >> timeout >> inode;
-
-    // Convert hexadecimal status to integer
-    int status_int = 0;
-    std::stringstream ss;
-    ss << std::hex << status;
-    ss >> status_int;
-
-    // Convert status to string
-    std::string status_str;
-    switch (status_int) {
-      case 1:
-        status_str = "ESTABLISHED";
-        break;
-      case 2:
-        status_str = "SYN_SENT";
-        break;
-      case 3:
-        status_str = "SYN_RECV";
-        break;
-      case 4:
-        status_str = "FIN_WAIT1";
-        break;
-      case 5:
-        status_str = "FIN_WAIT2";
-        break;
-      case 6:
-        status_str = "TIME_WAIT";
-        break;
-      case 7:
-        status_str = "CLOSE";
-        break;
-      case 8:
-        status_str = "CLOSE_WAIT";
-        break;
-      case 9:
-        status_str = "LAST_ACK";
-        break;
-      case 10:
-        status_str = "LISTEN";
-        break;
-      case 11:
-        status_str = "CLOSING";
-        break;
-      default:
-        status_str = "UNKNOWN";
-        break;
+    if (!tcp_file.is_open()) {
+      LOGE("Failed to open /proc/net/tcp - Permission denied or file not available");
+      // Get detailed error information
+      char error_msg[256];
+      strerror_r(errno, error_msg, sizeof(error_msg));
+      std::string error_string = "Error: Failed to read TCP connection information. Reason: ";
+      error_string += error_msg;
+      return error_string;
     }
 
-    // Add data in JSON format
-    if (!first_connection) {
-      json += ",";
+    // Skip header line
+    std::getline(tcp_file, line);
+
+    // Process each TCP connection information
+    while (std::getline(tcp_file, line)) {
+      std::stringstream line_stream(line);
+      std::string sl, local_address, remote_address, status, tx_queue, rx_queue, tr, tm_when,
+          retrnsmt, uid_str, timeout, inode, rest;
+
+      line_stream >> sl >> local_address >> remote_address >> status >> tx_queue >> rx_queue >>
+          tr >> tm_when >> retrnsmt >> uid_str >> timeout >> inode;
+
+      // Convert hexadecimal status to integer
+      int status_int = 0;
+      std::stringstream ss;
+      ss << std::hex << status;
+      ss >> status_int;
+
+      // Convert status to string
+      std::string status_str;
+      switch (status_int) {
+        case 1:
+          status_str = "ESTABLISHED";
+          break;
+        case 2:
+          status_str = "SYN_SENT";
+          break;
+        case 3:
+          status_str = "SYN_RECV";
+          break;
+        case 4:
+          status_str = "FIN_WAIT1";
+          break;
+        case 5:
+          status_str = "FIN_WAIT2";
+          break;
+        case 6:
+          status_str = "TIME_WAIT";
+          break;
+        case 7:
+          status_str = "CLOSE";
+          break;
+        case 8:
+          status_str = "CLOSE_WAIT";
+          break;
+        case 9:
+          status_str = "LAST_ACK";
+          break;
+        case 10:
+          status_str = "LISTEN";
+          break;
+        case 11:
+          status_str = "CLOSING";
+          break;
+        default:
+          status_str = "UNKNOWN";
+          break;
+      }
+
+      // Add data in JSON format
+      if (!first_connection) {
+        json += ",";
+      }
+      first_connection = false;
+
+      json += "{";
+      json += "\"local_address\":\"" + local_address + "\",";
+      json += "\"remote_address\":\"" + remote_address + "\",";
+      json += "\"status\":\"" + status_str + "\",";
+      json += "\"uid\":" + uid_str + ",";
+      json += "\"inode\":\"" + inode + "\"";
+      json += "}";
     }
-    first_connection = false;
 
-    json += "{";
-    json += "\"local_address\":\"" + local_address + "\",";
-    json += "\"remote_address\":\"" + remote_address + "\",";
-    json += "\"status\":\"" + status_str + "\",";
-    json += "\"uid\":" + uid_str + ",";
-    json += "\"inode\":\"" + inode + "\"";
-    json += "}";
-  }
+    json += "]}";
+    tcp_file.close();
+    LOGI("Read TCP connection statistics");
 
-  json += "]}";
-  tcp_file.close();
-  LOGI("Read TCP connection statistics");
-
-  return env->NewStringUTF(json.c_str());
+    return json;
+  });
 }

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/ByteFormat.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/ByteFormat.kt
@@ -1,0 +1,29 @@
+package com.aoscoremonitor.diagnostics
+
+import java.util.Locale
+
+/**
+ * Renders a byte count at a readable scale.
+ *
+ * Every screen that shows a size was about to grow its own copy of this — the network screen
+ * already had one — so it lives in one place. Gigabytes and above carry one decimal: a filesystem
+ * shown as "107 GB" whether it holds 107.0 or 107.9 hides more than the digit costs, while a
+ * decimal on kilobytes would be noise.
+ *
+ * Binary multiples throughout, matching what /proc and statvfs report.
+ */
+fun formatBytes(bytes: Long): String = when {
+    bytes < KILO -> "$bytes B"
+    bytes < MEGA -> "${bytes / KILO} KB"
+    bytes < GIGA -> "${bytes / MEGA} MB"
+    bytes < TERA -> String.format(Locale.US, "%.1f GB", bytes.toDouble() / GIGA)
+    else -> String.format(Locale.US, "%.1f TB", bytes.toDouble() / TERA)
+}
+
+/** The same, for the kilobyte counters /proc reports. */
+fun formatKilobytes(kilobytes: Long): String = formatBytes(kilobytes * KILO)
+
+private const val KILO = 1024L
+private const val MEGA = KILO * 1024
+private const val GIGA = MEGA * 1024
+private const val TERA = GIGA * 1024

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/JsonReading.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/JsonReading.kt
@@ -4,6 +4,35 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 /**
+ * Why a reading is missing, as the native side classified the errno that stopped it.
+ *
+ * The distinction is worth carrying: a path SELinux refuses is a property of the app sandbox, and
+ * one that does not exist is a property of the kernel. The screens word the two differently, and
+ * neither is the same as "the value is zero".
+ */
+enum class Unavailable {
+    /** The sandbox may not read it — EACCES or EPERM. */
+    Denied,
+
+    /** The kernel does not expose it — ENOENT and friends. */
+    Absent,
+
+    /** Read, but not usable: empty, malformed, or a failure with no better name. */
+    Error;
+
+    internal companion object {
+        fun of(token: String?): Unavailable? = when (token) {
+            "denied" -> Denied
+            "absent" -> Absent
+            "error" -> Error
+            else -> null
+        }
+    }
+}
+
+internal fun JSONObject.unavailable(key: String): Unavailable? = Unavailable.of(stringOrNull(key))
+
+/**
  * Reading helpers for the JSON the native collectors return.
  *
  * The native side leaves a key out when it could not take the reading, rather than sending a zero

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/JsonReading.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/JsonReading.kt
@@ -1,0 +1,48 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Reading helpers for the JSON the native collectors return.
+ *
+ * The native side leaves a key out when it could not take the reading, rather than sending a zero
+ * or a null — a CPU whose current frequency the sandbox may not read is not a CPU running at
+ * 0 kHz. These accessors carry that distinction across as a Kotlin null, which `JSONObject.optLong`
+ * cannot: it answers 0 for both.
+ */
+internal fun JSONObject.longOrNull(key: String): Long? = if (has(key)) optLong(key) else null
+
+internal fun JSONObject.intOrNull(key: String): Int? = if (has(key)) optInt(key) else null
+
+internal fun JSONObject.stringOrNull(key: String): String? = if (has(key)) optString(key) else null
+
+/** Iterates a JSON array of objects, skipping entries that are not objects. */
+internal inline fun <T> JSONArray.mapObjects(transform: (JSONObject) -> T): List<T> =
+    (0 until length()).mapNotNull { index -> optJSONObject(index)?.let(transform) }
+
+/**
+ * Reads the named object's members into a map.
+ *
+ * Iteration order is not part of the contract — Android's `JSONObject` happens to preserve
+ * insertion order and the JVM implementation the unit tests run against does not — so screens
+ * name the keys they show in the order they want them rather than iterating the map.
+ */
+internal fun JSONObject.longMap(key: String): Map<String, Long> {
+    val nested = optJSONObject(key) ?: return emptyMap()
+    val values = LinkedHashMap<String, Long>()
+    for (name in nested.keys()) {
+        values[name] = nested.optLong(name)
+    }
+    return values
+}
+
+/** The same, for members that are strings. */
+internal fun JSONObject.stringMap(key: String): Map<String, String> {
+    val nested = optJSONObject(key) ?: return emptyMap()
+    val values = LinkedHashMap<String, String>()
+    for (name in nested.keys()) {
+        values[name] = nested.optString(name)
+    }
+    return values
+}

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeCpuInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeCpuInspector.kt
@@ -19,6 +19,7 @@ data class CpuCore(
     val minKhz: Long? = null,
     val maxKhz: Long? = null,
     val curKhz: Long? = null,
+    val frequencyUnavailable: Unavailable? = null,
     val online: Boolean = true,
     val governor: String? = null
 ) {
@@ -57,7 +58,12 @@ data class CpuSnapshot(
         return copy(
             cores = cores.map { core ->
                 val reading = byId[core.id] ?: return@map core
-                core.copy(curKhz = reading.curKhz, online = reading.online, governor = reading.governor)
+                core.copy(
+                    curKhz = reading.curKhz,
+                    frequencyUnavailable = reading.frequencyUnavailable,
+                    online = reading.online,
+                    governor = reading.governor
+                )
             }
         )
     }
@@ -133,6 +139,7 @@ internal fun parseCpuFrequencies(json: String): List<CpuCore> = JSONObject(json)
     CpuCore(
         id = core.optInt("id"),
         curKhz = core.longOrNull("cur_khz"),
+        frequencyUnavailable = core.unavailable("cur_khz_unavailable"),
         online = core.optBoolean("online", true),
         governor = core.stringOrNull("governor")
     )

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeCpuInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeCpuInspector.kt
@@ -1,0 +1,139 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/**
+ * One CPU core.
+ *
+ * Everything except [id] is nullable because sysfs exposes a different subset on every device:
+ * `scaling_cur_freq` is denied to apps on some, `topology/` is absent on others. A null means the
+ * reading could not be taken, which the screen states rather than papering over with a zero.
+ */
+data class CpuCore(
+    val id: Int,
+    val coreId: Int? = null,
+    val packageId: Int? = null,
+    val minKhz: Long? = null,
+    val maxKhz: Long? = null,
+    val curKhz: Long? = null,
+    val online: Boolean = true,
+    val governor: String? = null
+) {
+    /** Where the current frequency sits between the core's limits, for a progress indicator. */
+    val frequencyFraction: Float?
+        get() {
+            val current = curKhz ?: return null
+            val low = minKhz ?: return null
+            val high = maxKhz ?: return null
+            if (high <= low) return null
+            return ((current - low).toFloat() / (high - low).toFloat()).coerceIn(0f, 1f)
+        }
+}
+
+/** The CPU as a whole, plus the per-core readings. */
+data class CpuSnapshot(
+    val configuredCores: Int = 0,
+    val onlineCores: Int = 0,
+    val pageSize: Long = 0,
+    val clockTicks: Long = 0,
+    val machine: String? = null,
+    val kernelRelease: String? = null,
+    val cores: List<CpuCore> = emptyList(),
+    val features: List<String> = emptyList()
+) {
+    /**
+     * Folds a fresh frequency reading into the topology read once at startup.
+     *
+     * The two are collected separately because they change at different rates — core layout and
+     * instruction set are fixed for the life of the process, while the frequency moves every few
+     * milliseconds — and re-reading the fixed part every second would be work for no new data.
+     */
+    fun withFrequencies(readings: List<CpuCore>): CpuSnapshot {
+        if (readings.isEmpty()) return this
+        val byId = readings.associateBy { it.id }
+        return copy(
+            cores = cores.map { core ->
+                val reading = byId[core.id] ?: return@map core
+                core.copy(curKhz = reading.curKhz, online = reading.online, governor = reading.governor)
+            }
+        )
+    }
+}
+
+/**
+ * Reads the CPU's shape and speed through JNI.
+ *
+ * The topology comes from sysfs and the instruction set from the ELF auxiliary vector, which is
+ * why this is native code: `getauxval(AT_HWCAP)` has no Java equivalent, and the alternative —
+ * parsing /proc/cpuinfo — returns nothing useful on most arm64 kernels.
+ */
+class NativeCpuInspector {
+
+    external fun getCpuStaticNative(): String
+    external fun getCpuFrequenciesNative(): String
+
+    suspend fun readStatic(): CpuSnapshot? = withContext(Dispatchers.IO) {
+        if (!NativeLibrary.isAvailable) return@withContext null
+        try {
+            parseCpuStatic(getCpuStaticNative())
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing CPU topology", e)
+            null
+        }
+    }
+
+    suspend fun readFrequencies(): List<CpuCore> = withContext(Dispatchers.IO) {
+        if (!NativeLibrary.isAvailable) return@withContext emptyList()
+        try {
+            parseCpuFrequencies(getCpuFrequenciesNative())
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing CPU frequencies", e)
+            emptyList()
+        }
+    }
+
+    private companion object {
+        const val TAG = "NativeCpuInspector"
+    }
+}
+
+/** Kept apart from the JNI call so it can be exercised without a device. */
+internal fun parseCpuStatic(json: String): CpuSnapshot {
+    val root = JSONObject(json)
+    val cores = root.optJSONArray("cores")?.mapObjects { core ->
+        CpuCore(
+            id = core.optInt("id"),
+            coreId = core.intOrNull("core_id"),
+            packageId = core.intOrNull("package_id"),
+            minKhz = core.longOrNull("min_khz"),
+            maxKhz = core.longOrNull("max_khz")
+        )
+    }.orEmpty()
+
+    val features = root.optJSONArray("features")?.let { array ->
+        (0 until array.length()).map { array.optString(it) }.filter { it.isNotEmpty() }
+    }.orEmpty()
+
+    return CpuSnapshot(
+        configuredCores = root.optInt("configured"),
+        onlineCores = root.optInt("online"),
+        pageSize = root.optLong("page_size"),
+        clockTicks = root.optLong("clock_ticks"),
+        machine = root.stringOrNull("machine"),
+        kernelRelease = root.stringOrNull("kernel_release"),
+        cores = cores,
+        features = features
+    )
+}
+
+internal fun parseCpuFrequencies(json: String): List<CpuCore> = JSONObject(json).optJSONArray("cores")?.mapObjects { core ->
+    CpuCore(
+        id = core.optInt("id"),
+        curKhz = core.longOrNull("cur_khz"),
+        online = core.optBoolean("online", true),
+        governor = core.stringOrNull("governor")
+    )
+}.orEmpty()

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeLibrary.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeLibrary.kt
@@ -1,0 +1,29 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import android.util.Log
+
+/**
+ * Whether libsystem_monitor loaded. Every `external fun` in this package throws without it.
+ *
+ * The load failure was already being caught and logged, but nothing recorded the result, so the
+ * `external fun` calls went ahead anyway and threw [UnsatisfiedLinkError]. That is an [Error], not
+ * an [Exception], so the `catch (e: Exception)` around each call did not stop it and the app
+ * crashed — on a device where the library will not load, the native screens were unreachable. The
+ * fallbacks those catch blocks guard were written for exactly this case; they just never ran.
+ *
+ * It lives here rather than on one collector because five of them now share the library: a
+ * `loadLibrary` call per collector would ask the runtime to load the same object five times and
+ * would report the failure five times over.
+ */
+internal object NativeLibrary {
+    private const val TAG = "NativeLibrary"
+
+    val isAvailable: Boolean = try {
+        System.loadLibrary("system_monitor")
+        Log.i(TAG, "Native library loaded successfully")
+        true
+    } catch (e: UnsatisfiedLinkError) {
+        Log.e(TAG, "Failed to load native library; native readings are unavailable", e)
+        false
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeMemoryInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeMemoryInspector.kt
@@ -1,0 +1,114 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/**
+ * The process's resident footprint, summed over every mapping it owns.
+ *
+ * [fromRollupFile] records which file the numbers came from: the kernel's own `smaps_rollup`
+ * summary, or the per-mapping `smaps` walked and totalled by hand where that file is missing. The
+ * values mean the same thing either way, but the second is a much longer read and worth naming.
+ */
+data class MemoryRollup(
+    val rssKb: Long,
+    val pssKb: Long,
+    val privateCleanKb: Long,
+    val privateDirtyKb: Long,
+    val sharedCleanKb: Long,
+    val sharedDirtyKb: Long,
+    val swapKb: Long,
+    val swapPssKb: Long,
+    val fromRollupFile: Boolean
+)
+
+/** How much of the address space is given over to one kind of mapping. */
+data class RegionCategory(val key: String, val count: Int, val sizeKb: Long)
+
+/**
+ * Everything the memory screen shows, from one pass over /proc/self.
+ *
+ * [reservedKb] is address space mapped with no access at all — the CFI shadow, WebView's
+ * reservation, the allocator's reserve — which is most of a 64-bit process's address space and
+ * holds nothing. It is reported on its own rather than mixed into [categories], where it would
+ * dwarf every category that describes actual memory.
+ */
+data class MemorySnapshot(
+    val rollup: MemoryRollup? = null,
+    val status: Map<String, String> = emptyMap(),
+    val totalRegions: Int = 0,
+    val reservedRegions: Int = 0,
+    val reservedKb: Long = 0,
+    val categories: List<RegionCategory> = emptyList(),
+    val malloc: Map<String, Long> = emptyMap(),
+    val limits: Map<String, Long> = emptyMap()
+) {
+    /** The accessible total the category sizes are shares of. */
+    val mappedKb: Long get() = categories.sumOf { it.sizeKb }
+}
+
+/**
+ * Reads this process's own address space.
+ *
+ * Unlike the system-wide counters the older native screen reads, none of this can be denied: a
+ * process may always read its own /proc entries. The native heap figures come from `mallinfo2`,
+ * which is inside libc and has no Java equivalent at all.
+ */
+class NativeMemoryInspector {
+
+    external fun getMemoryMapNative(): String
+
+    suspend fun read(): MemorySnapshot? = withContext(Dispatchers.IO) {
+        if (!NativeLibrary.isAvailable) return@withContext null
+        try {
+            parseMemoryMap(getMemoryMapNative())
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing memory map", e)
+            null
+        }
+    }
+
+    private companion object {
+        const val TAG = "NativeMemoryInspector"
+    }
+}
+
+internal fun parseMemoryMap(json: String): MemorySnapshot {
+    val root = JSONObject(json)
+
+    val rollup = root.optJSONObject("rollup")?.let { values ->
+        MemoryRollup(
+            rssKb = values.optLong("rss_kb"),
+            pssKb = values.optLong("pss_kb"),
+            privateCleanKb = values.optLong("private_clean_kb"),
+            privateDirtyKb = values.optLong("private_dirty_kb"),
+            sharedCleanKb = values.optLong("shared_clean_kb"),
+            sharedDirtyKb = values.optLong("shared_dirty_kb"),
+            swapKb = values.optLong("swap_kb"),
+            swapPssKb = values.optLong("swap_pss_kb"),
+            fromRollupFile = values.optBoolean("from_rollup_file")
+        )
+    }
+
+    val regions = root.optJSONObject("regions")
+    val categories = regions?.optJSONArray("categories")?.mapObjects { category ->
+        RegionCategory(
+            key = category.optString("key"),
+            count = category.optInt("count"),
+            sizeKb = category.optLong("size_kb")
+        )
+    }.orEmpty()
+
+    return MemorySnapshot(
+        rollup = rollup,
+        status = root.stringMap("status"),
+        totalRegions = regions?.optInt("total") ?: 0,
+        reservedRegions = regions?.optInt("reserved_count") ?: 0,
+        reservedKb = regions?.optLong("reserved_kb") ?: 0,
+        categories = categories.sortedByDescending { it.sizeKb },
+        malloc = root.longMap("malloc"),
+        limits = root.longMap("limits")
+    )
+}

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeModuleInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeModuleInspector.kt
@@ -5,9 +5,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 
-/** One loadable segment of an ELF object, and how much address space it takes. */
-data class ModuleSegment(val flags: String, val memSize: Long)
-
 /**
  * A shared object the dynamic linker has mapped into this process.
  *
@@ -23,8 +20,7 @@ data class LoadedModule(
     val buildId: String? = null,
     val hasRelro: Boolean = false,
     val hasTls: Boolean = false,
-    val headerCount: Int = 0,
-    val segments: List<ModuleSegment> = emptyList()
+    val segmentCount: Int = 0
 ) {
     /** The file name on its own, which is what identifies a library at a glance. */
     val fileName: String get() = path.substringAfterLast('/')
@@ -77,10 +73,7 @@ internal fun parseLoadedModules(json: String): ModuleSnapshot {
             buildId = module.stringOrNull("build_id"),
             hasRelro = module.optBoolean("relro"),
             hasTls = module.optBoolean("tls"),
-            headerCount = module.optInt("phnum"),
-            segments = module.optJSONArray("segments")?.mapObjects { segment ->
-                ModuleSegment(flags = segment.optString("flags"), memSize = segment.optLong("memsz"))
-            }.orEmpty()
+            segmentCount = module.optInt("segment_count")
         )
     }.orEmpty()
 

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeModuleInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeModuleInspector.kt
@@ -1,0 +1,94 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/** One loadable segment of an ELF object, and how much address space it takes. */
+data class ModuleSegment(val flags: String, val memSize: Long)
+
+/**
+ * A shared object the dynamic linker has mapped into this process.
+ *
+ * @param path as the linker reports it. Empty for the main executable, which the linker names
+ *   with an empty string rather than a path.
+ * @param buildId the GNU build id, which ties the mapped library back to the symbols the platform
+ *   build produced. Null when the object was linked without one.
+ */
+data class LoadedModule(
+    val path: String,
+    val baseAddress: String,
+    val mappedSize: Long,
+    val buildId: String? = null,
+    val hasRelro: Boolean = false,
+    val hasTls: Boolean = false,
+    val headerCount: Int = 0,
+    val segments: List<ModuleSegment> = emptyList()
+) {
+    /** The file name on its own, which is what identifies a library at a glance. */
+    val fileName: String get() = path.substringAfterLast('/')
+
+    /** The directory it was loaded from — /apex, /system, /vendor or the app's own lib dir. */
+    val directory: String get() = path.substringBeforeLast('/', missingDelimiterValue = "")
+
+    /** The linker reports the main executable with an empty name. */
+    val isMainExecutable: Boolean get() = path.isEmpty()
+}
+
+/** The loaded set, and how much churn the linker has seen. */
+data class ModuleSnapshot(val modules: List<LoadedModule> = emptyList(), val loadEvents: Int? = null, val unloadEvents: Int? = null) {
+    val totalMappedSize: Long get() = modules.sumOf { it.mappedSize }
+}
+
+/**
+ * Lists what the dynamic linker has loaded.
+ *
+ * This is the reading that most needs native code: the linker publishes its list through
+ * `dl_iterate_phdr` and nowhere else. Nothing in the Java API can name the mapped libraries, let
+ * alone their load addresses or build ids.
+ */
+class NativeModuleInspector {
+
+    external fun getLoadedModulesNative(): String
+
+    suspend fun read(): ModuleSnapshot? = withContext(Dispatchers.IO) {
+        if (!NativeLibrary.isAvailable) return@withContext null
+        try {
+            parseLoadedModules(getLoadedModulesNative())
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing loaded modules", e)
+            null
+        }
+    }
+
+    private companion object {
+        const val TAG = "NativeModuleInspector"
+    }
+}
+
+internal fun parseLoadedModules(json: String): ModuleSnapshot {
+    val root = JSONObject(json)
+    val modules = root.optJSONArray("modules")?.mapObjects { module ->
+        LoadedModule(
+            path = module.optString("path"),
+            baseAddress = module.optString("base"),
+            mappedSize = module.optLong("mapped_size"),
+            buildId = module.stringOrNull("build_id"),
+            hasRelro = module.optBoolean("relro"),
+            hasTls = module.optBoolean("tls"),
+            headerCount = module.optInt("phnum"),
+            segments = module.optJSONArray("segments")?.mapObjects { segment ->
+                ModuleSegment(flags = segment.optString("flags"), memSize = segment.optLong("memsz"))
+            }.orEmpty()
+        )
+    }.orEmpty()
+
+    return ModuleSnapshot(
+        // Largest first: the libraries worth noticing are the ones holding the most address space,
+        // and the linker's own order is load order, which says nothing the screen can use.
+        modules = modules.sortedByDescending { it.mappedSize },
+        loadEvents = root.intOrNull("adds"),
+        unloadEvents = root.intOrNull("subs")
+    )
+}

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeStorageInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeStorageInspector.kt
@@ -1,0 +1,109 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/**
+ * One entry from the process's mount table.
+ *
+ * The capacity fields are null when `statvfs` was refused, which happens for /proc, /sys and most
+ * of /mnt from inside the app sandbox. The mount is still worth listing — that it exists is part
+ * of the picture — so it is kept with its capacity left unknown rather than dropped.
+ */
+data class MountPoint(
+    val source: String,
+    val target: String,
+    val fsType: String,
+    val options: String,
+    val readOnly: Boolean,
+    val totalBytes: Long? = null,
+    val freeBytes: Long? = null,
+    val availableBytes: Long? = null,
+    val blockSize: Long? = null,
+    val inodesTotal: Long? = null,
+    val inodesFree: Long? = null
+) {
+    /**
+     * Space in use.
+     *
+     * Measured against the free total rather than the available one: the difference is the reserve
+     * the filesystem keeps for root, which is in use by nobody and should not be counted as used.
+     */
+    val usedBytes: Long?
+        get() {
+            val total = totalBytes ?: return null
+            val free = freeBytes ?: return null
+            return (total - free).coerceAtLeast(0)
+        }
+
+    val usedFraction: Float?
+        get() {
+            val total = totalBytes ?: return null
+            val used = usedBytes ?: return null
+            if (total <= 0) return null
+            return (used.toFloat() / total.toFloat()).coerceIn(0f, 1f)
+        }
+
+    /**
+     * Whether this holds files, as opposed to being a kernel interface mounted like a filesystem.
+     *
+     * The split is made here rather than in the native collector so that changing what counts as
+     * interesting does not mean rebuilding the library. An Android mount table has upwards of a
+     * hundred entries and all but a handful are pseudo filesystems, so the screen would otherwise
+     * bury /data under cgroup mounts.
+     */
+    val isRealFilesystem: Boolean get() = fsType in REAL_FILESYSTEMS
+
+    private companion object {
+        val REAL_FILESYSTEMS = setOf(
+            "f2fs", "ext2", "ext3", "ext4", "erofs", "squashfs", "vfat", "exfat", "ntfs", "ntfs3",
+            "fuse", "fuseblk", "sdcardfs", "overlay", "incremental-fs"
+        )
+    }
+}
+
+/**
+ * Reads the mount table and the space left on each filesystem.
+ *
+ * `/proc/self/mounts` describes the caller's own mount namespace, which keeps it readable where
+ * the system-wide /proc files this app also reads are denied. `statvfs` is a syscall with no
+ * Java counterpart that reports free space for an arbitrary path — `File.getFreeSpace` covers only
+ * paths the app can already see, and says nothing about filesystem type, options or inodes.
+ */
+class NativeStorageInspector {
+
+    external fun getMountsNative(): String
+
+    suspend fun read(): List<MountPoint>? = withContext(Dispatchers.IO) {
+        if (!NativeLibrary.isAvailable) return@withContext null
+        try {
+            parseMounts(getMountsNative())
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing mount table", e)
+            null
+        }
+    }
+
+    private companion object {
+        const val TAG = "NativeStorageInspector"
+    }
+}
+
+internal fun parseMounts(json: String): List<MountPoint> = JSONObject(json).optJSONArray("mounts")?.mapObjects { mount ->
+    val measured = mount.optBoolean("statvfs_ok")
+    MountPoint(
+        source = mount.optString("source"),
+        target = mount.optString("target"),
+        fsType = mount.optString("fs_type"),
+        options = mount.optString("options"),
+        readOnly = mount.optBoolean("readonly"),
+        totalBytes = if (measured) mount.longOrNull("total_bytes") else null,
+        freeBytes = if (measured) mount.longOrNull("free_bytes") else null,
+        availableBytes = if (measured) mount.longOrNull("available_bytes") else null,
+        blockSize = if (measured) mount.longOrNull("block_size") else null,
+        inodesTotal = if (measured) mount.longOrNull("inodes_total") else null,
+        inodesFree = if (measured) mount.longOrNull("inodes_free") else null
+    )
+}.orEmpty()

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeStorageInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeStorageInspector.kt
@@ -22,7 +22,8 @@ data class MountPoint(
     val freeBytes: Long? = null,
     val availableBytes: Long? = null,
     val inodesTotal: Long? = null,
-    val inodesFree: Long? = null
+    val inodesFree: Long? = null,
+    val capacityUnavailable: Unavailable? = null
 ) {
     /**
      * Space in use.
@@ -102,6 +103,7 @@ internal fun parseMounts(json: String): List<MountPoint> = JSONObject(json).optJ
         freeBytes = if (measured) mount.longOrNull("free_bytes") else null,
         availableBytes = if (measured) mount.longOrNull("available_bytes") else null,
         inodesTotal = if (measured) mount.longOrNull("inodes_total") else null,
-        inodesFree = if (measured) mount.longOrNull("inodes_free") else null
+        inodesFree = if (measured) mount.longOrNull("inodes_free") else null,
+        capacityUnavailable = if (measured) null else mount.unavailable("statvfs_unavailable")
     )
 }.orEmpty()

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeStorageInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeStorageInspector.kt
@@ -21,7 +21,6 @@ data class MountPoint(
     val totalBytes: Long? = null,
     val freeBytes: Long? = null,
     val availableBytes: Long? = null,
-    val blockSize: Long? = null,
     val inodesTotal: Long? = null,
     val inodesFree: Long? = null
 ) {
@@ -102,7 +101,6 @@ internal fun parseMounts(json: String): List<MountPoint> = JSONObject(json).optJ
         totalBytes = if (measured) mount.longOrNull("total_bytes") else null,
         freeBytes = if (measured) mount.longOrNull("free_bytes") else null,
         availableBytes = if (measured) mount.longOrNull("available_bytes") else null,
-        blockSize = if (measured) mount.longOrNull("block_size") else null,
         inodesTotal = if (measured) mount.longOrNull("inodes_total") else null,
         inodesFree = if (measured) mount.longOrNull("inodes_free") else null
     )

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeSystemMonitor.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeSystemMonitor.kt
@@ -2,6 +2,7 @@ package com.aoscoremonitor.diagnostics.jni
 
 import android.util.Log
 import com.aoscoremonitor.diagnostics.Collected
+import com.aoscoremonitor.diagnostics.formatBytes
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -13,21 +14,10 @@ class NativeSystemMonitor {
         /**
          * Whether libsystem_monitor loaded. Every `external fun` below throws without it.
          *
-         * The load failure was already being caught and logged, but nothing recorded the result,
-         * so the `external fun` calls went ahead anyway and threw [UnsatisfiedLinkError]. That is
-         * an [Error], not an [Exception], so the `catch (e: Exception)` around each call did not
-         * stop it and the app crashed — on a device where the library will not load, three of the
-         * nine screens were unreachable. The fallbacks those catch blocks guard were written for
-         * exactly this case; they just never ran.
+         * The check itself moved to [NativeLibrary] once the newer collectors started sharing the
+         * same library; the guard it provides is unchanged.
          */
-        private val isLibraryAvailable: Boolean = try {
-            System.loadLibrary("system_monitor")
-            Log.i(TAG, "Native library loaded successfully")
-            true
-        } catch (e: UnsatisfiedLinkError) {
-            Log.e(TAG, "Failed to load native library; native readings are unavailable", e)
-            false
-        }
+        private val isLibraryAvailable: Boolean get() = NativeLibrary.isAvailable
     }
 
     // Native methods
@@ -111,15 +101,10 @@ class NativeSystemMonitor {
         val txErrors: Long,
         val txDropped: Long
     ) {
+        // The formatter this class used to carry now lives in ByteFormat, shared with the screens
+        // that report memory and filesystem sizes.
         fun getFormattedRxBytes(): String = formatBytes(rxBytes)
         fun getFormattedTxBytes(): String = formatBytes(txBytes)
-
-        private fun formatBytes(bytes: Long): String = when {
-            bytes < 1024 -> "$bytes B"
-            bytes < 1024 * 1024 -> "${bytes / 1024} KB"
-            bytes < 1024 * 1024 * 1024 -> "${bytes / (1024 * 1024)} MB"
-            else -> "${bytes / (1024 * 1024 * 1024)} GB"
-        }
     }
 
     suspend fun getNetworkStats(): Collected<Map<String, InterfaceStats>> = withContext(Dispatchers.IO) {

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
@@ -7,10 +7,14 @@ import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Computer
+import androidx.compose.material.icons.filled.DataUsage
+import androidx.compose.material.icons.filled.DeveloperBoard
+import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.NetworkCell
 import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Storage
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation3.runtime.NavKey
 import com.aoscoremonitor.R
@@ -119,13 +123,47 @@ sealed interface Destination : NavKey {
         @Transient
         override val icon: ImageVector = Icons.Default.Cloud
     }
+
+    @Serializable
+    data object CpuCores : Destination {
+        override val titleRes get() = R.string.cpu_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.DeveloperBoard
+    }
+
+    @Serializable
+    data object MemoryMap : Destination {
+        override val titleRes get() = R.string.memory_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.DataUsage
+    }
+
+    @Serializable
+    data object LoadedLibraries : Destination {
+        override val titleRes get() = R.string.libraries_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.Layers
+    }
+
+    @Serializable
+    data object StorageMounts : Destination {
+        override val titleRes get() = R.string.storage_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.Storage
+    }
 }
 
 /**
  * What the home screen offers, in the order it offers it.
  *
  * Grouped by layer — the Android framework first, then the native and network views underneath —
- * rather than the arbitrary order the grid grew in.
+ * rather than the arbitrary order the grid grew in. The four screens added last read the CPU,
+ * the process's own address space, the linker and the mount table, so they continue the native
+ * run rather than starting a group of their own.
  */
 val HomeDestinations: List<Destination> = listOf(
     Destination.SystemInfo,
@@ -135,6 +173,10 @@ val HomeDestinations: List<Destination> = listOf(
     Destination.FrameworkAnalysis,
     Destination.HalInfo,
     Destination.NativeSystemMonitor,
+    Destination.CpuCores,
+    Destination.MemoryMap,
+    Destination.LoadedLibraries,
+    Destination.StorageMounts,
     Destination.NetworkStats,
     Destination.TcpConnections
 )
@@ -153,4 +195,8 @@ val Destination.shortTitleRes: Int
         Destination.NativeSystemMonitor -> R.string.destination_native_monitor
         Destination.NetworkStats -> R.string.destination_network_stats
         Destination.TcpConnections -> R.string.destination_tcp_connections
+        Destination.CpuCores -> R.string.destination_cpu_cores
+        Destination.MemoryMap -> R.string.destination_memory_map
+        Destination.LoadedLibraries -> R.string.destination_loaded_libraries
+        Destination.StorageMounts -> R.string.destination_storage
     }

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
@@ -43,7 +43,19 @@ import com.aoscoremonitor.ui.screens.jni.TcpConnectionsScreen
 @Composable
 fun MonitorNavHost(modifier: Modifier = Modifier) {
     val backStack = rememberNavBackStack(Destination.Home)
-    val goBack: () -> Unit = { backStack.removeLastOrNull() }
+
+    // Guarded because [NavDisplay] throws IllegalArgumentException — "backstack cannot be empty" —
+    // the moment the last entry goes, and this app was seen to crash with exactly that message.
+    //
+    // The trigger was not reproduced: system back, a double back, the edge-swipe gesture, rotation
+    // and process death were all tried against the unguarded version without emptying the stack,
+    // because NavDisplay does not route back here once Home is the only entry. So this does not
+    // fix a known path; it makes the state the crash reported unreachable from this callback,
+    // which is one comparison.
+    //
+    // What it must not do is turn back at the root into a no-op, leaving the user unable to leave
+    // the app. MonitorNavigationTest.backingOutPastHomeLeavesTheApp pins that.
+    val goBack: () -> Unit = { if (backStack.size > 1) backStack.removeLastOrNull() }
 
     NavDisplay(
         backStack = backStack,

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
@@ -15,8 +15,12 @@ import com.aoscoremonitor.ui.screens.LogScreen
 import com.aoscoremonitor.ui.screens.SecurityInfoScreen
 import com.aoscoremonitor.ui.screens.SystemDiagnosticsScreen
 import com.aoscoremonitor.ui.screens.SystemInfoScreen
+import com.aoscoremonitor.ui.screens.jni.CpuCoresScreen
+import com.aoscoremonitor.ui.screens.jni.LoadedLibrariesScreen
+import com.aoscoremonitor.ui.screens.jni.MemoryMapScreen
 import com.aoscoremonitor.ui.screens.jni.NativeSystemMonitorScreen
 import com.aoscoremonitor.ui.screens.jni.NetworkStatsScreen
+import com.aoscoremonitor.ui.screens.jni.StorageMountsScreen
 import com.aoscoremonitor.ui.screens.jni.TcpConnectionsScreen
 
 /**
@@ -61,6 +65,10 @@ fun MonitorNavHost(modifier: Modifier = Modifier) {
                 entry<Destination.NativeSystemMonitor> { NativeSystemMonitorScreen(onNavigateBack = goBack) }
                 entry<Destination.NetworkStats> { NetworkStatsScreen(onNavigateBack = goBack) }
                 entry<Destination.TcpConnections> { TcpConnectionsScreen(onNavigateBack = goBack) }
+                entry<Destination.CpuCores> { CpuCoresScreen(onNavigateBack = goBack) }
+                entry<Destination.MemoryMap> { MemoryMapScreen(onNavigateBack = goBack) }
+                entry<Destination.LoadedLibraries> { LoadedLibrariesScreen(onNavigateBack = goBack) }
+                entry<Destination.StorageMounts> { StorageMountsScreen(onNavigateBack = goBack) }
             }
         }
     )

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/HomeScreen.kt
@@ -182,7 +182,9 @@ private val TileMinSize = 108.dp
 private val IconWellSize = 48.dp
 private val IconSize = 24.dp
 private const val STAGGER_STEP_MS = 35L
-private const val MAX_STAGGER_STEPS = 8
+
+/** One less than the number of tiles, so the last one still arrives after the one before it. */
+private const val MAX_STAGGER_STEPS = 12
 
 @Preview(name = "Home", showBackground = true)
 @Preview(name = "Home (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/CpuCoresScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/CpuCoresScreen.kt
@@ -1,0 +1,276 @@
+package com.aoscoremonitor.ui.screens.jni
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeveloperBoard
+import androidx.compose.material.icons.filled.Extension
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.jni.CpuCore
+import com.aoscoremonitor.diagnostics.jni.CpuSnapshot
+import com.aoscoremonitor.ui.components.EmptyState
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.LabeledValue
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.CpuCoresUiState
+import com.aoscoremonitor.ui.viewmodel.CpuCoresViewModel
+
+@Composable
+fun CpuCoresScreen(onNavigateBack: () -> Unit, modifier: Modifier = Modifier, viewModel: CpuCoresViewModel = viewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    CpuCoresContent(uiState = uiState, onNavigateBack = onNavigateBack, modifier = modifier)
+}
+
+@Composable
+private fun CpuCoresContent(uiState: CpuCoresUiState, onNavigateBack: () -> Unit, modifier: Modifier = Modifier) {
+    MonitorScaffold(
+        title = stringResource(R.string.cpu_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier
+    ) { innerPadding ->
+        val cpu = uiState.cpu
+        if (cpu == null) {
+            FullScreenMessage(
+                message = stringResource(if (uiState.hasLoaded) R.string.cpu_unavailable else R.string.cpu_loading),
+                icon = Icons.Default.DeveloperBoard,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            item(key = "overview-header") {
+                SectionHeader(
+                    title = stringResource(R.string.cpu_overview_section),
+                    subtitle = stringResource(R.string.cpu_overview_subtitle),
+                    icon = Icons.Default.DeveloperBoard
+                )
+            }
+            item(key = "overview") { CpuOverviewCard(cpu) }
+
+            item(key = "cores-header") {
+                SectionHeader(
+                    title = stringResource(R.string.cpu_cores_section),
+                    subtitle = stringResource(R.string.cpu_cores_subtitle),
+                    icon = Icons.Default.Speed
+                )
+            }
+            items(cpu.cores, key = { core -> core.id }) { core -> CoreCard(core) }
+
+            item(key = "features-header") {
+                SectionHeader(
+                    title = stringResource(R.string.cpu_features_section),
+                    subtitle = stringResource(R.string.cpu_features_subtitle),
+                    icon = Icons.Default.Extension
+                )
+            }
+            item(key = "features") {
+                if (cpu.features.isEmpty()) {
+                    EmptyState(stringResource(R.string.cpu_features_empty))
+                } else {
+                    FeatureChips(cpu.features)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun CpuOverviewCard(cpu: CpuSnapshot, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.cpu_core_count, cpu.configuredCores, cpu.onlineCores),
+            style = MaterialTheme.typography.titleMedium
+        )
+        cpu.machine?.let { LabeledValue(label = stringResource(R.string.cpu_machine), value = it) }
+        cpu.kernelRelease?.let { LabeledValue(label = stringResource(R.string.cpu_kernel), value = it) }
+        LabeledValue(
+            label = stringResource(R.string.cpu_page_size),
+            value = stringResource(R.string.cpu_bytes, cpu.pageSize)
+        )
+        LabeledValue(
+            label = stringResource(R.string.cpu_clock_ticks),
+            value = cpu.clockTicks.toString()
+        )
+    }
+}
+
+/**
+ * One core.
+ *
+ * The frequency is stated on its own line at title weight because it is the number that moves —
+ * everything else on the card is there to give it a scale to be read against.
+ */
+@Composable
+private fun CoreCard(core: CpuCore, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.cpu_core_label, core.id),
+                style = MaterialTheme.typography.titleMedium
+            )
+            val badge = when {
+                !core.online -> stringResource(R.string.cpu_core_offline)
+                core.packageId != null -> stringResource(R.string.cpu_core_cluster, core.packageId)
+                else -> null
+            }
+            badge?.let { Chip(text = it) }
+        }
+
+        Text(
+            text = core.curKhz?.let { frequency(it) }
+                ?: stringResource(R.string.cpu_frequency_unavailable),
+            style = MaterialTheme.typography.titleLarge,
+            color = if (core.curKhz != null) {
+                MaterialTheme.colorScheme.onSurface
+            } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+            }
+        )
+
+        core.frequencyFraction?.let { fraction ->
+            LinearProgressIndicator(
+                progress = { fraction },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = Spacing.ExtraSmall)
+            )
+        }
+
+        if (core.minKhz != null && core.maxKhz != null) {
+            Text(
+                text = if (core.maxKhz >= KHZ_PER_MHZ) {
+                    stringResource(R.string.cpu_frequency_range, core.minKhz / KHZ_PER_MHZ, core.maxKhz / KHZ_PER_MHZ)
+                } else {
+                    stringResource(R.string.cpu_frequency_range_khz, core.minKhz, core.maxKhz)
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        core.governor?.let {
+            Text(
+                text = stringResource(R.string.cpu_governor, it),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+/**
+ * A frequency at whichever scale states it without rounding it away.
+ *
+ * Megahertz for anything a real core runs at, kilohertz below that. The emulator's cpufreq nodes
+ * answer with single-digit kilohertz, which in megahertz is "0 MHz" on every core — a reading that
+ * looks like a failure rather than like the stub value it is.
+ */
+@Composable
+private fun frequency(khz: Long): String = if (khz >= KHZ_PER_MHZ) {
+    stringResource(R.string.cpu_megahertz, khz / KHZ_PER_MHZ)
+} else {
+    stringResource(R.string.cpu_kilohertz, khz)
+}
+
+private const val KHZ_PER_MHZ = 1000L
+
+/**
+ * The instruction set extensions, as a wrapping run of chips.
+ *
+ * Plain surfaces rather than Material's `AssistChip`: a chip is a control and takes an `onClick`,
+ * and putting forty tappable things on screen that do nothing when tapped is worse for a screen
+ * reader than the flat text this actually is.
+ */
+@Composable
+private fun FeatureChips(features: List<String>, modifier: Modifier = Modifier) {
+    FlowRow(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.Small),
+        verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+    ) {
+        features.forEach { feature -> Chip(text = feature) }
+    }
+}
+
+@Composable
+private fun Chip(text: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(percent = 50),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(horizontal = Spacing.Medium, vertical = Spacing.ExtraSmall)
+        )
+    }
+}
+
+@Preview(name = "CPU cores", showBackground = true)
+@Preview(name = "CPU cores (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun CpuCoresPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        CpuCoresContent(
+            uiState = CpuCoresUiState(
+                cpu = CpuSnapshot(
+                    configuredCores = 8,
+                    onlineCores = 8,
+                    pageSize = 4096,
+                    clockTicks = 100,
+                    machine = "aarch64",
+                    kernelRelease = "5.15.123-android14",
+                    cores = listOf(
+                        CpuCore(id = 0, packageId = 0, minKhz = 300_000, maxKhz = 1_804_800, curKhz = 1_113_600, governor = "schedutil"),
+                        CpuCore(id = 1, packageId = 0, minKhz = 300_000, maxKhz = 1_804_800, curKhz = 300_000, governor = "schedutil"),
+                        CpuCore(id = 7, packageId = 1, minKhz = 500_000, maxKhz = 2_841_600, online = false)
+                    ),
+                    features = listOf("fp", "asimd", "aes", "sha2", "crc32", "atomics", "asimddp", "sve")
+                ),
+                hasLoaded = true
+            ),
+            onNavigateBack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/CpuCoresScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/CpuCoresScreen.kt
@@ -1,5 +1,6 @@
 package com.aoscoremonitor.ui.screens.jni
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
@@ -30,6 +31,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.aoscoremonitor.R
 import com.aoscoremonitor.diagnostics.jni.CpuCore
 import com.aoscoremonitor.diagnostics.jni.CpuSnapshot
+import com.aoscoremonitor.diagnostics.jni.Unavailable
 import com.aoscoremonitor.ui.components.EmptyState
 import com.aoscoremonitor.ui.components.FullScreenMessage
 import com.aoscoremonitor.ui.components.LabeledValue
@@ -154,16 +156,17 @@ private fun CoreCard(core: CpuCore, modifier: Modifier = Modifier) {
             badge?.let { Chip(text = it) }
         }
 
-        Text(
-            text = core.curKhz?.let { frequency(it) }
-                ?: stringResource(R.string.cpu_frequency_unavailable),
-            style = MaterialTheme.typography.titleLarge,
-            color = if (core.curKhz != null) {
-                MaterialTheme.colorScheme.onSurface
-            } else {
-                MaterialTheme.colorScheme.onSurfaceVariant
-            }
-        )
+        // A frequency is a number to be read at a glance; the reason it is missing is a sentence.
+        // They do not belong at the same weight.
+        if (core.curKhz != null) {
+            Text(text = frequency(core.curKhz), style = MaterialTheme.typography.titleLarge)
+        } else {
+            Text(
+                text = stringResource(unavailableReason(core.frequencyUnavailable)),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
 
         core.frequencyFraction?.let { fraction ->
             LinearProgressIndicator(
@@ -210,6 +213,20 @@ private fun frequency(khz: Long): String = if (khz >= KHZ_PER_MHZ) {
 }
 
 private const val KHZ_PER_MHZ = 1000L
+
+/**
+ * What to say in place of a frequency.
+ *
+ * The reason travels up from the errno the read failed with, so the screen can separate a value
+ * the sandbox is refused from one this kernel never had. Without a reason it says only that the
+ * reading is missing, which is all it used to be able to say.
+ */
+@StringRes
+private fun unavailableReason(reason: Unavailable?): Int = when (reason) {
+    Unavailable.Denied -> R.string.cpu_frequency_denied
+    Unavailable.Absent -> R.string.cpu_frequency_absent
+    else -> R.string.cpu_frequency_unavailable
+}
 
 /**
  * The instruction set extensions, as a wrapping run of chips.

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/LoadedLibrariesScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/LoadedLibrariesScreen.kt
@@ -173,7 +173,7 @@ private fun ModuleCard(module: LoadedModule, modifier: Modifier = Modifier) {
         ) {
             if (module.hasRelro) ModuleTag(stringResource(R.string.libraries_relro))
             if (module.hasTls) ModuleTag(stringResource(R.string.libraries_tls))
-            ModuleTag(pluralStringResource(R.plurals.libraries_segments, module.segments.size, module.segments.size))
+            ModuleTag(pluralStringResource(R.plurals.libraries_segments, module.segmentCount, module.segmentCount))
         }
     }
 }
@@ -213,8 +213,7 @@ private fun LoadedLibrariesPreview() {
                             buildId = "9f2c14ad55e0b3771c0e4a8d2b7f6613",
                             hasRelro = true,
                             hasTls = true,
-                            headerCount = 9,
-                            segments = emptyList()
+                            segmentCount = 4
                         ),
                         LoadedModule(
                             path = "/apex/com.android.runtime/lib64/bionic/libc.so",
@@ -223,8 +222,7 @@ private fun LoadedLibrariesPreview() {
                             buildId = "1ab3ff90c7d5e2418800aa11bc93de77",
                             hasRelro = true,
                             hasTls = true,
-                            headerCount = 8,
-                            segments = emptyList()
+                            segmentCount = 4
                         )
                     ),
                     loadEvents = 231,

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/LoadedLibrariesScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/LoadedLibrariesScreen.kt
@@ -1,0 +1,239 @@
+package com.aoscoremonitor.ui.screens.jni
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.formatBytes
+import com.aoscoremonitor.diagnostics.jni.LoadedModule
+import com.aoscoremonitor.diagnostics.jni.ModuleSnapshot
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.MonitorTypography
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.LoadedLibrariesUiState
+import com.aoscoremonitor.ui.viewmodel.LoadedLibrariesViewModel
+
+@Composable
+fun LoadedLibrariesScreen(onNavigateBack: () -> Unit, modifier: Modifier = Modifier, viewModel: LoadedLibrariesViewModel = viewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LoadedLibrariesContent(
+        uiState = uiState,
+        onNavigateBack = onNavigateBack,
+        onRefresh = viewModel::refresh,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun LoadedLibrariesContent(
+    uiState: LoadedLibrariesUiState,
+    onNavigateBack: () -> Unit,
+    onRefresh: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    MonitorScaffold(
+        title = stringResource(R.string.libraries_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier,
+        floatingActionButton = {
+            // This screen does not poll — the loaded set barely changes — so taking a new reading
+            // has to be something the user can ask for.
+            FloatingActionButton(onClick = onRefresh) {
+                Icon(
+                    imageVector = Icons.Default.Refresh,
+                    contentDescription = stringResource(R.string.action_refresh)
+                )
+            }
+        }
+    ) { innerPadding ->
+        val snapshot = uiState.modules
+        if (snapshot == null || snapshot.modules.isEmpty()) {
+            FullScreenMessage(
+                message = stringResource(if (uiState.hasLoaded) R.string.libraries_unavailable else R.string.libraries_loading),
+                icon = Icons.Default.Layers,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            item(key = "summary-header") {
+                SectionHeader(
+                    title = stringResource(R.string.libraries_summary_section),
+                    subtitle = stringResource(
+                        R.string.libraries_summary,
+                        snapshot.modules.size,
+                        formatBytes(snapshot.totalMappedSize)
+                    ),
+                    icon = Icons.Default.Layers
+                )
+            }
+            if (snapshot.loadEvents != null && snapshot.unloadEvents != null) {
+                item(key = "events") {
+                    Text(
+                        text = stringResource(R.string.libraries_load_events, snapshot.loadEvents, snapshot.unloadEvents),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = Spacing.Small)
+                    )
+                }
+            }
+            items(snapshot.modules, key = { module -> module.baseAddress + module.path }) { module ->
+                ModuleCard(module)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ModuleCard(module: LoadedModule, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = if (module.isMainExecutable) stringResource(R.string.libraries_main_executable) else module.fileName,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(end = Spacing.Small)
+            )
+            Text(
+                text = formatBytes(module.mappedSize),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        if (module.directory.isNotEmpty()) {
+            Text(
+                text = module.directory,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                // The interesting end of a library path is the right-hand one, but the file name is
+                // already on the line above, so the head is what is worth keeping here.
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        Text(
+            text = module.baseAddress,
+            style = MonitorTypography.machineText,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        Text(
+            text = module.buildId?.let { stringResource(R.string.libraries_build_id, it.take(BUILD_ID_DIGITS)) }
+                ?: stringResource(R.string.libraries_no_build_id),
+            style = MonitorTypography.machineText,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Row(
+            modifier = Modifier.padding(top = Spacing.ExtraSmall),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            if (module.hasRelro) ModuleTag(stringResource(R.string.libraries_relro))
+            if (module.hasTls) ModuleTag(stringResource(R.string.libraries_tls))
+            ModuleTag(pluralStringResource(R.plurals.libraries_segments, module.segments.size, module.segments.size))
+        }
+    }
+}
+
+@Composable
+private fun ModuleTag(text: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(percent = 50),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(horizontal = Spacing.Medium, vertical = Spacing.ExtraSmall)
+        )
+    }
+}
+
+/** Enough of a build id to tell two builds apart without wrapping the line. */
+private const val BUILD_ID_DIGITS = 16
+
+@Preview(name = "Loaded libraries", showBackground = true)
+@Preview(name = "Loaded libraries (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun LoadedLibrariesPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        LoadedLibrariesContent(
+            uiState = LoadedLibrariesUiState(
+                modules = ModuleSnapshot(
+                    modules = listOf(
+                        LoadedModule(
+                            path = "/apex/com.android.art/lib64/libart.so",
+                            baseAddress = "0x7b1c2a0000",
+                            mappedSize = 8_912_896,
+                            buildId = "9f2c14ad55e0b3771c0e4a8d2b7f6613",
+                            hasRelro = true,
+                            hasTls = true,
+                            headerCount = 9,
+                            segments = emptyList()
+                        ),
+                        LoadedModule(
+                            path = "/apex/com.android.runtime/lib64/bionic/libc.so",
+                            baseAddress = "0x7b0f440000",
+                            mappedSize = 1_052_672,
+                            buildId = "1ab3ff90c7d5e2418800aa11bc93de77",
+                            hasRelro = true,
+                            hasTls = true,
+                            headerCount = 8,
+                            segments = emptyList()
+                        )
+                    ),
+                    loadEvents = 231,
+                    unloadEvents = 3
+                ),
+                hasLoaded = true
+            ),
+            onNavigateBack = {},
+            onRefresh = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/MemoryMapScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/MemoryMapScreen.kt
@@ -36,7 +36,6 @@ import com.aoscoremonitor.ui.components.FullScreenMessage
 import com.aoscoremonitor.ui.components.LabeledValue
 import com.aoscoremonitor.ui.components.MonitorCard
 import com.aoscoremonitor.ui.components.MonitorScaffold
-import com.aoscoremonitor.ui.components.SampleDataBanner
 import com.aoscoremonitor.ui.components.SectionHeader
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
 import com.aoscoremonitor.ui.theme.Spacing
@@ -83,9 +82,18 @@ private fun MemoryMapContent(uiState: MemoryMapUiState, onNavigateBack: () -> Un
                     )
                 }
                 if (!rollup.fromRollupFile) {
-                    // Not a fallback to invented numbers, so not a sample banner's subject — but the
-                    // reader should know the total was assembled here rather than by the kernel.
-                    item(key = "smaps-notice") { SampleDataBanner(stringResource(R.string.memory_smaps_notice)) }
+                    // A note rather than a SampleDataBanner, which this used to be: that banner is
+                    // titled "Sample data", and these are measurements — only the summing was done
+                    // here rather than by the kernel. Labelling a real reading as a sample is the
+                    // exact confusion the banner exists to prevent.
+                    item(key = "smaps-notice") {
+                        Text(
+                            text = stringResource(R.string.memory_smaps_notice),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(bottom = Spacing.Small)
+                        )
+                    }
                 }
                 item(key = "footprint") { FootprintCard(rollup) }
             }

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/MemoryMapScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/MemoryMapScreen.kt
@@ -1,0 +1,311 @@
+package com.aoscoremonitor.ui.screens.jni
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DataUsage
+import androidx.compose.material.icons.filled.Layers
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.Widgets
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.formatBytes
+import com.aoscoremonitor.diagnostics.formatKilobytes
+import com.aoscoremonitor.diagnostics.jni.MemoryRollup
+import com.aoscoremonitor.diagnostics.jni.MemorySnapshot
+import com.aoscoremonitor.diagnostics.jni.RegionCategory
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.LabeledValue
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.SampleDataBanner
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.MemoryMapUiState
+import com.aoscoremonitor.ui.viewmodel.MemoryMapViewModel
+
+@Composable
+fun MemoryMapScreen(onNavigateBack: () -> Unit, modifier: Modifier = Modifier, viewModel: MemoryMapViewModel = viewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    MemoryMapContent(uiState = uiState, onNavigateBack = onNavigateBack, modifier = modifier)
+}
+
+@Composable
+private fun MemoryMapContent(uiState: MemoryMapUiState, onNavigateBack: () -> Unit, modifier: Modifier = Modifier) {
+    MonitorScaffold(
+        title = stringResource(R.string.memory_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier
+    ) { innerPadding ->
+        val memory = uiState.memory
+        if (memory == null) {
+            FullScreenMessage(
+                message = stringResource(if (uiState.hasLoaded) R.string.memory_unavailable else R.string.memory_loading),
+                icon = Icons.Default.DataUsage,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            memory.rollup?.let { rollup ->
+                item(key = "footprint-header") {
+                    SectionHeader(
+                        title = stringResource(R.string.memory_footprint_section),
+                        subtitle = stringResource(R.string.memory_footprint_subtitle),
+                        icon = Icons.Default.DataUsage
+                    )
+                }
+                if (!rollup.fromRollupFile) {
+                    // Not a fallback to invented numbers, so not a sample banner's subject — but the
+                    // reader should know the total was assembled here rather than by the kernel.
+                    item(key = "smaps-notice") { SampleDataBanner(stringResource(R.string.memory_smaps_notice)) }
+                }
+                item(key = "footprint") { FootprintCard(rollup) }
+            }
+
+            item(key = "regions-header") {
+                SectionHeader(
+                    title = stringResource(R.string.memory_regions_section),
+                    subtitle = pluralStringResource(
+                        R.plurals.memory_regions_subtitle,
+                        memory.totalRegions,
+                        memory.totalRegions
+                    ),
+                    icon = Icons.Default.Layers
+                )
+            }
+            if (memory.reservedRegions > 0) {
+                item(key = "reserved") {
+                    Text(
+                        text = stringResource(
+                            R.string.memory_reserved,
+                            formatKilobytes(memory.reservedKb),
+                            memory.reservedRegions
+                        ),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = Spacing.Small)
+                    )
+                }
+            }
+            items(memory.categories, key = { category -> category.key }) { category ->
+                CategoryCard(category = category, mappedKb = memory.mappedKb)
+            }
+
+            item(key = "heap-header") {
+                SectionHeader(
+                    title = stringResource(R.string.memory_heap_section),
+                    subtitle = stringResource(R.string.memory_heap_subtitle),
+                    icon = Icons.Default.Memory
+                )
+            }
+            item(key = "heap") { ByteReadingsCard(memory.malloc, MallocLabels) }
+
+            if (memory.status.isNotEmpty()) {
+                item(key = "status-header") {
+                    SectionHeader(
+                        title = stringResource(R.string.memory_status_section),
+                        subtitle = stringResource(R.string.memory_status_subtitle),
+                        icon = Icons.Default.Widgets
+                    )
+                }
+                item(key = "status") {
+                    MonitorCard {
+                        memory.status.forEach { (name, value) -> LabeledValue(label = name, value = value) }
+                    }
+                }
+            }
+
+            if (memory.limits.isNotEmpty()) {
+                item(key = "limits-header") {
+                    SectionHeader(
+                        title = stringResource(R.string.memory_limits_section),
+                        subtitle = stringResource(R.string.memory_limits_subtitle),
+                        icon = Icons.Default.Lock
+                    )
+                }
+                item(key = "limits") { ByteReadingsCard(memory.limits, LimitLabels, countKeys = setOf("open_files")) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FootprintCard(rollup: MemoryRollup, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Text(
+            text = formatKilobytes(rollup.pssKb),
+            style = MaterialTheme.typography.headlineSmall
+        )
+        Text(
+            text = stringResource(R.string.memory_pss),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.Small))
+
+        LabeledValue(label = stringResource(R.string.memory_rss), value = formatKilobytes(rollup.rssKb))
+        LabeledValue(label = stringResource(R.string.memory_private_dirty), value = formatKilobytes(rollup.privateDirtyKb))
+        LabeledValue(label = stringResource(R.string.memory_private_clean), value = formatKilobytes(rollup.privateCleanKb))
+        LabeledValue(label = stringResource(R.string.memory_shared_dirty), value = formatKilobytes(rollup.sharedDirtyKb))
+        LabeledValue(label = stringResource(R.string.memory_shared_clean), value = formatKilobytes(rollup.sharedCleanKb))
+        LabeledValue(label = stringResource(R.string.memory_swap), value = formatKilobytes(rollup.swapKb))
+        LabeledValue(label = stringResource(R.string.memory_swap_pss), value = formatKilobytes(rollup.swapPssKb))
+    }
+}
+
+/**
+ * One kind of mapping, as a share of the mapped total.
+ *
+ * The bar is what makes the list readable at a glance: the same seven categories appear on every
+ * device, and it is their proportions, not their byte counts, that differ.
+ */
+@Composable
+private fun CategoryCard(category: RegionCategory, mappedKb: Long, modifier: Modifier = Modifier) {
+    val share = if (mappedKb > 0) category.sizeKb.toFloat() / mappedKb.toFloat() else 0f
+
+    MonitorCard(modifier = modifier) {
+        Text(
+            text = stringResource(categoryLabel(category.key)),
+            style = MaterialTheme.typography.titleMedium
+        )
+        LinearProgressIndicator(
+            progress = { share },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = Spacing.ExtraSmall)
+        )
+        Text(
+            text = stringResource(
+                R.string.memory_category_detail,
+                formatKilobytes(category.sizeKb),
+                category.count,
+                (share * 100).toInt()
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+/**
+ * A card of named byte counts.
+ *
+ * The keys are listed by the caller rather than taken from the map's own iteration order, which
+ * `JSONObject` does not promise to preserve. Anything the native side sends that is not named here
+ * is left out on purpose: an unlabelled key would reach the screen as a bare identifier.
+ */
+@Composable
+private fun ByteReadingsCard(
+    readings: Map<String, Long>,
+    labels: List<Pair<String, Int>>,
+    modifier: Modifier = Modifier,
+    countKeys: Set<String> = emptySet()
+) {
+    MonitorCard(modifier = modifier) {
+        labels.forEach { (key, labelRes) ->
+            val value = readings[key] ?: return@forEach
+            LabeledValue(
+                label = stringResource(labelRes),
+                value = if (key in countKeys) {
+                    stringResource(R.string.memory_count, value)
+                } else {
+                    formatBytes(value)
+                }
+            )
+        }
+    }
+}
+
+private val MallocLabels = listOf(
+    "in_use" to R.string.memory_malloc_in_use,
+    "free" to R.string.memory_malloc_free,
+    "arena" to R.string.memory_malloc_arena,
+    "mmapped" to R.string.memory_malloc_mmapped,
+    "peak" to R.string.memory_malloc_peak,
+    "releasable" to R.string.memory_malloc_releasable,
+    "free_chunks" to R.string.memory_malloc_free_chunks
+)
+
+private val LimitLabels = listOf(
+    "address_space" to R.string.memory_limit_address_space,
+    "data" to R.string.memory_limit_data,
+    "stack" to R.string.memory_limit_stack,
+    "open_files" to R.string.memory_limit_open_files
+)
+
+/** The display name for a category key the native collector emits. */
+@StringRes
+private fun categoryLabel(key: String): Int = when (key) {
+    "native_lib" -> R.string.memory_category_native_lib
+    "art" -> R.string.memory_category_art
+    "dalvik" -> R.string.memory_category_dalvik
+    "native_heap" -> R.string.memory_category_native_heap
+    "stack" -> R.string.memory_category_stack
+    "anon" -> R.string.memory_category_anon
+    else -> R.string.memory_category_other
+}
+
+@Preview(name = "Memory map", showBackground = true)
+@Preview(name = "Memory map (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun MemoryMapPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        MemoryMapContent(
+            uiState = MemoryMapUiState(
+                memory = MemorySnapshot(
+                    rollup = MemoryRollup(
+                        rssKb = 98_304,
+                        pssKb = 74_120,
+                        privateCleanKb = 4_096,
+                        privateDirtyKb = 51_200,
+                        sharedCleanKb = 40_960,
+                        sharedDirtyKb = 2_048,
+                        swapKb = 0,
+                        swapPssKb = 0,
+                        fromRollupFile = true
+                    ),
+                    status = mapOf("VmSize" to "14 GB", "VmRSS" to "98304 kB", "Threads" to "21"),
+                    totalRegions = 1832,
+                    categories = listOf(
+                        RegionCategory("native_lib", 412, 198_340),
+                        RegionCategory("anon", 900, 40_960),
+                        RegionCategory("native_heap", 40, 22_528)
+                    ),
+                    malloc = mapOf("in_use" to 6_291_456L, "free" to 2_097_152L, "arena" to 8_388_608L),
+                    limits = mapOf("open_files" to 32_768L, "stack" to 8_388_608L)
+                ),
+                hasLoaded = true
+            ),
+            onNavigateBack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/StorageMountsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/StorageMountsScreen.kt
@@ -1,5 +1,6 @@
 package com.aoscoremonitor.ui.screens.jni
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -28,6 +29,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.aoscoremonitor.R
 import com.aoscoremonitor.diagnostics.formatBytes
 import com.aoscoremonitor.diagnostics.jni.MountPoint
+import com.aoscoremonitor.diagnostics.jni.Unavailable
 import com.aoscoremonitor.ui.components.FullScreenMessage
 import com.aoscoremonitor.ui.components.MonitorCard
 import com.aoscoremonitor.ui.components.MonitorScaffold
@@ -150,7 +152,7 @@ private fun MountCard(mount: MountPoint, modifier: Modifier = Modifier) {
             }
         } else {
             Text(
-                text = stringResource(R.string.storage_unmeasurable),
+                text = stringResource(unmeasurableReason(mount.capacityUnavailable)),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -217,6 +219,14 @@ private fun MountTag(text: String, modifier: Modifier = Modifier) {
             modifier = Modifier.padding(horizontal = Spacing.Medium, vertical = Spacing.ExtraSmall)
         )
     }
+}
+
+/** Why the capacity is missing, when statvfs said why. */
+@StringRes
+private fun unmeasurableReason(reason: Unavailable?): Int = when (reason) {
+    Unavailable.Denied -> R.string.storage_unmeasurable_denied
+    Unavailable.Absent -> R.string.storage_unmeasurable_absent
+    else -> R.string.storage_unmeasurable
 }
 
 private const val NEARLY_FULL = 0.9f

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/StorageMountsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/StorageMountsScreen.kt
@@ -239,7 +239,6 @@ private fun StorageMountsPreview() {
                         totalBytes = 107_374_182_400,
                         freeBytes = 42_949_672_960,
                         availableBytes = 40_000_000_000,
-                        blockSize = 4096,
                         inodesTotal = 26_214_400,
                         inodesFree = 25_000_000
                     ),
@@ -251,8 +250,7 @@ private fun StorageMountsPreview() {
                         readOnly = true,
                         totalBytes = 4_294_967_296,
                         freeBytes = 0,
-                        availableBytes = 0,
-                        blockSize = 4096
+                        availableBytes = 0
                     )
                 ),
                 pseudoFilesystems = listOf(

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/StorageMountsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/StorageMountsScreen.kt
@@ -1,0 +1,267 @@
+package com.aoscoremonitor.ui.screens.jni
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.formatBytes
+import com.aoscoremonitor.diagnostics.jni.MountPoint
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.ReadingStatus
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.MonitorTypography
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.StorageMountsUiState
+import com.aoscoremonitor.ui.viewmodel.StorageMountsViewModel
+
+@Composable
+fun StorageMountsScreen(onNavigateBack: () -> Unit, modifier: Modifier = Modifier, viewModel: StorageMountsViewModel = viewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    StorageMountsContent(uiState = uiState, onNavigateBack = onNavigateBack, modifier = modifier)
+}
+
+@Composable
+private fun StorageMountsContent(uiState: StorageMountsUiState, onNavigateBack: () -> Unit, modifier: Modifier = Modifier) {
+    MonitorScaffold(
+        title = stringResource(R.string.storage_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier
+    ) { innerPadding ->
+        if (uiState.filesystems.isEmpty() && uiState.pseudoFilesystems.isEmpty()) {
+            FullScreenMessage(
+                message = stringResource(if (uiState.hasLoaded) R.string.storage_empty else R.string.storage_loading),
+                icon = Icons.Default.Storage,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            item(key = "filesystems-header") {
+                SectionHeader(
+                    title = stringResource(R.string.storage_filesystems_section),
+                    subtitle = stringResource(R.string.storage_filesystems_subtitle),
+                    icon = Icons.Default.Storage
+                )
+            }
+            items(uiState.filesystems, key = { mount -> mount.target }) { mount -> MountCard(mount) }
+
+            if (uiState.pseudoFilesystems.isNotEmpty()) {
+                item(key = "pseudo-header") {
+                    SectionHeader(
+                        title = stringResource(R.string.storage_pseudo_section),
+                        subtitle = stringResource(R.string.storage_pseudo_subtitle),
+                        icon = Icons.Default.Memory
+                    )
+                }
+                items(uiState.pseudoFilesystems, key = { mount -> "pseudo-" + mount.target }) { mount ->
+                    PseudoMountRow(mount)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * One filesystem, with what is left on it.
+ *
+ * The bar turns amber past nine tenths full through [ReadingStatus], which is the same threshold
+ * and the same colour the rest of the app uses for a reading that is working but worth watching.
+ */
+@Composable
+private fun MountCard(mount: MountPoint, modifier: Modifier = Modifier) {
+    val fraction = mount.usedFraction
+    val status = when {
+        fraction == null -> ReadingStatus.Neutral
+        fraction >= NEARLY_FULL -> ReadingStatus.Warning
+        else -> ReadingStatus.Neutral
+    }
+
+    MonitorCard(modifier = modifier, status = status) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = mount.target,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(end = Spacing.Small)
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.Small)) {
+                if (mount.readOnly) MountTag(stringResource(R.string.storage_readonly))
+                MountTag(mount.fsType)
+            }
+        }
+
+        val total = mount.totalBytes
+        val used = mount.usedBytes
+        if (fraction != null && total != null && used != null) {
+            LinearProgressIndicator(
+                progress = { fraction },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = Spacing.ExtraSmall)
+            )
+            Text(
+                text = stringResource(R.string.storage_usage, formatBytes(used), formatBytes(total)),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            mount.availableBytes?.let {
+                Text(
+                    text = stringResource(R.string.storage_available, formatBytes(it)),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            Text(
+                text = stringResource(R.string.storage_unmeasurable),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        if (mount.inodesTotal != null && mount.inodesFree != null && mount.inodesTotal > 0) {
+            Text(
+                text = stringResource(R.string.storage_inodes, mount.inodesFree.toString(), mount.inodesTotal.toString()),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Text(
+            text = stringResource(R.string.storage_source, mount.source),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Text(
+            text = mount.options,
+            style = MonitorTypography.machineText,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = OPTION_LINES,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+/** A pseudo filesystem has no capacity to report, so it gets a line rather than a card of its own. */
+@Composable
+private fun PseudoMountRow(mount: MountPoint, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = mount.target,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(end = Spacing.Small)
+            )
+            MountTag(mount.fsType)
+        }
+    }
+}
+
+@Composable
+private fun MountTag(text: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(percent = 50),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            maxLines = 1,
+            modifier = Modifier.padding(horizontal = Spacing.Medium, vertical = Spacing.ExtraSmall)
+        )
+    }
+}
+
+private const val NEARLY_FULL = 0.9f
+private const val OPTION_LINES = 2
+
+@Preview(name = "Storage", showBackground = true)
+@Preview(name = "Storage (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun StorageMountsPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        StorageMountsContent(
+            uiState = StorageMountsUiState(
+                filesystems = listOf(
+                    MountPoint(
+                        source = "/dev/block/dm-9",
+                        target = "/data",
+                        fsType = "f2fs",
+                        options = "rw,nosuid,nodev,noatime,background_gc=on,discard,inline_xattr",
+                        readOnly = false,
+                        totalBytes = 107_374_182_400,
+                        freeBytes = 42_949_672_960,
+                        availableBytes = 40_000_000_000,
+                        blockSize = 4096,
+                        inodesTotal = 26_214_400,
+                        inodesFree = 25_000_000
+                    ),
+                    MountPoint(
+                        source = "/dev/block/dm-0",
+                        target = "/",
+                        fsType = "erofs",
+                        options = "ro,seclabel,relatime",
+                        readOnly = true,
+                        totalBytes = 4_294_967_296,
+                        freeBytes = 0,
+                        availableBytes = 0,
+                        blockSize = 4096
+                    )
+                ),
+                pseudoFilesystems = listOf(
+                    MountPoint("proc", "/proc", "proc", "rw,nosuid,nodev,noexec,relatime", false),
+                    MountPoint("sysfs", "/sys", "sysfs", "rw,seclabel,nosuid,nodev,noexec,relatime", false)
+                ),
+                hasLoaded = true
+            ),
+            onNavigateBack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/CpuCoresViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/CpuCoresViewModel.kt
@@ -1,0 +1,46 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.jni.CpuSnapshot
+import com.aoscoremonitor.diagnostics.jni.NativeCpuInspector
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * The CPU as the screen shows it.
+ *
+ * [hasLoaded] separates "nothing read yet" from "read, and there was nothing" so the screen can
+ * say which — the same distinction the network screen needed, for the same reason.
+ */
+data class CpuCoresUiState(val cpu: CpuSnapshot? = null, val hasLoaded: Boolean = false)
+
+/**
+ * Polls the per-core frequencies once a second, over topology read once.
+ *
+ * Core layout and instruction set cannot change while the process runs, so they are read on the
+ * first collection and reused; only `scaling_cur_freq` and the governor are re-read. Reading the
+ * whole of sysfs every second would be a dozen file opens per core for values known to be fixed.
+ */
+class CpuCoresViewModel : ViewModel() {
+
+    private val inspector = NativeCpuInspector()
+
+    val uiState: StateFlow<CpuCoresUiState> = flow {
+        val topology = inspector.readStatic()
+        if (topology == null) {
+            emit(CpuCoresUiState(hasLoaded = true))
+            return@flow
+        }
+        while (true) {
+            emit(CpuCoresUiState(cpu = topology.withFrequencies(inspector.readFrequencies()), hasLoaded = true))
+            delay(REFRESH_INTERVAL_MS)
+        }
+    }.stateIn(viewModelScope, WhileScreenVisible, CpuCoresUiState())
+
+    private companion object {
+        const val REFRESH_INTERVAL_MS = 1_000L
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/LoadedLibrariesViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/LoadedLibrariesViewModel.kt
@@ -1,0 +1,46 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.jni.ModuleSnapshot
+import com.aoscoremonitor.diagnostics.jni.NativeModuleInspector
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class LoadedLibrariesUiState(val modules: ModuleSnapshot? = null, val hasLoaded: Boolean = false, val isRefreshing: Boolean = false)
+
+/**
+ * Reads the loaded library list once, and again when asked.
+ *
+ * The other native screens poll, but the set of loaded objects is settled within a second of
+ * startup and then changes only when something calls `dlopen` — polling it would serialise several
+ * hundred entries a second to produce the same list. The screen offers a refresh instead, which is
+ * also what makes a change visible: take a reading, do the thing that loads a library, refresh.
+ */
+class LoadedLibrariesViewModel : ViewModel() {
+
+    private val inspector = NativeModuleInspector()
+    private val _uiState = MutableStateFlow(LoadedLibrariesUiState())
+    val uiState: StateFlow<LoadedLibrariesUiState> = _uiState.asStateFlow()
+
+    private var refreshJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        // A second tap while a read is in flight would otherwise start a competing coroutine whose
+        // result races the first one into the state.
+        if (refreshJob?.isActive == true) return
+
+        refreshJob = viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isRefreshing = true)
+            val snapshot = inspector.read()
+            _uiState.value = LoadedLibrariesUiState(modules = snapshot, hasLoaded = true, isRefreshing = false)
+        }
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/MemoryMapViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/MemoryMapViewModel.kt
@@ -1,0 +1,35 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.jni.MemorySnapshot
+import com.aoscoremonitor.diagnostics.jni.NativeMemoryInspector
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+
+data class MemoryMapUiState(val memory: MemorySnapshot? = null, val hasLoaded: Boolean = false)
+
+/**
+ * Polls this process's memory map every two seconds.
+ *
+ * Slower than the CPU screen because the read is heavier — `/proc/self/maps` is hundreds of lines
+ * and is walked in full — and because a process's own footprint moves in steps rather than
+ * continuously. [WhileScreenVisible] stops it when the screen goes away.
+ */
+class MemoryMapViewModel : ViewModel() {
+
+    private val inspector = NativeMemoryInspector()
+
+    val uiState: StateFlow<MemoryMapUiState> = flow {
+        while (true) {
+            emit(MemoryMapUiState(memory = inspector.read(), hasLoaded = true))
+            delay(REFRESH_INTERVAL_MS)
+        }
+    }.stateIn(viewModelScope, WhileScreenVisible, MemoryMapUiState())
+
+    private companion object {
+        const val REFRESH_INTERVAL_MS = 2_000L
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/StorageMountsViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/StorageMountsViewModel.kt
@@ -1,0 +1,52 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.jni.MountPoint
+import com.aoscoremonitor.diagnostics.jni.NativeStorageInspector
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * The mount table, split into the filesystems that hold files and the kernel interfaces that do
+ * not.
+ *
+ * The split is made once here rather than in each list: an Android mount table runs to well over a
+ * hundred entries, nearly all of them cgroup and tmpfs mounts, and the screen would otherwise open
+ * on a wall of them with /data somewhere below the fold.
+ */
+data class StorageMountsUiState(
+    val filesystems: List<MountPoint> = emptyList(),
+    val pseudoFilesystems: List<MountPoint> = emptyList(),
+    val hasLoaded: Boolean = false
+)
+
+/** Polls the mount table every five seconds. */
+class StorageMountsViewModel : ViewModel() {
+
+    private val inspector = NativeStorageInspector()
+
+    val uiState: StateFlow<StorageMountsUiState> = flow {
+        while (true) {
+            val mounts = inspector.read().orEmpty()
+            emit(
+                StorageMountsUiState(
+                    // Fullest first, so a filesystem about to run out is the one in view.
+                    filesystems = mounts.filter { it.isRealFilesystem }
+                        .sortedByDescending { it.usedFraction ?: -1f },
+                    pseudoFilesystems = mounts.filterNot { it.isRealFilesystem }
+                        .sortedBy { it.target },
+                    hasLoaded = true
+                )
+            )
+            delay(REFRESH_INTERVAL_MS)
+        }
+    }.stateIn(viewModelScope, WhileScreenVisible, StorageMountsUiState())
+
+    private companion object {
+        // Free space moves in minutes, not seconds, and each poll runs a statvfs per mount.
+        const val REFRESH_INTERVAL_MS = 5_000L
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -198,6 +198,8 @@
     <string name="cpu_frequency_range">%1$d – %2$d MHz</string>
     <string name="cpu_frequency_range_khz">%1$d – %2$d kHz</string>
     <string name="cpu_frequency_unavailable">Current frequency not readable</string>
+    <string name="cpu_frequency_denied">Current frequency: the sandbox may not read it</string>
+    <string name="cpu_frequency_absent">Current frequency: this kernel does not expose it</string>
     <string name="cpu_governor">Governor · %1$s</string>
     <string name="cpu_features_section">Instruction set</string>
     <string name="cpu_features_subtitle">Extensions the kernel advertises through the ELF auxiliary vector</string>
@@ -278,7 +280,9 @@
     <string name="storage_pseudo_subtitle">Kernel interfaces mounted like filesystems. They hold no files, so they have no capacity.</string>
     <string name="storage_usage">%1$s used of %2$s</string>
     <string name="storage_available">%1$s available</string>
-    <string name="storage_unmeasurable">Capacity not readable from the app sandbox</string>
+    <string name="storage_unmeasurable">Capacity not readable</string>
+    <string name="storage_unmeasurable_denied">Capacity: the sandbox may not read it</string>
+    <string name="storage_unmeasurable_absent">Capacity: nothing mounted here to measure</string>
     <string name="storage_readonly">Read-only</string>
     <string name="storage_source">Device · %1$s</string>
     <string name="storage_inodes">Inodes · %1$s free of %2$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -282,5 +282,4 @@
     <string name="storage_readonly">Read-only</string>
     <string name="storage_source">Device · %1$s</string>
     <string name="storage_inodes">Inodes · %1$s free of %2$s</string>
-    <string name="storage_options">Mount options</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="action_scroll_to_bottom">Scroll to bottom</string>
     <string name="action_expand">Show all</string>
     <string name="action_collapse">Show less</string>
+    <string name="action_refresh">Take a new reading</string>
     <string name="sample_data_label">Sample data</string>
     <string name="status_supported">Supported</string>
     <string name="status_not_supported">Not supported</string>
@@ -21,6 +22,10 @@
     <string name="destination_native_monitor">Native Monitor</string>
     <string name="destination_network_stats">Network Stats</string>
     <string name="destination_tcp_connections">TCP Connections</string>
+    <string name="destination_cpu_cores">CPU Cores</string>
+    <string name="destination_memory_map">Memory Map</string>
+    <string name="destination_loaded_libraries">Libraries</string>
+    <string name="destination_storage">Storage</string>
 
     <!-- System logs -->
     <string name="logs_title">System Logs</string>
@@ -170,4 +175,112 @@
     <string name="tcp_remote">Remote</string>
     <string name="tcp_uid">UID</string>
     <string name="tcp_sample">/proc/net/tcp is not readable by apps</string>
+
+    <!-- CPU cores -->
+    <string name="cpu_title">CPU Cores</string>
+    <string name="cpu_loading">Reading CPU topology…</string>
+    <string name="cpu_unavailable">The native library did not load, so no CPU readings are available on this device.</string>
+    <string name="cpu_overview_section">Processor</string>
+    <string name="cpu_overview_subtitle">What the kernel reports about this CPU</string>
+    <string name="cpu_core_count">%1$d cores configured · %2$d online</string>
+    <string name="cpu_machine">Machine</string>
+    <string name="cpu_kernel">Kernel</string>
+    <string name="cpu_page_size">Page size</string>
+    <string name="cpu_clock_ticks">Clock ticks per second</string>
+    <string name="cpu_bytes">%1$d bytes</string>
+    <string name="cpu_cores_section">Cores</string>
+    <string name="cpu_cores_subtitle">Current frequency and governor, per core</string>
+    <string name="cpu_core_label">Core %1$d</string>
+    <string name="cpu_core_cluster">Cluster %1$d</string>
+    <string name="cpu_core_offline">Offline</string>
+    <string name="cpu_megahertz">%1$d MHz</string>
+    <string name="cpu_kilohertz">%1$d kHz</string>
+    <string name="cpu_frequency_range">%1$d – %2$d MHz</string>
+    <string name="cpu_frequency_range_khz">%1$d – %2$d kHz</string>
+    <string name="cpu_frequency_unavailable">Current frequency not readable</string>
+    <string name="cpu_governor">Governor · %1$s</string>
+    <string name="cpu_features_section">Instruction set</string>
+    <string name="cpu_features_subtitle">Extensions the kernel advertises through the ELF auxiliary vector</string>
+    <string name="cpu_features_empty">The kernel advertised no instruction set extensions for this CPU.</string>
+
+    <!-- Memory map -->
+    <string name="memory_title">Memory Map</string>
+    <string name="memory_loading">Reading /proc/self…</string>
+    <string name="memory_unavailable">The native library did not load, so this process\'s memory map cannot be read.</string>
+    <string name="memory_footprint_section">Footprint</string>
+    <string name="memory_footprint_subtitle">Resident memory, totalled over every mapping this process owns</string>
+    <string name="memory_rss">Resident (RSS)</string>
+    <string name="memory_pss">Proportional (PSS)</string>
+    <string name="memory_private_clean">Private clean</string>
+    <string name="memory_private_dirty">Private dirty</string>
+    <string name="memory_shared_clean">Shared clean</string>
+    <string name="memory_shared_dirty">Shared dirty</string>
+    <string name="memory_swap">Swapped</string>
+    <string name="memory_swap_pss">Swapped (proportional)</string>
+    <string name="memory_smaps_notice">Totalled from /proc/self/smaps. The kernel\'s own smaps_rollup summary is not available here.</string>
+    <string name="memory_regions_section">Address space</string>
+    <plurals name="memory_regions_subtitle">
+        <item quantity="one">%1$d mapping. Sizes are address space, not resident memory.</item>
+        <item quantity="other">%1$d mappings. Sizes are address space, not resident memory — ART maps its heap in full whether or not it has filled it.</item>
+    </plurals>
+    <string name="memory_category_native_lib">Shared libraries</string>
+    <string name="memory_category_art">ART and dex files</string>
+    <string name="memory_category_dalvik">Dalvik heap</string>
+    <string name="memory_category_native_heap">Native heap</string>
+    <string name="memory_category_stack">Thread stacks</string>
+    <string name="memory_category_anon">Anonymous</string>
+    <string name="memory_category_other">Other files</string>
+    <string name="memory_category_detail">%1$s · %2$d mappings · %3$d%%</string>
+    <string name="memory_reserved">Leaves out %1$s across %2$d mappings with no access — the CFI shadow, WebView\'s reservation and the allocator\'s reserve. They hold nothing.</string>
+    <string name="memory_heap_section">Native heap</string>
+    <string name="memory_heap_subtitle">libc\'s own accounting, from mallinfo2</string>
+    <string name="memory_malloc_arena">Arena</string>
+    <string name="memory_malloc_in_use">In use</string>
+    <string name="memory_malloc_free">Free</string>
+    <string name="memory_malloc_free_chunks">Free chunks</string>
+    <string name="memory_malloc_mmapped">Mapped directly</string>
+    <string name="memory_malloc_peak">Peak</string>
+    <string name="memory_malloc_releasable">Releasable by a trim</string>
+    <string name="memory_status_section">Process</string>
+    <string name="memory_status_subtitle">Counters from /proc/self/status</string>
+    <string name="memory_limits_section">Limits</string>
+    <string name="memory_limits_subtitle">Resource ceilings this process runs under. Unlimited resources are not listed.</string>
+    <string name="memory_limit_address_space">Address space</string>
+    <string name="memory_limit_data">Data segment</string>
+    <string name="memory_limit_stack">Stack</string>
+    <string name="memory_limit_open_files">Open files</string>
+    <string name="memory_count">%1$d</string>
+
+    <!-- Loaded libraries -->
+    <string name="libraries_title">Loaded Libraries</string>
+    <string name="libraries_loading">Walking the linker\'s module list…</string>
+    <string name="libraries_unavailable">The native library did not load, so the linker\'s module list cannot be read.</string>
+    <string name="libraries_summary_section">Linked objects</string>
+    <string name="libraries_summary">%1$d objects · %2$s mapped</string>
+    <string name="libraries_load_events">%1$d loads · %2$d unloads since the process started</string>
+    <string name="libraries_main_executable">(main executable)</string>
+    <string name="libraries_build_id">Build ID %1$s</string>
+    <string name="libraries_no_build_id">No build ID</string>
+    <string name="libraries_relro">RELRO</string>
+    <string name="libraries_tls">TLS</string>
+    <plurals name="libraries_segments">
+        <item quantity="one">%1$d loadable segment</item>
+        <item quantity="other">%1$d loadable segments</item>
+    </plurals>
+
+    <!-- Storage and mounts -->
+    <string name="storage_title">Storage</string>
+    <string name="storage_loading">Reading the mount table…</string>
+    <string name="storage_empty">No mounts were reported for this process.</string>
+    <string name="storage_filesystems_section">Filesystems</string>
+    <string name="storage_filesystems_subtitle">Mounts that hold files, fullest first</string>
+    <string name="storage_pseudo_section">Pseudo filesystems</string>
+    <string name="storage_pseudo_subtitle">Kernel interfaces mounted like filesystems. They hold no files, so they have no capacity.</string>
+    <string name="storage_usage">%1$s used of %2$s</string>
+    <string name="storage_available">%1$s available</string>
+    <string name="storage_unmeasurable">Capacity not readable from the app sandbox</string>
+    <string name="storage_readonly">Read-only</string>
+    <string name="storage_source">Device · %1$s</string>
+    <string name="storage_inodes">Inodes · %1$s free of %2$s</string>
+    <string name="storage_options">Mount options</string>
 </resources>

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/CpuParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/CpuParsingTest.kt
@@ -1,0 +1,77 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Covers the half of the CPU collector that can be tested without a device.
+ *
+ * The point of these is the absent-key contract: sysfs exposes a different subset on every device,
+ * and the native side leaves a key out rather than sending a zero. A parser that turned those into
+ * zeros would have the screen report a core running at 0 MHz between limits of 0 and 0.
+ */
+class CpuParsingTest {
+
+    @Test
+    fun readsTopologyAndFeatures() {
+        val snapshot = parseCpuStatic(
+            """
+            {"configured":8,"online":6,"page_size":4096,"clock_ticks":100,
+             "machine":"aarch64","kernel_release":"5.15.123-android14",
+             "cores":[{"id":0,"core_id":0,"package_id":0,"min_khz":300000,"max_khz":1804800}],
+             "features":["fp","asimd","sve"]}
+            """.trimIndent()
+        )
+
+        assertEquals(8, snapshot.configuredCores)
+        assertEquals(6, snapshot.onlineCores)
+        assertEquals("aarch64", snapshot.machine)
+        assertEquals(listOf("fp", "asimd", "sve"), snapshot.features)
+        assertEquals(1, snapshot.cores.size)
+        assertEquals(1_804_800L, snapshot.cores.first().maxKhz)
+    }
+
+    @Test
+    fun missingReadingsStayNullRatherThanBecomingZero() {
+        val snapshot = parseCpuStatic("""{"configured":1,"cores":[{"id":0}],"features":[]}""")
+
+        val core = snapshot.cores.single()
+        assertNull(core.minKhz)
+        assertNull(core.maxKhz)
+        assertNull(core.coreId)
+        assertNull(core.packageId)
+        assertNull(snapshot.machine)
+    }
+
+    @Test
+    fun frequencyReadingIsFoldedIntoTheTopology() {
+        val topology = parseCpuStatic(
+            """{"configured":2,"cores":[{"id":0,"min_khz":300000,"max_khz":1800000},{"id":1}],"features":[]}"""
+        )
+        val readings = parseCpuFrequencies(
+            """{"cores":[{"id":0,"online":true,"cur_khz":900000,"governor":"schedutil"},{"id":1,"online":false}]}"""
+        )
+
+        val merged = topology.withFrequencies(readings)
+
+        val first = merged.cores.first()
+        assertEquals(900_000L, first.curKhz)
+        assertEquals("schedutil", first.governor)
+        // The limits came from the topology read and must survive the merge.
+        assertEquals(300_000L, first.minKhz)
+        assertTrue(first.online)
+        assertEquals(false, merged.cores[1].online)
+        assertNull(merged.cores[1].curKhz)
+    }
+
+    @Test
+    fun frequencyFractionNeedsBothLimitsAndAReading() {
+        assertEquals(0.5f, CpuCore(id = 0, minKhz = 0, maxKhz = 2000, curKhz = 1000).frequencyFraction)
+        assertNull(CpuCore(id = 0, minKhz = 0, maxKhz = 2000).frequencyFraction)
+        assertNull(CpuCore(id = 0, curKhz = 1000).frequencyFraction)
+        // A core whose limits are equal would divide by zero.
+        assertNull(CpuCore(id = 0, minKhz = 1000, maxKhz = 1000, curKhz = 1000).frequencyFraction)
+    }
+}

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/CpuParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/CpuParsingTest.kt
@@ -67,6 +67,39 @@ class CpuParsingTest {
     }
 
     @Test
+    fun aMissingFrequencyCarriesTheReasonItIsMissing() {
+        val cores = parseCpuFrequencies(
+            """
+            {"cores":[{"id":0,"online":true,"cur_khz_unavailable":"denied"},
+                      {"id":1,"online":true,"cur_khz_unavailable":"absent"},
+                      {"id":2,"online":true,"cur_khz":900000}]}
+            """.trimIndent()
+        )
+
+        assertEquals(Unavailable.Denied, cores[0].frequencyUnavailable)
+        assertEquals(Unavailable.Absent, cores[1].frequencyUnavailable)
+        // A reading that succeeded has no reason attached to it.
+        assertNull(cores[2].frequencyUnavailable)
+    }
+
+    @Test
+    fun anUnknownReasonIsNoReasonRatherThanACrash() {
+        val cores = parseCpuFrequencies("""{"cores":[{"id":0,"cur_khz_unavailable":"something new"}]}""")
+
+        assertNull(cores.single().frequencyUnavailable)
+    }
+
+    @Test
+    fun theReasonSurvivesTheMergeIntoTheTopology() {
+        val topology = parseCpuStatic("""{"configured":1,"cores":[{"id":0}],"features":[]}""")
+        val merged = topology.withFrequencies(
+            parseCpuFrequencies("""{"cores":[{"id":0,"cur_khz_unavailable":"denied"}]}""")
+        )
+
+        assertEquals(Unavailable.Denied, merged.cores.single().frequencyUnavailable)
+    }
+
+    @Test
     fun frequencyFractionNeedsBothLimitsAndAReading() {
         assertEquals(0.5f, CpuCore(id = 0, minKhz = 0, maxKhz = 2000, curKhz = 1000).frequencyFraction)
         assertNull(CpuCore(id = 0, minKhz = 0, maxKhz = 2000).frequencyFraction)

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/MemoryMapParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/MemoryMapParsingTest.kt
@@ -1,0 +1,79 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MemoryMapParsingTest {
+
+    @Test
+    fun readsTheRollupAndTheCategories() {
+        val snapshot = parseMemoryMap(
+            """
+            {"rollup":{"rss_kb":98304,"pss_kb":74120,"private_clean_kb":4096,"private_dirty_kb":51200,
+                       "shared_clean_kb":40960,"shared_dirty_kb":2048,"swap_kb":0,"swap_pss_kb":0,
+                       "from_rollup_file":true},
+             "status":{"VmRSS":"98304 kB","Threads":"21"},
+             "regions":{"total":3,"categories":[{"key":"anon","count":2,"size_kb":1024},
+                                                {"key":"native_lib","count":1,"size_kb":8192}]},
+             "malloc":{"arena":8388608,"in_use":6291456},
+             "limits":{"open_files":32768}}
+            """.trimIndent()
+        )
+
+        assertEquals(74_120L, snapshot.rollup?.pssKb)
+        assertTrue(snapshot.rollup!!.fromRollupFile)
+        assertEquals(3, snapshot.totalRegions)
+        assertEquals("98304 kB", snapshot.status["VmRSS"])
+        assertEquals(8_388_608L, snapshot.malloc["arena"])
+        assertEquals(32_768L, snapshot.limits["open_files"])
+    }
+
+    @Test
+    fun categoriesAreOrderedByTheSpaceTheyHold() {
+        val snapshot = parseMemoryMap(
+            """
+            {"regions":{"total":3,"categories":[{"key":"anon","count":2,"size_kb":1024},
+                                                {"key":"native_lib","count":1,"size_kb":8192},
+                                                {"key":"stack","count":1,"size_kb":4096}]}}
+            """.trimIndent()
+        )
+
+        assertEquals(listOf("native_lib", "stack", "anon"), snapshot.categories.map { it.key })
+        assertEquals(13_312L, snapshot.mappedKb)
+    }
+
+    @Test
+    fun reservationsAreCountedApartFromTheCategories() {
+        val snapshot = parseMemoryMap(
+            """
+            {"regions":{"total":10,"reserved_count":3,"reserved_kb":8388608,
+                        "categories":[{"key":"anon","count":7,"size_kb":1024}]}}
+            """.trimIndent()
+        )
+
+        assertEquals(3, snapshot.reservedRegions)
+        assertEquals(8_388_608L, snapshot.reservedKb)
+        // The share each category is drawn as must be of the accessible total, not of an address
+        // space that is four fifths reservation.
+        assertEquals(1_024L, snapshot.mappedKb)
+    }
+
+    @Test
+    fun aMissingRollupIsNullRatherThanAnEmptyReading() {
+        val snapshot = parseMemoryMap("""{"regions":{"total":0,"categories":[]}}""")
+
+        assertNull(snapshot.rollup)
+        assertEquals(0, snapshot.totalRegions)
+        assertTrue(snapshot.categories.isEmpty())
+    }
+
+    @Test
+    fun theSmapsFallbackIsDistinguishableFromTheKernelSummary() {
+        val snapshot = parseMemoryMap("""{"rollup":{"rss_kb":1,"pss_kb":1,"from_rollup_file":false}}""")
+
+        assertFalse(snapshot.rollup!!.fromRollupFile)
+    }
+}

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/ModuleParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/ModuleParsingTest.kt
@@ -1,0 +1,64 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ModuleParsingTest {
+
+    @Test
+    fun readsModulesLargestFirst() {
+        val snapshot = parseLoadedModules(
+            """
+            {"adds":231,"subs":3,"modules":[
+              {"path":"/apex/com.android.runtime/lib64/bionic/libc.so","base":"0x7b0f440000",
+               "mapped_size":1052672,"phnum":8,"relro":true,"tls":true,"build_id":"1ab3ff90",
+               "segments":[{"flags":"r--","memsz":4096},{"flags":"r-x","memsz":1024000}]},
+              {"path":"/apex/com.android.art/lib64/libart.so","base":"0x7b1c2a0000",
+               "mapped_size":8912896,"phnum":9,"relro":true,"tls":false,"segments":[]}]}
+            """.trimIndent()
+        )
+
+        assertEquals(listOf("libart.so", "libc.so"), snapshot.modules.map { it.fileName })
+        assertEquals(231, snapshot.loadEvents)
+        assertEquals(3, snapshot.unloadEvents)
+        assertEquals(9_965_568L, snapshot.totalMappedSize)
+    }
+
+    @Test
+    fun splitsAPathIntoItsNameAndDirectory() {
+        val snapshot = parseLoadedModules(
+            """{"modules":[{"path":"/apex/com.android.art/lib64/libart.so","base":"0x1","mapped_size":1}]}"""
+        )
+
+        val module = snapshot.modules.single()
+        assertEquals("libart.so", module.fileName)
+        assertEquals("/apex/com.android.art/lib64", module.directory)
+        assertEquals(false, module.isMainExecutable)
+    }
+
+    @Test
+    fun theMainExecutableHasNoPath() {
+        val snapshot = parseLoadedModules("""{"modules":[{"path":"","base":"0x0","mapped_size":4096}]}""")
+
+        val module = snapshot.modules.single()
+        assertTrue(module.isMainExecutable)
+        assertEquals("", module.directory)
+    }
+
+    @Test
+    fun anObjectWithoutABuildIdReportsNoneRatherThanAnEmptyString() {
+        val snapshot = parseLoadedModules("""{"modules":[{"path":"/x/y.so","base":"0x1","mapped_size":1}]}""")
+
+        assertNull(snapshot.modules.single().buildId)
+    }
+
+    @Test
+    fun linkerEventCountsAreOptional() {
+        val snapshot = parseLoadedModules("""{"modules":[]}""")
+
+        assertNull(snapshot.loadEvents)
+        assertNull(snapshot.unloadEvents)
+    }
+}

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/ModuleParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/ModuleParsingTest.kt
@@ -13,10 +13,9 @@ class ModuleParsingTest {
             """
             {"adds":231,"subs":3,"modules":[
               {"path":"/apex/com.android.runtime/lib64/bionic/libc.so","base":"0x7b0f440000",
-               "mapped_size":1052672,"phnum":8,"relro":true,"tls":true,"build_id":"1ab3ff90",
-               "segments":[{"flags":"r--","memsz":4096},{"flags":"r-x","memsz":1024000}]},
+               "mapped_size":1052672,"segment_count":4,"relro":true,"tls":true,"build_id":"1ab3ff90"},
               {"path":"/apex/com.android.art/lib64/libart.so","base":"0x7b1c2a0000",
-               "mapped_size":8912896,"phnum":9,"relro":true,"tls":false,"segments":[]}]}
+               "mapped_size":8912896,"segment_count":5,"relro":true,"tls":false}]}
             """.trimIndent()
         )
 
@@ -24,6 +23,7 @@ class ModuleParsingTest {
         assertEquals(231, snapshot.loadEvents)
         assertEquals(3, snapshot.unloadEvents)
         assertEquals(9_965_568L, snapshot.totalMappedSize)
+        assertEquals(5, snapshot.modules.first().segmentCount)
     }
 
     @Test

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/MountParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/MountParsingTest.kt
@@ -1,0 +1,77 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MountParsingTest {
+
+    @Test
+    fun readsAMeasuredFilesystem() {
+        val mounts = parseMounts(
+            """
+            {"mounts":[{"source":"/dev/block/dm-9","target":"/data","fs_type":"f2fs",
+                        "options":"rw,nosuid,nodev,noatime","readonly":false,"statvfs_ok":true,
+                        "block_size":4096,"total_bytes":100,"free_bytes":40,"available_bytes":30,
+                        "inodes_total":1000,"inodes_free":900}]}
+            """.trimIndent()
+        )
+
+        val mount = mounts.single()
+        assertEquals("/data", mount.target)
+        assertEquals(60L, mount.usedBytes)
+        assertEquals(0.6f, mount.usedFraction)
+        assertTrue(mount.isRealFilesystem)
+        assertFalse(mount.readOnly)
+    }
+
+    @Test
+    fun aMountStatvfsRefusedKeepsItsIdentityAndLosesItsCapacity() {
+        val mounts = parseMounts(
+            """{"mounts":[{"source":"proc","target":"/proc","fs_type":"proc","options":"rw","readonly":false,"statvfs_ok":false}]}"""
+        )
+
+        val mount = mounts.single()
+        assertEquals("/proc", mount.target)
+        assertNull(mount.totalBytes)
+        assertNull(mount.usedBytes)
+        assertNull(mount.usedFraction)
+        assertFalse(mount.isRealFilesystem)
+    }
+
+    @Test
+    fun capacityIsIgnoredWhenTheCallDidNotSucceed() {
+        // Should the native side ever send sizes alongside a failed statvfs, they are not readings
+        // and must not reach the screen as though they were.
+        val mounts = parseMounts(
+            """{"mounts":[{"source":"x","target":"/x","fs_type":"f2fs","options":"rw","readonly":false,"statvfs_ok":false,"total_bytes":100,"free_bytes":40}]}"""
+        )
+
+        assertNull(mounts.single().totalBytes)
+    }
+
+    @Test
+    fun aFilesystemWithoutAnInodeTableReportsNoCount() {
+        // erofs and f2fs answer statvfs with every bit set rather than a count, so the native side
+        // omits the keys entirely. Nothing downstream may turn that into a number.
+        val mounts = parseMounts(
+            """{"mounts":[{"source":"/dev/block/dm-0","target":"/","fs_type":"erofs","options":"ro","readonly":true,"statvfs_ok":true,"total_bytes":100,"free_bytes":0}]}"""
+        )
+
+        val mount = mounts.single()
+        assertNull(mount.inodesTotal)
+        assertNull(mount.inodesFree)
+        assertEquals(100L, mount.totalBytes)
+    }
+
+    @Test
+    fun readOnlyMountsAreMarked() {
+        val mounts = parseMounts(
+            """{"mounts":[{"source":"/dev/block/dm-0","target":"/","fs_type":"erofs","options":"ro,seclabel","readonly":true,"statvfs_ok":false}]}"""
+        )
+
+        assertTrue(mounts.single().readOnly)
+    }
+}

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/MountParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/MountParsingTest.kt
@@ -14,7 +14,7 @@ class MountParsingTest {
             """
             {"mounts":[{"source":"/dev/block/dm-9","target":"/data","fs_type":"f2fs",
                         "options":"rw,nosuid,nodev,noatime","readonly":false,"statvfs_ok":true,
-                        "block_size":4096,"total_bytes":100,"free_bytes":40,"available_bytes":30,
+                        "total_bytes":100,"free_bytes":40,"available_bytes":30,
                         "inodes_total":1000,"inodes_free":900}]}
             """.trimIndent()
         )

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/MountParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/MountParsingTest.kt
@@ -67,6 +67,24 @@ class MountParsingTest {
     }
 
     @Test
+    fun aRefusedStatvfsSaysWhyItWasRefused() {
+        val mounts = parseMounts(
+            """{"mounts":[{"source":"proc","target":"/proc","fs_type":"proc","options":"rw","readonly":false,"statvfs_ok":false,"statvfs_unavailable":"denied"}]}"""
+        )
+
+        assertEquals(Unavailable.Denied, mounts.single().capacityUnavailable)
+    }
+
+    @Test
+    fun aMeasuredMountCarriesNoReason() {
+        val mounts = parseMounts(
+            """{"mounts":[{"source":"x","target":"/x","fs_type":"f2fs","options":"rw","readonly":false,"statvfs_ok":true,"total_bytes":100,"free_bytes":40}]}"""
+        )
+
+        assertNull(mounts.single().capacityUnavailable)
+    }
+
+    @Test
     fun readOnlyMountsAreMarked() {
         val mounts = parseMounts(
             """{"mounts":[{"source":"/dev/block/dm-0","target":"/","fs_type":"erofs","options":"ro,seclabel","readonly":true,"statvfs_ok":false}]}"""

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ activityCompose = "1.13.0"
 composeBom = "2026.06.01"
 nav3Core = "1.1.5"
 kotlinxSerializationCore = "1.11.0"
-orgJson = "20250107"
+orgJson = "20260719"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ activityCompose = "1.13.0"
 composeBom = "2026.06.01"
 nav3Core = "1.1.5"
 kotlinxSerializationCore = "1.11.0"
+orgJson = "20250107"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -34,6 +35,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
+org-json = { group = "org.json", name = "json", version.ref = "orgJson" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Four screens — CPU Cores, Memory Map, Loaded Libraries, Storage — reading sysfs, `/proc/self`,
`dl_iterate_phdr` and `statvfs` through JNI. All show real data on device, none falls back to
samples. 9 screens → 13.

**Fixed on the way**
- Every native screen was dead on 16 KB-page devices: the library was aligned for 4 KB, which
  Android 15 cannot map. The three existing ones had been silently serving sample data.
- 2,067 exported symbols where the runtime calls 10 — nearly all of static libc++, able to bind
  another library's `std::` calls to this copy. A version script cuts it to 10, and 1.6 MB.
- C++ exceptions could cross the JNI boundary, which Android's JNI guide forbids. All 10 entry
  points now contain them, and the `dl_iterate_phdr` callback is `noexcept`.
- The memory screen labelled its own measurements "Sample data".

**Toolchain**: NDK r27 → r29 (Clang 21), C++17 → C++23, CMake pinned at 3.31.6. `std::expected`
carries the errno behind a failed /proc read up to the UI — "the sandbox may not read it" rather
than just "not readable".

**Tests**: 29 unit, 13 instrumented; the latter run the collectors on device, which is the only
thing that catches a mistyped JNI symbol. Two caveats are recorded in the commits — the back-stack
guard fixes a crash whose trigger I could not reproduce, and the new reason path is vacuous on an
emulator that denies nothing.