### PR TITLE
refactor(ui): give each screen one subject, and add the two that were missing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
-    id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
+    alias(libs.plugins.ktlint)
 }
 
 ktlint {
@@ -57,12 +57,14 @@ android {
             )
         }
     }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
     buildFeatures {
         compose = true
+    }
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
+++ b/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
@@ -83,6 +83,21 @@ class NativeInspectorTest {
     }
 
     @Test
+    fun threadInspectorListsThisProcessesThreads() = runBlocking {
+        val snapshot = NativeThreadInspector().read()
+
+        assertNotNull("Thread list could not be read", snapshot)
+        assertTrue("No threads reported", snapshot!!.threads.isNotEmpty())
+        // The thread running the test is in its own list, and every Android process is scheduled
+        // with a USER_HZ the kernel reports.
+        assertTrue("No clock rate reported", snapshot.clockTicks > 0)
+        assertTrue(
+            "No thread reports a scheduling policy",
+            snapshot.threads.any { it.policy != SchedulerPolicy.Unknown }
+        )
+    }
+
+    @Test
     fun storageInspectorReadsTheMountTable() = runBlocking {
         val mounts = NativeStorageInspector().read()
 

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(
     memory_map.cpp
     elf_modules.cpp
     storage_info.cpp
+    thread_info.cpp
 )
 
 # The conversion warnings earn their place here: this code carries kernel counters — size_t,

--- a/app/src/main/cpp/native_util.cpp
+++ b/app/src/main/cpp/native_util.cpp
@@ -284,6 +284,13 @@ JsonWriter& JsonWriter::Value(uint64_t value) {
   return *this;
 }
 
+JsonWriter& JsonWriter::Value(int64_t value) {
+  Separate();
+  out_.append(std::to_string(value));
+  needs_comma_ = true;
+  return *this;
+}
+
 JsonWriter& JsonWriter::Value(bool value) {
   Separate();
   out_.append(value ? "true" : "false");
@@ -312,6 +319,10 @@ JsonWriter& JsonWriter::Field(std::string_view key, std::string_view value) {
 }
 
 JsonWriter& JsonWriter::Field(std::string_view key, uint64_t value) {
+  return Key(key).Value(value);
+}
+
+JsonWriter& JsonWriter::Field(std::string_view key, int64_t value) {
   return Key(key).Value(value);
 }
 

--- a/app/src/main/cpp/native_util.h
+++ b/app/src/main/cpp/native_util.h
@@ -83,6 +83,8 @@ class JsonWriter {
 
   JsonWriter& Value(std::string_view value);
   JsonWriter& Value(uint64_t value);
+  /** For counters the kernel reports signed — a thread's nice value runs from -20. */
+  JsonWriter& Value(int64_t value);
   JsonWriter& Value(bool value);
   /**
    * Keeps a C string a string.
@@ -94,6 +96,8 @@ class JsonWriter {
   JsonWriter& Value(const char* value);
   JsonWriter& Field(std::string_view key, std::string_view value);
   JsonWriter& Field(std::string_view key, uint64_t value);
+  /** See [Value(int64_t)]. */
+  JsonWriter& Field(std::string_view key, int64_t value);
   JsonWriter& Field(std::string_view key, bool value);
   /** See [Value(const char*)] — the same overload trap applies here. */
   JsonWriter& Field(std::string_view key, const char* value);

--- a/app/src/main/cpp/system_monitor.cpp
+++ b/app/src/main/cpp/system_monitor.cpp
@@ -66,35 +66,9 @@ Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getMemInfoNative(JNI
   });
 }
 
-// Function to get process information
-extern "C" JNIEXPORT jstring JNICALL
-Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getProcessInfoNative(JNIEnv* env,
-                                                                                 jobject /* this */,
-                                                                                 jint pid) {
-  return aoscm::ReturnJson(env, [pid] {
-    std::stringstream path;
-    path << "/proc/" << pid << "/status";
-
-    std::ifstream status_file(path.str());
-    std::string line;
-    std::stringstream result;
-
-    if (!status_file.is_open()) {
-      LOGE("Failed to open %s", path.str().c_str());
-      return std::string("Error: Process not found or permission denied");
-    }
-
-    // Read contents of the status file
-    while (std::getline(status_file, line)) {
-      result << line << "\n";
-    }
-
-    status_file.close();
-    LOGI("Read process info for PID: %d", pid);
-
-    return result.str();
-  });
-}
+// A getProcessInfoNative(pid) returning /proc/<pid>/status verbatim used to sit here.
+// memory_map.cpp reads the same file for this process and picks out the lines worth showing, so the
+// two readings reached the UI as two screens of the same counters. This one went; that one stayed.
 
 // Function to get network interface statistics
 extern "C" JNIEXPORT jstring JNICALL

--- a/app/src/main/cpp/thread_info.cpp
+++ b/app/src/main/cpp/thread_info.cpp
@@ -1,0 +1,261 @@
+#include <dirent.h>
+#include <jni.h>
+#include <sched.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <charconv>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+#include "native_util.h"
+
+namespace {
+
+using aoscm::JsonWriter;
+using aoscm::Reading;
+
+/** Closes the directory however the scope is left, exception included. */
+using TaskDir = std::unique_ptr<DIR, decltype([](DIR* dir) { closedir(dir); })>;
+
+// Offsets into /proc/<tid>/stat once the comm field and everything before it is dropped, so index 0
+// is `state`, which proc(5) numbers as field 3.
+constexpr size_t kStateField = 0;
+constexpr size_t kUtimeField = 11;
+constexpr size_t kStimeField = 12;
+constexpr size_t kPriorityField = 15;
+constexpr size_t kNiceField = 16;
+constexpr size_t kLastCpuField = 36;
+constexpr size_t kRtPriorityField = 37;
+
+/** What the kernel falls back to when sysconf cannot answer. Android has always set USER_HZ to 100.
+ */
+constexpr uint64_t kAssumedClockTicks = 100;
+
+template <typename T>
+std::optional<T> Number(std::string_view text) {
+  T value{};
+  const char* const first = text.data();
+  const char* const last = first + text.size();
+  const auto [end, error] = std::from_chars(first, last, value);
+  if (error != std::errc() || end != last) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+std::optional<std::string_view> FieldAt(const std::vector<std::string_view>& fields, size_t index) {
+  if (index >= fields.size()) {
+    return std::nullopt;
+  }
+  return fields[index];
+}
+
+/**
+ * Splits /proc/<tid>/stat after its comm field.
+ *
+ * comm is the thread name in parentheses and may contain spaces and parentheses of its own — a
+ * thread named "Chrome_IOThread (2)" is legal — so the split is made at the last ") " rather than
+ * by counting spaces from the left, which is the mistake this file exists not to repeat.
+ *
+ * The views point into `line`, which the caller keeps alive for as long as it reads them.
+ */
+std::vector<std::string_view> StatFieldsAfterComm(std::string_view line) {
+  const size_t comm_end = line.rfind(") ");
+  if (comm_end == std::string_view::npos) {
+    return {};
+  }
+
+  std::vector<std::string_view> fields;
+  size_t start = comm_end + 2;
+  while (start < line.size()) {
+    const size_t end = line.find(' ', start);
+    if (end == std::string_view::npos) {
+      fields.push_back(line.substr(start));
+      break;
+    }
+    fields.push_back(line.substr(start, end - start));
+    start = end + 1;
+  }
+  return fields;
+}
+
+/** The scheduling policy's name, as the SCHED_* constant it came back as. */
+const char* PolicyName(int policy) {
+  switch (policy) {
+    case SCHED_OTHER:
+      return "other";
+    case SCHED_FIFO:
+      return "fifo";
+    case SCHED_RR:
+      return "rr";
+    case SCHED_BATCH:
+      return "batch";
+    case SCHED_IDLE:
+      return "idle";
+#ifdef SCHED_DEADLINE
+    case SCHED_DEADLINE:
+      return "deadline";
+#endif
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * The set as a cpulist — "0-3,6" — which is the form the kernel itself uses in
+ * /proc/self/status's Cpus_allowed_list, and reads better than eight ones and zeros.
+ */
+std::string CpuList(const cpu_set_t& mask, int cpu_count) {
+  std::string list;
+  int run_start = -1;
+
+  // Runs to cpu_count inclusive so that a run reaching the last CPU is closed by the same branch
+  // as every other run, rather than needing a second copy of it after the loop.
+  for (int cpu = 0; cpu <= cpu_count; ++cpu) {
+    const bool allowed = cpu < cpu_count && CPU_ISSET(cpu, &mask);
+    if (allowed && run_start < 0) {
+      run_start = cpu;
+      continue;
+    }
+    if (!allowed && run_start >= 0) {
+      if (!list.empty()) {
+        list.push_back(',');
+      }
+      list.append(std::to_string(run_start));
+      if (cpu - 1 > run_start) {
+        list.push_back('-');
+        list.append(std::to_string(cpu - 1));
+      }
+      run_start = -1;
+    }
+  }
+  return list;
+}
+
+/**
+ * Which CPUs the task may run on.
+ *
+ * `sched_getaffinity` takes a thread id where it documents a pid, which is how a per-thread mask is
+ * asked for at all: Java has no equivalent, and /proc/<tid>/status reports the mask only for the
+ * process on some kernels.
+ */
+void WriteAffinity(JsonWriter* writer, pid_t task, int cpu_count) {
+  cpu_set_t mask;
+  CPU_ZERO(&mask);
+  if (sched_getaffinity(task, sizeof(mask), &mask) != 0) {
+    writer->Field("affinity_unavailable", aoscm::DescribeFailure(errno));
+    return;
+  }
+  writer->Field("affinity", CpuList(mask, cpu_count));
+  writer->Field("affinity_count", static_cast<uint64_t>(CPU_COUNT(&mask)));
+}
+
+void WriteSchedulerPolicy(JsonWriter* writer, pid_t task) {
+  const int policy = sched_getscheduler(task);
+  if (policy < 0) {
+    writer->Field("policy_unavailable", aoscm::DescribeFailure(errno));
+    return;
+  }
+  writer->Field("policy", PolicyName(policy));
+}
+
+void WriteThread(JsonWriter* writer, std::string_view tid_name, pid_t tid, int cpu_count) {
+  const std::string task = std::string("/proc/self/task/").append(tid_name);
+  const Reading<std::string> stat = aoscm::ReadTrimmedLine(task + "/stat");
+  if (!stat.has_value()) {
+    // The thread exited between listing the directory and reading it, which is ordinary: a thread
+    // that is gone has nothing to report and is left out rather than listed as a blank row.
+    return;
+  }
+  const std::vector<std::string_view> fields = StatFieldsAfterComm(*stat);
+
+  writer->BeginObject();
+  writer->Field("tid", static_cast<uint64_t>(tid));
+
+  // comm rather than the name inside stat: the same string, but without the parentheses and the
+  // escaping that a name containing one would need.
+  const Reading<std::string> name = aoscm::ReadTrimmedLine(task + "/comm");
+  writer->FieldIfSet("name", name);
+
+  if (const auto state = FieldAt(fields, kStateField)) {
+    writer->Field("state", *state);
+  }
+  if (const auto utime = FieldAt(fields, kUtimeField).and_then(Number<uint64_t>)) {
+    writer->Field("utime_ticks", *utime);
+  }
+  if (const auto stime = FieldAt(fields, kStimeField).and_then(Number<uint64_t>)) {
+    writer->Field("stime_ticks", *stime);
+  }
+  if (const auto priority = FieldAt(fields, kPriorityField).and_then(Number<int64_t>)) {
+    writer->Field("priority", *priority);
+  }
+  if (const auto nice = FieldAt(fields, kNiceField).and_then(Number<int64_t>)) {
+    writer->Field("nice", *nice);
+  }
+  if (const auto last_cpu = FieldAt(fields, kLastCpuField).and_then(Number<uint64_t>)) {
+    writer->Field("last_cpu", *last_cpu);
+  }
+  if (const auto rt_priority = FieldAt(fields, kRtPriorityField).and_then(Number<uint64_t>)) {
+    writer->Field("rt_priority", *rt_priority);
+  }
+
+  WriteSchedulerPolicy(writer, tid);
+  WriteAffinity(writer, tid, cpu_count);
+  writer->EndObject();
+}
+
+}  // namespace
+
+/**
+ * Every thread this process is running, with what the scheduler is doing with each.
+ *
+ * /proc/self/task is a process's own directory, so none of this can be refused the way the
+ * system-wide counters elsewhere in this library are. The scheduling policy and the CPU affinity
+ * come from `sched_getscheduler` and `sched_getaffinity`, which have no counterpart in the Java
+ * API at all — `Thread` exposes a priority that is a hint to the runtime, not the policy the
+ * kernel is actually scheduling the thread under.
+ */
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_aoscoremonitor_diagnostics_jni_NativeThreadInspector_getThreadsNative(JNIEnv* env,
+                                                                               jobject /* this */) {
+  return aoscm::ReturnJson(env, [] {
+    const long configured_cpus = sysconf(_SC_NPROCESSORS_CONF);
+    const int cpu_count =
+        configured_cpus > 0 ? static_cast<int>(std::min<long>(configured_cpus, CPU_SETSIZE)) : 1;
+    const long clock_ticks = sysconf(_SC_CLK_TCK);
+
+    JsonWriter writer;
+    writer.BeginObject();
+    writer.Field("clock_ticks",
+                 clock_ticks > 0 ? static_cast<uint64_t>(clock_ticks) : kAssumedClockTicks);
+    writer.Field("cpu_count", static_cast<uint64_t>(cpu_count));
+
+    // The process's own mask, which is the ceiling every thread's mask sits under. Written with the
+    // same keys as a thread's so that one parser reads both.
+    WriteAffinity(&writer, 0, cpu_count);
+
+    writer.Key("threads").BeginArray();
+    if (const TaskDir tasks{opendir("/proc/self/task")}) {
+      while (const dirent* entry = readdir(tasks.get())) {
+        const std::string_view name(entry->d_name);
+        const auto tid = Number<pid_t>(name);
+        if (!tid.has_value()) {
+          // "." and "..", which readdir reports alongside the thread ids.
+          continue;
+        }
+        WriteThread(&writer, name, *tid, cpu_count);
+      }
+    }
+    writer.EndArray();
+
+    writer.EndObject();
+    return writer.Take();
+  });
+}

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/HalInterfaceCollector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/HalInterfaceCollector.kt
@@ -28,9 +28,26 @@ class HalInterfaceCollector(private val context: Context, private val onUpdate: 
         val status: String
     )
 
-    data class HwService(val name: String, val server: String, val clients: List<String>)
+    /**
+     * One entry from `service list`: a name registered with servicemanager, and the interface
+     * descriptor it publishes.
+     *
+     * This used to carry `server` and `clients` as well. Neither came from the device: every entry
+     * was given `server = "system_server"` and the same two client packages, because `service list`
+     * reports neither. The screen presented them as readings. The descriptor below is what that
+     * command actually prints.
+     */
+    data class HwService(val name: String, val interfaceDescriptor: String)
 
-    data class VndkInfo(val version: String, val libraries: List<String>)
+    /**
+     * The VNDK version this build declares, if any.
+     *
+     * The library list that used to hang off this was a hard-coded set of five names — the same
+     * five whether or not the property was readable — with a fabricated "30" standing in for the
+     * version when `getprop` returned nothing. Both are gone: the libraries actually mapped into
+     * the process are the loaded-libraries screen's subject, and are read from the linker there.
+     */
+    data class VndkInfo(val version: String?)
 
     companion object {
         /**
@@ -77,26 +94,9 @@ class HalInterfaceCollector(private val context: Context, private val onUpdate: 
 
         /** Shown when `service list` produces nothing. */
         private val SAMPLE_HW_SERVICES = listOf(
-            HwService(
-                name = "SurfaceFlinger",
-                server = "surfaceflinger",
-                clients = listOf("system_server", "com.android.systemui")
-            ),
-            HwService(
-                name = "audio",
-                server = "audioserver",
-                clients = listOf("com.android.music", "com.spotify.music")
-            ),
-            HwService(
-                name = "camera",
-                server = "cameraserver",
-                clients = listOf("com.android.camera")
-            ),
-            HwService(
-                name = "power",
-                server = "system_server",
-                clients = listOf("com.android.systemui", "com.android.settings")
-            )
+            HwService(name = "SurfaceFlinger", interfaceDescriptor = "android.ui.ISurfaceComposer"),
+            HwService(name = "audio", interfaceDescriptor = "android.media.IAudioService"),
+            HwService(name = "power", interfaceDescriptor = "android.os.IPowerManager")
         )
     }
 
@@ -205,20 +205,15 @@ class HalInterfaceCollector(private val context: Context, private val onUpdate: 
             while (true) {
                 val line = reader.readLine() ?: break
                 if (line.contains(": [")) {
-                    // Parse service information
+                    // A line reads "12  power: [android.os.IPowerManager]", so the name is what
+                    // precedes the colon once its index is dropped, and the descriptor is what sits
+                    // in the brackets. The descriptor was parsed here before and then thrown away.
                     val parts = line.split(": [")
                     if (parts.size >= 2) {
-                        val serviceName = parts[0].trim()
-                        val serviceInfo = parts[1].replace("]", "").trim()
+                        val serviceName = parts[0].substringAfter('\t').trim()
+                        val descriptor = parts[1].substringBefore(']').trim()
 
-                        services.add(
-                            HwService(
-                                name = serviceName,
-                                // Most services run in system_server
-                                server = "system_server",
-                                clients = listOf("com.android.systemui", "com.android.settings")
-                            )
-                        )
+                        services.add(HwService(name = serviceName, interfaceDescriptor = descriptor))
                     }
                 }
             }
@@ -232,12 +227,16 @@ class HalInterfaceCollector(private val context: Context, private val onUpdate: 
         return services
     }
 
+    /**
+     * Reads `ro.vndk.version`, and reports nothing when it is unset.
+     *
+     * Unset is the normal answer on a current device — Android 15 removed the VNDK — so the screen
+     * says that rather than showing the "30" this used to substitute silently.
+     */
     private suspend fun collectVndkInfo(): VndkInfo {
-        var vndkVersion = "Unknown"
-        val libraries = mutableListOf<String>()
+        var vndkVersion: String? = null
 
         try {
-            // Get VNDK version
             val versionProcess = Runtime.getRuntime().exec("getprop ro.vndk.version")
             val versionReader = BufferedReader(InputStreamReader(versionProcess.inputStream))
             val version = versionReader.readLine()
@@ -246,42 +245,10 @@ class HalInterfaceCollector(private val context: Context, private val onUpdate: 
             }
             versionReader.close()
             versionProcess.destroy()
-
-            // List some VNDK libraries (would need root to actually list the directory)
-            if (vndkVersion != "Unknown") {
-                libraries.addAll(
-                    listOf(
-                        "libc++.so",
-                        "libhardware.so",
-                        "libhidlbase.so",
-                        "libutils.so",
-                        "libcutils.so"
-                    )
-                )
-            }
         } catch (e: Exception) {
             e.printStackTrace()
         }
 
-        // If no real data is available, provide example data
-        if (vndkVersion == "Unknown") {
-            vndkVersion = "30" // Example for Android 11
-            libraries.addAll(
-                listOf(
-                    "libc++.so",
-                    "libhardware.so",
-                    "libhidlbase.so",
-                    "libutils.so",
-                    "libcutils.so",
-                    "libui.so",
-                    "libgui.so"
-                )
-            )
-        }
-
-        return VndkInfo(
-            version = vndkVersion,
-            libraries = libraries
-        )
+        return VndkInfo(version = vndkVersion)
     }
 }

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/SensorInventory.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/SensorInventory.kt
@@ -88,6 +88,12 @@ fun sensorId(sensor: Sensor): String = "${sensor.type}:${sensor.name}"
  * be exercised off-device: the constants are compile-time integers, while every method on [Sensor]
  * needs a device to answer.
  */
+// TYPE_ORIENTATION and TYPE_TEMPERATURE are deprecated for apps to read, and named here anyway:
+// devices still publish both — an orientation sensor for apps written before rotation vectors, and a
+// temperature sensor on hardware predating TYPE_AMBIENT_TEMPERATURE — and this screen reports what a
+// device says it has. Leaving them out would not hide such a sensor, only file one the device really
+// carries under "Other" with no unit.
+@Suppress("DEPRECATION")
 fun sensorCategory(type: Int): SensorCategory = when (type) {
     Sensor.TYPE_ACCELEROMETER,
     Sensor.TYPE_ACCELEROMETER_UNCALIBRATED,
@@ -122,6 +128,8 @@ fun sensorCategory(type: Int): SensorCategory = when (type) {
  * The rotation vectors are the reason for the null rather than a "unit" of some kind: their values
  * are components of a unit quaternion and are not in anything.
  */
+// Deprecated types are named here for the reason given on [sensorCategory].
+@Suppress("DEPRECATION")
 fun sensorUnit(type: Int): SensorUnit? = when (type) {
     Sensor.TYPE_ACCELEROMETER,
     Sensor.TYPE_ACCELEROMETER_UNCALIBRATED,

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/SensorInventory.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/SensorInventory.kt
@@ -1,0 +1,159 @@
+package com.aoscoremonitor.diagnostics
+
+import android.hardware.Sensor
+import android.hardware.SensorManager
+
+/**
+ * One sensor the device reports, with what it says about itself.
+ *
+ * Everything here is metadata the platform publishes without a permission and without the sensor
+ * being switched on — the HAL's own description of the part. It is the one hardware inventory in
+ * this app that is measured rather than illustrated: the HAL screen's interface list comes from
+ * `lshal`, which an app may not run, and falls back to samples.
+ */
+data class SensorInfo(
+    val id: String,
+    val name: String,
+    val vendor: String,
+    val type: Int,
+    val stringType: String,
+    val version: Int,
+    val maximumRange: Float,
+    val resolution: Float,
+    val power: Float,
+    val minDelayUs: Int,
+    val maxDelayUs: Int,
+    val isWakeUp: Boolean,
+    val isDynamic: Boolean,
+    val reportingMode: Int
+) {
+    /** The fastest rate the sensor will report at, or null for one that reports only on change. */
+    val maxRateHz: Float? get() = if (minDelayUs > 0) MICROS_PER_SECOND / minDelayUs else null
+
+    private companion object {
+        const val MICROS_PER_SECOND = 1_000_000f
+    }
+}
+
+/** How the sensors are grouped on screen — by what they measure, not by the order the HAL lists them. */
+enum class SensorCategory {
+    Motion,
+    Position,
+    Environment,
+    Other
+}
+
+/** One reading, copied out of the event: the framework reuses the array it hands to the listener. */
+data class SensorReading(val values: List<Float>, val accuracy: Int, val timestampNanos: Long)
+
+/**
+ * Everything the device exposes, in the order the screen shows it.
+ *
+ * `TYPE_ALL` includes the dynamic sensors and the vendor-defined ones above the documented range,
+ * which is deliberate: what a device actually carries is the point of the screen.
+ */
+fun readSensorInventory(sensorManager: SensorManager?): List<SensorInfo> =
+    sensorManager?.getSensorList(Sensor.TYPE_ALL).orEmpty().map { sensor ->
+        SensorInfo(
+            id = sensorId(sensor),
+            name = sensor.name,
+            vendor = sensor.vendor,
+            type = sensor.type,
+            stringType = sensor.stringType.orEmpty(),
+            version = sensor.version,
+            maximumRange = sensor.maximumRange,
+            resolution = sensor.resolution,
+            power = sensor.power,
+            minDelayUs = sensor.minDelay,
+            maxDelayUs = sensor.maxDelay,
+            isWakeUp = sensor.isWakeUpSensor,
+            isDynamic = sensor.isDynamicSensor,
+            reportingMode = sensor.reportingMode
+        )
+    }
+
+/**
+ * A key for one sensor.
+ *
+ * Type and name together: a device may carry two sensors of the same type — an uncalibrated
+ * magnetometer alongside a calibrated one — so neither is a key on its own. Defined here so that
+ * the list and the view model that registers a listener agree on what identifies a row.
+ */
+fun sensorId(sensor: Sensor): String = "${sensor.type}:${sensor.name}"
+
+/**
+ * Which group a sensor belongs to.
+ *
+ * Kept as a function over the type constant rather than read from the sensor object so that it can
+ * be exercised off-device: the constants are compile-time integers, while every method on [Sensor]
+ * needs a device to answer.
+ */
+fun sensorCategory(type: Int): SensorCategory = when (type) {
+    Sensor.TYPE_ACCELEROMETER,
+    Sensor.TYPE_ACCELEROMETER_UNCALIBRATED,
+    Sensor.TYPE_GRAVITY,
+    Sensor.TYPE_GYROSCOPE,
+    Sensor.TYPE_GYROSCOPE_UNCALIBRATED,
+    Sensor.TYPE_LINEAR_ACCELERATION,
+    Sensor.TYPE_SIGNIFICANT_MOTION,
+    Sensor.TYPE_STEP_COUNTER,
+    Sensor.TYPE_STEP_DETECTOR -> SensorCategory.Motion
+
+    Sensor.TYPE_GAME_ROTATION_VECTOR,
+    Sensor.TYPE_GEOMAGNETIC_ROTATION_VECTOR,
+    Sensor.TYPE_MAGNETIC_FIELD,
+    Sensor.TYPE_MAGNETIC_FIELD_UNCALIBRATED,
+    Sensor.TYPE_ORIENTATION,
+    Sensor.TYPE_PROXIMITY,
+    Sensor.TYPE_ROTATION_VECTOR -> SensorCategory.Position
+
+    Sensor.TYPE_AMBIENT_TEMPERATURE,
+    Sensor.TYPE_LIGHT,
+    Sensor.TYPE_PRESSURE,
+    Sensor.TYPE_RELATIVE_HUMIDITY,
+    Sensor.TYPE_TEMPERATURE -> SensorCategory.Environment
+
+    else -> SensorCategory.Other
+}
+
+/**
+ * The unit a sensor's values are in, or null when the type has none to name.
+ *
+ * The rotation vectors are the reason for the null rather than a "unit" of some kind: their values
+ * are components of a unit quaternion and are not in anything.
+ */
+fun sensorUnit(type: Int): SensorUnit? = when (type) {
+    Sensor.TYPE_ACCELEROMETER,
+    Sensor.TYPE_ACCELEROMETER_UNCALIBRATED,
+    Sensor.TYPE_GRAVITY,
+    Sensor.TYPE_LINEAR_ACCELERATION -> SensorUnit.MetresPerSecondSquared
+
+    Sensor.TYPE_GYROSCOPE,
+    Sensor.TYPE_GYROSCOPE_UNCALIBRATED -> SensorUnit.RadiansPerSecond
+
+    Sensor.TYPE_MAGNETIC_FIELD,
+    Sensor.TYPE_MAGNETIC_FIELD_UNCALIBRATED -> SensorUnit.MicroTesla
+
+    Sensor.TYPE_LIGHT -> SensorUnit.Lux
+    Sensor.TYPE_PRESSURE -> SensorUnit.HectoPascal
+    Sensor.TYPE_PROXIMITY -> SensorUnit.Centimetres
+    Sensor.TYPE_RELATIVE_HUMIDITY -> SensorUnit.Percent
+    Sensor.TYPE_AMBIENT_TEMPERATURE, Sensor.TYPE_TEMPERATURE -> SensorUnit.Celsius
+    Sensor.TYPE_ORIENTATION -> SensorUnit.Degrees
+    Sensor.TYPE_STEP_COUNTER -> SensorUnit.Steps
+    else -> null
+}
+
+/** The units the sensor types above report in. Named here, worded in strings.xml. */
+enum class SensorUnit {
+    MetresPerSecondSquared,
+    RadiansPerSecond,
+    MicroTesla,
+    Lux,
+    HectoPascal,
+    Centimetres,
+    Percent,
+    Celsius,
+    Degrees,
+    Steps
+}

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/SystemDiagnosticsCollector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/SystemDiagnosticsCollector.kt
@@ -18,13 +18,12 @@ import kotlinx.coroutines.withContext
 class SystemDiagnosticsCollector(private val context: Context, private val onUpdate: (DiagnosticsInfo) -> Unit) {
     /**
      * Data class containing system diagnostic information.
+     *
+     * Available memory was here too, read from the same `ActivityManager.MemoryInfo.availMem` the
+     * system info collector reads a second earlier. Two collectors polling one API for one figure
+     * put the same number on two screens, so the figure lives on the system info screen alone now.
      */
-    data class DiagnosticsInfo(
-        val runningProcesses: List<String>,
-        val availableMemory: String,
-        val screenOn: Boolean,
-        val dumpsysResult: String
-    )
+    data class DiagnosticsInfo(val runningProcesses: List<String>, val screenOn: Boolean, val dumpsysResult: String)
 
     // Maintain CoroutineScope at class level
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -45,14 +44,10 @@ class SystemDiagnosticsCollector(private val context: Context, private val onUpd
 
                 while (isActive) {
                     // --- Get running process information from ActivityManager ---
+                    // Since Android 8 this returns the caller's own process and nothing else, which
+                    // is what the screen's heading and note now say.
                     val runningAppProcesses = activityManager.runningAppProcesses
                     val processNames = runningAppProcesses?.map { it.processName } ?: emptyList()
-
-                    // --- Get memory information from ActivityManager ---
-                    val memoryInfo = ActivityManager.MemoryInfo()
-                    activityManager.getMemoryInfo(memoryInfo)
-                    val availMemMB = memoryInfo.availMem / (1024 * 1024)
-                    val memoryStatus = "Available: $availMemMB MB"
 
                     // --- Get screen state from PowerManager ---
                     val screenOn = powerManager.isInteractive
@@ -63,7 +58,6 @@ class SystemDiagnosticsCollector(private val context: Context, private val onUpd
                     // --- Notify diagnostic information ---
                     val diagnosticsInfo = DiagnosticsInfo(
                         runningProcesses = processNames,
-                        availableMemory = memoryStatus,
                         screenOn = screenOn,
                         dumpsysResult = dumpsysResult
                     )

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeSystemMonitor.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeSystemMonitor.kt
@@ -23,7 +23,6 @@ class NativeSystemMonitor {
     // Native methods
     external fun getCpuInfoNative(): String
     external fun getMemInfoNative(): String
-    external fun getProcessInfoNative(pid: Int): String
     external fun getNetworkStatsNative(): String
     external fun getTcpConnectionsNative(): String
 
@@ -71,25 +70,9 @@ class NativeSystemMonitor {
         memInfo
     }
 
-    suspend fun getProcessInfo(pid: Int): Map<String, String> = withContext(Dispatchers.IO) {
-        val processInfo = mutableMapOf<String, String>()
-        if (!isLibraryAvailable) return@withContext processInfo
-        try {
-            val rawData = getProcessInfoNative(pid)
-            for (line in rawData.split("\n")) {
-                if (line.isBlank()) continue
-                val colonIndex = line.indexOf(':')
-                if (colonIndex > 0) {
-                    val key = line.substring(0, colonIndex).trim()
-                    val value = line.substring(colonIndex + 1).trim()
-                    processInfo[key] = value
-                }
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error parsing process info", e)
-        }
-        processInfo
-    }
+    // A getProcessInfo(pid) reading this process's /proc/self/status used to sit here. The memory
+    // map screen reads the same file through NativeMemoryInspector and shows a curated subset of
+    // it, so the two screens carried the same counters; this one went and that one stayed.
 
     data class InterfaceStats(
         val rxBytes: Long,

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeThreadInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeThreadInspector.kt
@@ -1,0 +1,173 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/**
+ * What a thread is doing, as the single letter /proc reports it.
+ *
+ * Kept as an enum rather than the letter itself so that the wording lives in strings.xml. A
+ * collector that returns "Sleeping" reads fine until the app is translated, at which point the
+ * screen is comparing against an English literal — a trap this codebase has already fallen into
+ * once, with the HAL screen's "Running".
+ */
+enum class ThreadState {
+    Running,
+    Sleeping,
+
+    /** Uninterruptible sleep, which on Android is nearly always a blocking read. */
+    DiskSleep,
+    Stopped,
+    TracingStop,
+    Zombie,
+    Idle,
+    Unknown;
+
+    internal companion object {
+        fun of(letter: String?): ThreadState = when (letter) {
+            "R" -> Running
+            "S" -> Sleeping
+            "D" -> DiskSleep
+            "T" -> Stopped
+            "t" -> TracingStop
+            "Z" -> Zombie
+            "I" -> Idle
+            else -> Unknown
+        }
+    }
+}
+
+/** Which scheduler the kernel is running the thread under. */
+enum class SchedulerPolicy {
+    Other,
+    Fifo,
+    RoundRobin,
+    Batch,
+    Idle,
+    Deadline,
+    Unknown;
+
+    /** Whether the thread is scheduled ahead of ordinary work, which is worth pointing out. */
+    val isRealTime: Boolean get() = this == Fifo || this == RoundRobin || this == Deadline
+
+    internal companion object {
+        fun of(name: String?): SchedulerPolicy = when (name) {
+            "other" -> Other
+            "fifo" -> Fifo
+            "rr" -> RoundRobin
+            "batch" -> Batch
+            "idle" -> Idle
+            "deadline" -> Deadline
+            else -> Unknown
+        }
+    }
+}
+
+/**
+ * One thread of this process.
+ *
+ * [cpuTicks] is cumulative since the thread started, not a rate: a rate needs two readings, and the
+ * total is the honest thing to show from one. [affinity] is a cpulist — "0-3,6" — in the form the
+ * kernel uses in /proc/self/status.
+ */
+data class ThreadInfo(
+    val tid: Int,
+    val name: String,
+    val state: ThreadState,
+    val userTicks: Long,
+    val systemTicks: Long,
+    val priority: Int? = null,
+    val nice: Int? = null,
+    val policy: SchedulerPolicy = SchedulerPolicy.Unknown,
+    val policyUnavailable: Unavailable? = null,
+    val realTimePriority: Int? = null,
+    val lastCpu: Int? = null,
+    val affinity: String? = null,
+    val affinityCount: Int? = null
+) {
+    val cpuTicks: Long get() = userTicks + systemTicks
+}
+
+/**
+ * The process's threads, and the scheduling ceiling they all sit under.
+ *
+ * [clockTicks] is USER_HZ, which is what turns the tick counts into milliseconds. It is read rather
+ * than assumed because it is a kernel build option; Android has always set it to 100, but a value
+ * this app derives every other figure from is not one to hard-code.
+ */
+data class ThreadSnapshot(
+    val threads: List<ThreadInfo> = emptyList(),
+    val clockTicks: Long = 0,
+    val cpuCount: Int = 0,
+    val processAffinity: String? = null,
+    val processAffinityCount: Int? = null
+) {
+    /** Milliseconds of CPU the thread has used since it started. */
+    fun cpuMillis(thread: ThreadInfo): Long = if (clockTicks > 0) thread.cpuTicks * MILLIS_PER_SECOND / clockTicks else 0
+
+    private companion object {
+        const val MILLIS_PER_SECOND = 1_000L
+    }
+}
+
+/**
+ * Reads this process's threads through JNI.
+ *
+ * The thread list itself could be read from Java, but nothing it holds could: `Thread.getPriority`
+ * is a hint to the runtime rather than the nice value the kernel scheduled with, and neither the
+ * scheduling policy nor the CPU affinity mask is exposed at all. Both come from `sched_*` calls
+ * that take a thread id.
+ */
+class NativeThreadInspector {
+
+    external fun getThreadsNative(): String
+
+    suspend fun read(): ThreadSnapshot? = withContext(Dispatchers.IO) {
+        if (!NativeLibrary.isAvailable) return@withContext null
+        try {
+            parseThreads(getThreadsNative())
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing thread list", e)
+            null
+        }
+    }
+
+    private companion object {
+        const val TAG = "NativeThreadInspector"
+    }
+}
+
+/** Kept apart from the JNI call so it can be exercised without a device. */
+internal fun parseThreads(json: String): ThreadSnapshot {
+    val root = JSONObject(json)
+
+    val threads = root.optJSONArray("threads")?.mapObjects { thread ->
+        ThreadInfo(
+            tid = thread.optInt("tid"),
+            name = thread.stringOrNull("name").orEmpty(),
+            state = ThreadState.of(thread.stringOrNull("state")),
+            userTicks = thread.optLong("utime_ticks"),
+            systemTicks = thread.optLong("stime_ticks"),
+            priority = thread.intOrNull("priority"),
+            nice = thread.intOrNull("nice"),
+            policy = SchedulerPolicy.of(thread.stringOrNull("policy")),
+            policyUnavailable = thread.unavailable("policy_unavailable"),
+            realTimePriority = thread.intOrNull("rt_priority"),
+            lastCpu = thread.intOrNull("last_cpu"),
+            affinity = thread.stringOrNull("affinity"),
+            affinityCount = thread.intOrNull("affinity_count")
+        )
+    }.orEmpty()
+
+    return ThreadSnapshot(
+        // Busiest first: a process has one thread worth looking at and twenty that are parked, and
+        // the kernel's own order is by thread id, which says nothing about which is which.
+        threads = threads.sortedByDescending { it.cpuTicks },
+        clockTicks = root.optLong("clock_ticks"),
+        cpuCount = root.optInt("cpu_count"),
+        processAffinity = root.stringOrNull("affinity"),
+        processAffinityCount = root.intOrNull("affinity_count")
+    )
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/components/ExpandableTextCard.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/components/ExpandableTextCard.kt
@@ -38,7 +38,14 @@ import com.aoscoremonitor.ui.theme.Spacing
  * neither short nor long output. Expanding in place removes the inner scroller entirely.
  */
 @Composable
-fun ExpandableTextCard(title: String, text: String, icon: ImageVector, modifier: Modifier = Modifier, collapsedLines: Int = 8) {
+fun ExpandableTextCard(
+    title: String,
+    text: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+    supportingText: String? = null,
+    collapsedLines: Int = 8
+) {
     var expanded by rememberSaveable(title) { mutableStateOf(false) }
     val canExpand = text.lineSequence().take(collapsedLines + 1).count() > collapsedLines
 
@@ -78,6 +85,17 @@ fun ExpandableTextCard(title: String, text: String, icon: ImageVector, modifier:
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
+            }
+            // Prose about the reading, in the body font rather than the machine one below: what
+            // limits a reading is not part of it. The diagnostics screen uses this to say that the
+            // platform will only ever report one process here.
+            if (supportingText != null) {
+                Text(
+                    text = supportingText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = Spacing.Small)
+                )
             }
             Spacer(modifier = Modifier.padding(top = Spacing.Small))
             Text(

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
@@ -3,6 +3,7 @@ package com.aoscoremonitor.ui.navigation
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.filled.AccountTree
 import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Cloud
@@ -13,6 +14,7 @@ import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.NetworkCell
 import androidx.compose.material.icons.filled.Security
+import androidx.compose.material.icons.filled.Sensors
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -101,6 +103,22 @@ sealed interface Destination : NavKey {
     }
 
     @Serializable
+    data object Sensors : Destination {
+        override val titleRes get() = R.string.sensors_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.Sensors
+    }
+
+    @Serializable
+    data object Threads : Destination {
+        override val titleRes get() = R.string.threads_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.AccountTree
+    }
+
+    @Serializable
     data object KernelCounters : Destination {
         override val titleRes get() = R.string.kernel_title
 
@@ -172,8 +190,10 @@ val HomeDestinations: List<Destination> = listOf(
     Destination.SecurityInfo,
     Destination.FrameworkAnalysis,
     Destination.HalInfo,
+    Destination.Sensors,
     Destination.KernelCounters,
     Destination.CpuCores,
+    Destination.Threads,
     Destination.MemoryMap,
     Destination.LoadedLibraries,
     Destination.StorageMounts,
@@ -192,6 +212,8 @@ val Destination.shortTitleRes: Int
         Destination.SecurityInfo -> R.string.destination_security
         Destination.FrameworkAnalysis -> R.string.destination_framework
         Destination.HalInfo -> R.string.destination_hal
+        Destination.Sensors -> R.string.destination_sensors
+        Destination.Threads -> R.string.destination_threads
         Destination.KernelCounters -> R.string.destination_kernel_counters
         Destination.NetworkStats -> R.string.destination_network_stats
         Destination.TcpConnections -> R.string.destination_tcp_connections

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
@@ -101,8 +101,8 @@ sealed interface Destination : NavKey {
     }
 
     @Serializable
-    data object NativeSystemMonitor : Destination {
-        override val titleRes get() = R.string.native_title
+    data object KernelCounters : Destination {
+        override val titleRes get() = R.string.kernel_title
 
         @Transient
         override val icon: ImageVector = Icons.Default.Memory
@@ -172,7 +172,7 @@ val HomeDestinations: List<Destination> = listOf(
     Destination.SecurityInfo,
     Destination.FrameworkAnalysis,
     Destination.HalInfo,
-    Destination.NativeSystemMonitor,
+    Destination.KernelCounters,
     Destination.CpuCores,
     Destination.MemoryMap,
     Destination.LoadedLibraries,
@@ -192,7 +192,7 @@ val Destination.shortTitleRes: Int
         Destination.SecurityInfo -> R.string.destination_security
         Destination.FrameworkAnalysis -> R.string.destination_framework
         Destination.HalInfo -> R.string.destination_hal
-        Destination.NativeSystemMonitor -> R.string.destination_native_monitor
+        Destination.KernelCounters -> R.string.destination_kernel_counters
         Destination.NetworkStats -> R.string.destination_network_stats
         Destination.TcpConnections -> R.string.destination_tcp_connections
         Destination.CpuCores -> R.string.destination_cpu_cores

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
@@ -16,9 +16,9 @@ import com.aoscoremonitor.ui.screens.SecurityInfoScreen
 import com.aoscoremonitor.ui.screens.SystemDiagnosticsScreen
 import com.aoscoremonitor.ui.screens.SystemInfoScreen
 import com.aoscoremonitor.ui.screens.jni.CpuCoresScreen
+import com.aoscoremonitor.ui.screens.jni.KernelCountersScreen
 import com.aoscoremonitor.ui.screens.jni.LoadedLibrariesScreen
 import com.aoscoremonitor.ui.screens.jni.MemoryMapScreen
-import com.aoscoremonitor.ui.screens.jni.NativeSystemMonitorScreen
 import com.aoscoremonitor.ui.screens.jni.NetworkStatsScreen
 import com.aoscoremonitor.ui.screens.jni.StorageMountsScreen
 import com.aoscoremonitor.ui.screens.jni.TcpConnectionsScreen
@@ -74,7 +74,7 @@ fun MonitorNavHost(modifier: Modifier = Modifier) {
                 entry<Destination.SecurityInfo> { SecurityInfoScreen(onNavigateBack = goBack) }
                 entry<Destination.FrameworkAnalysis> { FrameworkAnalysisScreen(onNavigateBack = goBack) }
                 entry<Destination.HalInfo> { HalInfoScreen(onNavigateBack = goBack) }
-                entry<Destination.NativeSystemMonitor> { NativeSystemMonitorScreen(onNavigateBack = goBack) }
+                entry<Destination.KernelCounters> { KernelCountersScreen(onNavigateBack = goBack) }
                 entry<Destination.NetworkStats> { NetworkStatsScreen(onNavigateBack = goBack) }
                 entry<Destination.TcpConnections> { TcpConnectionsScreen(onNavigateBack = goBack) }
                 entry<Destination.CpuCores> { CpuCoresScreen(onNavigateBack = goBack) }

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
@@ -13,6 +13,7 @@ import com.aoscoremonitor.ui.screens.HalInfoScreen
 import com.aoscoremonitor.ui.screens.HomeScreen
 import com.aoscoremonitor.ui.screens.LogScreen
 import com.aoscoremonitor.ui.screens.SecurityInfoScreen
+import com.aoscoremonitor.ui.screens.SensorsScreen
 import com.aoscoremonitor.ui.screens.SystemDiagnosticsScreen
 import com.aoscoremonitor.ui.screens.SystemInfoScreen
 import com.aoscoremonitor.ui.screens.jni.CpuCoresScreen
@@ -22,6 +23,7 @@ import com.aoscoremonitor.ui.screens.jni.MemoryMapScreen
 import com.aoscoremonitor.ui.screens.jni.NetworkStatsScreen
 import com.aoscoremonitor.ui.screens.jni.StorageMountsScreen
 import com.aoscoremonitor.ui.screens.jni.TcpConnectionsScreen
+import com.aoscoremonitor.ui.screens.jni.ThreadsScreen
 
 /**
  * The app's single navigation host.
@@ -74,6 +76,8 @@ fun MonitorNavHost(modifier: Modifier = Modifier) {
                 entry<Destination.SecurityInfo> { SecurityInfoScreen(onNavigateBack = goBack) }
                 entry<Destination.FrameworkAnalysis> { FrameworkAnalysisScreen(onNavigateBack = goBack) }
                 entry<Destination.HalInfo> { HalInfoScreen(onNavigateBack = goBack) }
+                entry<Destination.Sensors> { SensorsScreen(onNavigateBack = goBack) }
+                entry<Destination.Threads> { ThreadsScreen(onNavigateBack = goBack) }
                 entry<Destination.KernelCounters> { KernelCountersScreen(onNavigateBack = goBack) }
                 entry<Destination.NetworkStats> { NetworkStatsScreen(onNavigateBack = goBack) }
                 entry<Destination.TcpConnections> { TcpConnectionsScreen(onNavigateBack = goBack) }

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/HalInfoScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/HalInfoScreen.kt
@@ -36,7 +36,6 @@ import com.aoscoremonitor.ui.components.SectionHeader
 import com.aoscoremonitor.ui.components.StatusRow
 import com.aoscoremonitor.ui.components.TabContentList
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
-import com.aoscoremonitor.ui.theme.MonitorTypography
 import com.aoscoremonitor.ui.theme.Spacing
 import com.aoscoremonitor.ui.viewmodel.HalInfoViewModel
 import com.aoscoremonitor.ui.viewmodel.monitorViewModel
@@ -61,7 +60,9 @@ private fun HalInfoContent(halData: HalInterfaceCollector.HalData, onNavigateBac
     val tabs = listOf(
         MonitorTab(stringResource(R.string.hal_tab_interfaces), Icons.Default.Hardware, halData.halInterfaces.value.size),
         MonitorTab(stringResource(R.string.hal_tab_services), Icons.Default.Devices, halData.hwServices.value.size),
-        MonitorTab(stringResource(R.string.hal_tab_vndk), Icons.Default.Memory, halData.vndkInfo.libraries.size)
+        // No count: the tab holds one property, not a list. It used to be badged with the length of
+        // a hard-coded library list, so the badge said "5" on every device.
+        MonitorTab(stringResource(R.string.hal_tab_vndk), Icons.Default.Memory)
     )
     val pagerState = rememberPagerState(pageCount = { tabs.size })
 
@@ -147,11 +148,10 @@ private fun HwServicesTab(collected: Collected<List<HalInterfaceCollector.HwServ
             items(services, key = { it.name }) { service ->
                 MonitorCard {
                     Text(text = service.name, style = MaterialTheme.typography.titleMedium)
-                    LabeledValue(stringResource(R.string.hal_service_server), service.server)
                     LabeledValue(
-                        label = stringResource(R.string.hal_service_clients),
-                        value = service.clients.joinToString("\n")
-                            .ifEmpty { stringResource(R.string.hal_service_no_clients) }
+                        label = stringResource(R.string.hal_service_interface),
+                        value = service.interfaceDescriptor
+                            .ifEmpty { stringResource(R.string.hal_service_no_interface) }
                     )
                 }
             }
@@ -171,8 +171,13 @@ private fun VndkInfoTab(vndkInfo: HalInterfaceCollector.VndkInfo, modifier: Modi
         }
         item(key = "version") {
             MonitorCard {
+                val version = vndkInfo.version
                 Text(
-                    text = stringResource(R.string.hal_vndk_version, vndkInfo.version),
+                    text = if (version != null) {
+                        stringResource(R.string.hal_vndk_version, version)
+                    } else {
+                        stringResource(R.string.hal_vndk_unset)
+                    },
                     style = MaterialTheme.typography.titleMedium
                 )
                 Text(
@@ -182,23 +187,17 @@ private fun VndkInfoTab(vndkInfo: HalInterfaceCollector.VndkInfo, modifier: Modi
                 )
             }
         }
-        item(key = "libraries-header") {
-            SectionHeader(title = stringResource(R.string.hal_vndk_libraries))
-        }
-        if (vndkInfo.libraries.isEmpty()) {
-            item(key = "empty") { EmptyState(stringResource(R.string.hal_vndk_empty)) }
-        } else {
-            // A library name is one line of text; a card each turned the list into a wall of
-            // rounded rectangles, so they are plain rows now.
-            items(vndkInfo.libraries, key = { it }) { library ->
-                Text(
-                    text = library,
-                    style = MonitorTypography.machineText,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = Spacing.ExtraSmall)
-                )
-            }
+        // The list of library names that stood here was hard-coded, and named files this app never
+        // read. What is genuinely mapped into the process is on the native libraries screen.
+        item(key = "libraries-hint") {
+            Text(
+                text = stringResource(R.string.hal_vndk_libraries_hint),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = Spacing.Small)
+            )
         }
     }
 }
@@ -241,7 +240,7 @@ private fun HalInfoPreview() {
                     )
                 ),
                 hwServices = Collected.real(emptyList()),
-                vndkInfo = HalInterfaceCollector.VndkInfo(version = "36", libraries = listOf("libbase.so", "libcutils.so"))
+                vndkInfo = HalInterfaceCollector.VndkInfo(version = "36")
             ),
             onNavigateBack = {}
         )

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -39,6 +40,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -159,19 +161,32 @@ private fun DestinationTile(destination: Destination, index: Int, onClick: () ->
                         )
                     }
                 }
-                Text(
-                    text = stringResource(destination.shortTitleRes),
-                    style = MaterialTheme.typography.titleSmall,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier.padding(top = Spacing.Small),
-                    // Shrink to fit so long single words like "Diagnostics" are not broken
-                    // mid-word by the tile's width.
-                    maxLines = 2,
-                    autoSize = TextAutoSize.StepBased(
-                        minFontSize = 10.sp,
-                        maxFontSize = MaterialTheme.typography.titleSmall.fontSize
+                // Two lines of room whether the label needs them or not. The column centres what it
+                // holds, so a label that wrapped made the content taller and pushed the icon up —
+                // "Kernel Counters" and "Native Libraries" sat a line above the tiles beside them.
+                //
+                // The label is centred in that room rather than laid at the top of it, which is
+                // what `minLines = 2` would do: that fixed the icons but left a line-high hole
+                // under every short label. Room measured from the style's line height, so it grows
+                // with the user's font scale instead of being pinned to a dp constant.
+                val labelStyle = MaterialTheme.typography.titleSmall
+                val labelHeight = with(LocalDensity.current) { labelStyle.lineHeight.toDp() * 2 }
+                Box(
+                    modifier = Modifier
+                        .padding(top = Spacing.Small)
+                        .height(labelHeight),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = stringResource(destination.shortTitleRes),
+                        style = labelStyle,
+                        textAlign = TextAlign.Center,
+                        // Shrink to fit so long single words like "Diagnostics" are not broken
+                        // mid-word by the tile's width.
+                        maxLines = 2,
+                        autoSize = TextAutoSize.StepBased(minFontSize = 10.sp, maxFontSize = labelStyle.fontSize)
                     )
-                )
+                }
             }
         }
     }

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/HomeScreen.kt
@@ -199,7 +199,7 @@ private val IconSize = 24.dp
 private const val STAGGER_STEP_MS = 35L
 
 /** One less than the number of tiles, so the last one still arrives after the one before it. */
-private const val MAX_STAGGER_STEPS = 12
+private const val MAX_STAGGER_STEPS = 14
 
 @Preview(name = "Home", showBackground = true)
 @Preview(name = "Home (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/SensorsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/SensorsScreen.kt
@@ -1,0 +1,363 @@
+package com.aoscoremonitor.ui.screens
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Air
+import androidx.compose.material.icons.filled.Explore
+import androidx.compose.material.icons.filled.Sensors
+import androidx.compose.material.icons.filled.Vibration
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.SensorCategory
+import com.aoscoremonitor.diagnostics.SensorInfo
+import com.aoscoremonitor.diagnostics.SensorReading
+import com.aoscoremonitor.diagnostics.SensorUnit
+import com.aoscoremonitor.diagnostics.sensorCategory
+import com.aoscoremonitor.diagnostics.sensorUnit
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.LabeledValue
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.MonitorTypography
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.SensorsUiState
+import com.aoscoremonitor.ui.viewmodel.SensorsViewModel
+import com.aoscoremonitor.ui.viewmodel.monitorViewModel
+
+@Composable
+fun SensorsScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: SensorsViewModel = monitorViewModel { SensorsViewModel(it) }
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    SensorsContent(
+        uiState = uiState,
+        onSensorClick = viewModel::toggle,
+        onNavigateBack = onNavigateBack,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun SensorsContent(
+    uiState: SensorsUiState,
+    onSensorClick: (String) -> Unit,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    MonitorScaffold(
+        title = stringResource(R.string.sensors_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier
+    ) { innerPadding ->
+        if (uiState.sensors.isEmpty()) {
+            FullScreenMessage(
+                message = stringResource(if (uiState.hasLoaded) R.string.sensors_empty else R.string.sensors_loading),
+                icon = Icons.Default.Sensors,
+                supportingText = stringResource(R.string.sensors_empty_hint).takeIf { uiState.hasLoaded },
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        // Grouped once here rather than filtered per section, so a type this app has not heard of
+        // still appears — under Other — instead of being dropped by four filters that miss it.
+        val grouped = uiState.sensors.groupBy { sensorCategory(it.type) }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            item(key = "subtitle") {
+                Text(
+                    text = stringResource(R.string.sensors_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = Spacing.Small)
+                )
+            }
+            SensorCategory.entries.forEach { category ->
+                val sensors = grouped[category].orEmpty()
+                if (sensors.isNotEmpty()) {
+                    categorySection(
+                        category = category,
+                        sensors = sensors,
+                        uiState = uiState,
+                        onSensorClick = onSensorClick
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun LazyListScope.categorySection(
+    category: SensorCategory,
+    sensors: List<SensorInfo>,
+    uiState: SensorsUiState,
+    onSensorClick: (String) -> Unit
+) {
+    item(key = "${category.name}-header") {
+        SectionHeader(title = stringResource(category.labelRes), icon = category.icon)
+    }
+    items(sensors, key = { sensor -> sensor.id }) { sensor ->
+        SensorCard(
+            sensor = sensor,
+            reading = uiState.reading.takeIf { uiState.selectedId == sensor.id },
+            selected = uiState.selectedId == sensor.id,
+            onClick = { onSensorClick(sensor.id) }
+        )
+    }
+}
+
+/**
+ * One sensor, with its live values while it is the open one.
+ *
+ * Only the open sensor is registered — see [SensorsViewModel] — which is why this is a card the
+ * user opens rather than a list that streams everything at once.
+ */
+@Composable
+private fun SensorCard(sensor: SensorInfo, reading: SensorReading?, selected: Boolean, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier.clickable(onClick = onClick)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = sensor.name,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(end = Spacing.Small)
+            )
+            if (sensor.isWakeUp) SensorTag(stringResource(R.string.sensors_wakeup))
+        }
+
+        Text(
+            text = sensor.vendor,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Text(
+            text = sensor.stringType,
+            style = MonitorTypography.machineText,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        val unit = sensorUnit(sensor.type)?.let { stringResource(it.labelRes) }
+        LabeledValue(
+            label = stringResource(R.string.sensors_resolution),
+            value = formatValue(sensor.resolution, unit)
+        )
+        LabeledValue(
+            label = stringResource(R.string.sensors_range),
+            value = formatValue(sensor.maximumRange, unit)
+        )
+        LabeledValue(
+            label = stringResource(R.string.sensors_power),
+            value = stringResource(R.string.sensors_milliamps, sensor.power)
+        )
+        sensor.maxRateHz?.let {
+            LabeledValue(label = stringResource(R.string.sensors_max_rate), value = stringResource(R.string.sensors_hertz, it))
+        }
+
+        if (selected) {
+            HorizontalDivider(modifier = Modifier.padding(vertical = Spacing.Small))
+            if (reading == null) {
+                Text(
+                    // An on-change sensor reports when it changes and not before: proximity can sit
+                    // here for as long as nothing passes the phone.
+                    text = stringResource(R.string.sensors_waiting),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                reading.values.forEachIndexed { index, value ->
+                    LabeledValue(
+                        label = axisLabel(index, reading.values.size),
+                        value = formatValue(value, unit),
+                        valueStyle = MonitorTypography.machineText
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.sensors_accuracy, stringResource(accuracyLabel(reading.accuracy))),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        } else {
+            Text(
+                text = stringResource(R.string.sensors_tap_to_read),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(top = Spacing.ExtraSmall)
+            )
+        }
+    }
+}
+
+@Composable
+private fun SensorTag(text: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(percent = 50),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            maxLines = 1,
+            modifier = Modifier.padding(horizontal = Spacing.Medium, vertical = Spacing.ExtraSmall)
+        )
+    }
+}
+
+/** Three values from a sensor are axes; anything else is numbered, because it is not for us to say. */
+@Composable
+private fun axisLabel(index: Int, count: Int): String = when {
+    count == 1 -> stringResource(R.string.sensors_value)
+    count == 3 -> AXES[index]
+    else -> stringResource(R.string.sensors_value_indexed, index)
+}
+
+@Composable
+private fun formatValue(value: Float, unit: String?): String =
+    if (unit == null) FORMAT.format(value) else stringResource(R.string.sensors_value_with_unit, FORMAT.format(value), unit)
+
+private val SensorCategory.labelRes: Int
+    @StringRes
+    get() = when (this) {
+        SensorCategory.Motion -> R.string.sensors_category_motion
+        SensorCategory.Position -> R.string.sensors_category_position
+        SensorCategory.Environment -> R.string.sensors_category_environment
+        SensorCategory.Other -> R.string.sensors_category_other
+    }
+
+private val SensorCategory.icon: ImageVector
+    get() = when (this) {
+        SensorCategory.Motion -> Icons.Default.Vibration
+        SensorCategory.Position -> Icons.Default.Explore
+        SensorCategory.Environment -> Icons.Default.Air
+        SensorCategory.Other -> Icons.Default.Sensors
+    }
+
+private val SensorUnit.labelRes: Int
+    @StringRes
+    get() = when (this) {
+        SensorUnit.MetresPerSecondSquared -> R.string.sensors_unit_acceleration
+        SensorUnit.RadiansPerSecond -> R.string.sensors_unit_angular_rate
+        SensorUnit.MicroTesla -> R.string.sensors_unit_magnetic
+        SensorUnit.Lux -> R.string.sensors_unit_lux
+        SensorUnit.HectoPascal -> R.string.sensors_unit_pressure
+        SensorUnit.Centimetres -> R.string.sensors_unit_centimetres
+        SensorUnit.Percent -> R.string.sensors_unit_percent
+        SensorUnit.Celsius -> R.string.sensors_unit_celsius
+        SensorUnit.Degrees -> R.string.sensors_unit_degrees
+        SensorUnit.Steps -> R.string.sensors_unit_steps
+    }
+
+@StringRes
+private fun accuracyLabel(accuracy: Int): Int = when (accuracy) {
+    android.hardware.SensorManager.SENSOR_STATUS_ACCURACY_HIGH -> R.string.sensors_accuracy_high
+    android.hardware.SensorManager.SENSOR_STATUS_ACCURACY_MEDIUM -> R.string.sensors_accuracy_medium
+    android.hardware.SensorManager.SENSOR_STATUS_ACCURACY_LOW -> R.string.sensors_accuracy_low
+    android.hardware.SensorManager.SENSOR_STATUS_NO_CONTACT -> R.string.sensors_accuracy_no_contact
+    else -> R.string.sensors_accuracy_unreliable
+}
+
+private val AXES = listOf("x", "y", "z")
+
+/**
+ * Three decimals for every reading.
+ *
+ * A gyroscope at rest reads in thousandths and a light sensor in hundreds, so a format that suits
+ * both has to be fixed rather than significant-figure based.
+ */
+private val FORMAT = java.text.DecimalFormat("#,##0.###")
+
+@Preview(name = "Sensors", showBackground = true)
+@Preview(name = "Sensors (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun SensorsPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        SensorsContent(
+            uiState = SensorsUiState(
+                sensors = listOf(
+                    SensorInfo(
+                        id = "1:LSM6DSO Accelerometer",
+                        name = "LSM6DSO Accelerometer",
+                        vendor = "STMicroelectronics",
+                        type = 1,
+                        stringType = "android.sensor.accelerometer",
+                        version = 1,
+                        maximumRange = 78.4532f,
+                        resolution = 0.0023956f,
+                        power = 0.17f,
+                        minDelayUs = 2404,
+                        maxDelayUs = 200000,
+                        isWakeUp = false,
+                        isDynamic = false,
+                        reportingMode = 0
+                    ),
+                    SensorInfo(
+                        id = "5:TSL2591 Light",
+                        name = "TSL2591 Light",
+                        vendor = "AMS",
+                        type = 5,
+                        stringType = "android.sensor.light",
+                        version = 1,
+                        maximumRange = 40000f,
+                        resolution = 1f,
+                        power = 0.75f,
+                        minDelayUs = 0,
+                        maxDelayUs = 0,
+                        isWakeUp = true,
+                        isDynamic = false,
+                        reportingMode = 1
+                    )
+                ),
+                hasLoaded = true,
+                selectedId = "1:LSM6DSO Accelerometer",
+                reading = SensorReading(listOf(0.0316f, 9.7812f, 0.1435f), 3, 0)
+            ),
+            onSensorClick = {},
+            onNavigateBack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/SystemDiagnosticsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/SystemDiagnosticsScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
-import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -60,13 +59,6 @@ private fun SystemDiagnosticsContent(
             contentPadding = PaddingValues(Spacing.Large),
             verticalArrangement = Arrangement.spacedBy(Spacing.Medium)
         ) {
-            item(key = "memory") {
-                InfoCard(
-                    title = stringResource(R.string.diagnostics_memory),
-                    value = diagnostics.availableMemory,
-                    icon = Icons.Default.Memory
-                )
-            }
             item(key = "screen") {
                 InfoCard(
                     title = stringResource(R.string.diagnostics_screen_state),
@@ -83,7 +75,10 @@ private fun SystemDiagnosticsContent(
                     title = stringResource(R.string.diagnostics_running_processes),
                     text = diagnostics.runningProcesses.joinToString("\n")
                         .ifEmpty { stringResource(R.string.diagnostics_no_processes) },
-                    icon = Icons.AutoMirrored.Filled.List
+                    icon = Icons.AutoMirrored.Filled.List,
+                    // The heading used to read "Running Processes" over a list that the platform
+                    // has limited to one entry since Android 8 — this app's own process.
+                    supportingText = stringResource(R.string.diagnostics_processes_notice)
                 )
             }
             item(key = "dumpsys") {
@@ -105,8 +100,7 @@ private fun SystemDiagnosticsPreview() {
     AOSCoreMonitorTheme(dynamicColor = false) {
         SystemDiagnosticsContent(
             diagnostics = SystemDiagnosticsCollector.DiagnosticsInfo(
-                runningProcesses = listOf("com.android.systemui", "com.google.android.gms", "com.aoscoremonitor"),
-                availableMemory = "1686 MB available",
+                runningProcesses = listOf("com.aoscoremonitor"),
                 screenOn = true,
                 dumpsysResult = "Applications Memory Usage (in Kilobytes):\nUptime: 843211 Realtime: 843211"
             ),

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/KernelCountersScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/KernelCountersScreen.kt
@@ -9,7 +9,8 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.Widgets
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -26,53 +27,41 @@ import com.aoscoremonitor.ui.components.MonitorScaffold
 import com.aoscoremonitor.ui.components.SectionHeader
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
 import com.aoscoremonitor.ui.theme.Spacing
-import com.aoscoremonitor.ui.viewmodel.NativeSystemMonitorUiState
-import com.aoscoremonitor.ui.viewmodel.NativeSystemMonitorViewModel
+import com.aoscoremonitor.ui.viewmodel.KernelCountersUiState
+import com.aoscoremonitor.ui.viewmodel.KernelCountersViewModel
 
 @Composable
-fun NativeSystemMonitorScreen(
-    onNavigateBack: () -> Unit,
-    modifier: Modifier = Modifier,
-    viewModel: NativeSystemMonitorViewModel = viewModel()
-) {
+fun KernelCountersScreen(onNavigateBack: () -> Unit, modifier: Modifier = Modifier, viewModel: KernelCountersViewModel = viewModel()) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
-    NativeSystemMonitorContent(uiState = uiState, onNavigateBack = onNavigateBack, modifier = modifier)
+    KernelCountersContent(uiState = uiState, onNavigateBack = onNavigateBack, modifier = modifier)
 }
 
 @Composable
-private fun NativeSystemMonitorContent(uiState: NativeSystemMonitorUiState, onNavigateBack: () -> Unit, modifier: Modifier = Modifier) {
+private fun KernelCountersContent(uiState: KernelCountersUiState, onNavigateBack: () -> Unit, modifier: Modifier = Modifier) {
     // Resolved before the list is built: a LazyListScope lambda is not a composable context, so
     // stringResource cannot be called inside it.
     val sections = listOf(
         CounterSection(
             key = "cpu",
-            title = stringResource(R.string.native_cpu_section),
-            subtitle = stringResource(R.string.native_cpu_subtitle),
+            title = stringResource(R.string.kernel_cpu_section),
+            subtitle = stringResource(R.string.kernel_cpu_subtitle),
             icon = Icons.Default.Speed,
             readings = uiState.cpu.mapValues { (_, value) -> value.toString() },
-            emptyMessage = stringResource(R.string.native_cpu_unavailable)
+            emptyMessage = stringResource(R.string.kernel_cpu_unavailable)
         ),
         CounterSection(
             key = "memory",
-            title = stringResource(R.string.native_memory_section),
-            subtitle = stringResource(R.string.native_memory_subtitle),
+            title = stringResource(R.string.kernel_memory_section),
+            subtitle = stringResource(R.string.kernel_memory_subtitle),
             icon = Icons.Default.Memory,
-            readings = uiState.memory.mapValues { (_, value) -> stringResource(R.string.native_kilobytes, value) },
-            emptyMessage = stringResource(R.string.native_memory_unavailable)
-        ),
-        CounterSection(
-            key = "process",
-            title = stringResource(R.string.native_process_section),
-            subtitle = stringResource(R.string.native_process_subtitle),
-            icon = Icons.Default.Widgets,
-            readings = uiState.process,
-            emptyMessage = stringResource(R.string.native_process_unavailable)
+            readings = uiState.memory.mapValues { (_, value) -> stringResource(R.string.kernel_kilobytes, value) },
+            emptyMessage = stringResource(R.string.kernel_memory_unavailable)
         )
     )
 
     MonitorScaffold(
-        title = stringResource(R.string.native_title),
+        title = stringResource(R.string.kernel_title),
         onNavigateBack = onNavigateBack,
         modifier = modifier
     ) { innerPadding ->
@@ -83,6 +72,16 @@ private fun NativeSystemMonitorContent(uiState: NativeSystemMonitorUiState, onNa
             contentPadding = PaddingValues(Spacing.Large),
             verticalArrangement = Arrangement.spacedBy(Spacing.Small)
         ) {
+            // These counters are the raw form of what System Info summarises, so the screen says
+            // where its readings sit relative to the other two that touch the same files.
+            item(key = "subtitle") {
+                Text(
+                    text = stringResource(R.string.kernel_subtitle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = Spacing.Small)
+                )
+            }
             // Each group was a bold Text followed by a run of "key: value" strings, which left no
             // boundary between one group's last reading and the next group's heading.
             sections.forEach { section -> counterSection(section) }
@@ -117,16 +116,15 @@ private fun LazyListScope.counterSection(section: CounterSection) {
     }
 }
 
-@Preview(name = "Native monitor", showBackground = true)
-@Preview(name = "Native monitor (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "Kernel counters", showBackground = true)
+@Preview(name = "Kernel counters (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
 @Composable
-private fun NativeSystemMonitorPreview() {
+private fun KernelCountersPreview() {
     AOSCoreMonitorTheme(dynamicColor = false) {
-        NativeSystemMonitorContent(
-            uiState = NativeSystemMonitorUiState(
+        KernelCountersContent(
+            uiState = KernelCountersUiState(
                 cpu = emptyMap(),
-                memory = mapOf("MemTotal" to 2_027_136L, "MemAvailable" to 1_204_992L),
-                process = mapOf("Name" to "com.aoscoremonitor", "VmRSS" to "94112 kB")
+                memory = mapOf("MemTotal" to 2_027_136L, "MemAvailable" to 1_204_992L)
             ),
             onNavigateBack = {}
         )

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/ThreadsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/ThreadsScreen.kt
@@ -1,0 +1,289 @@
+package com.aoscoremonitor.ui.screens.jni
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.jni.SchedulerPolicy
+import com.aoscoremonitor.diagnostics.jni.ThreadInfo
+import com.aoscoremonitor.diagnostics.jni.ThreadSnapshot
+import com.aoscoremonitor.diagnostics.jni.ThreadState
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.LabeledValue
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.MonitorTypography
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.ThreadsUiState
+import com.aoscoremonitor.ui.viewmodel.ThreadsViewModel
+
+@Composable
+fun ThreadsScreen(onNavigateBack: () -> Unit, modifier: Modifier = Modifier, viewModel: ThreadsViewModel = viewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    ThreadsContent(uiState = uiState, onNavigateBack = onNavigateBack, modifier = modifier)
+}
+
+@Composable
+private fun ThreadsContent(uiState: ThreadsUiState, onNavigateBack: () -> Unit, modifier: Modifier = Modifier) {
+    MonitorScaffold(
+        title = stringResource(R.string.threads_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier
+    ) { innerPadding ->
+        val snapshot = uiState.snapshot
+        if (snapshot == null || snapshot.threads.isEmpty()) {
+            FullScreenMessage(
+                message = stringResource(if (uiState.hasLoaded) R.string.threads_unavailable else R.string.threads_loading),
+                icon = Icons.Default.AccountTree,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            item(key = "summary-header") {
+                SectionHeader(
+                    title = stringResource(R.string.threads_summary_section),
+                    subtitle = pluralStringResource(
+                        R.plurals.threads_summary,
+                        snapshot.threads.size,
+                        snapshot.threads.size
+                    ),
+                    icon = Icons.Default.AccountTree
+                )
+            }
+            item(key = "summary") { SummaryCard(snapshot) }
+
+            item(key = "threads-header") {
+                SectionHeader(
+                    title = stringResource(R.string.threads_section),
+                    subtitle = stringResource(R.string.threads_subtitle),
+                    icon = Icons.Default.Schedule
+                )
+            }
+            items(snapshot.threads, key = { thread -> thread.tid }) { thread ->
+                ThreadCard(thread = thread, snapshot = snapshot)
+            }
+        }
+    }
+}
+
+/**
+ * What every thread here shares.
+ *
+ * Deliberately not a second copy of the CPU screen's core count: what belongs here is the mask this
+ * process was given, which is a scheduling fact about the process rather than a fact about the CPU.
+ */
+@Composable
+private fun SummaryCard(snapshot: ThreadSnapshot, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        val realTime = snapshot.threads.count { it.policy.isRealTime }
+        LabeledValue(
+            label = stringResource(R.string.threads_allowed_cpus),
+            value = snapshot.processAffinity?.takeIf { it.isNotEmpty() }
+                ?: stringResource(R.string.threads_affinity_unavailable)
+        )
+        LabeledValue(
+            label = stringResource(R.string.threads_real_time),
+            value = pluralStringResource(R.plurals.threads_real_time_count, realTime, realTime)
+        )
+    }
+}
+
+@Composable
+private fun ThreadCard(thread: ThreadInfo, snapshot: ThreadSnapshot, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                // A thread with no name is possible — comm is empty for a moment after clone —
+                // so the id stands in rather than leaving the row headless.
+                text = thread.name.ifEmpty { stringResource(R.string.threads_unnamed, thread.tid) },
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(end = Spacing.Small)
+            )
+            Text(
+                text = stringResource(R.string.threads_cpu_time, snapshot.cpuMillis(thread)),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        Row(
+            modifier = Modifier.padding(vertical = Spacing.ExtraSmall),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            ThreadTag(stringResource(thread.state.labelRes))
+            ThreadTag(stringResource(thread.policy.labelRes))
+        }
+
+        Text(
+            text = stringResource(R.string.threads_identity, thread.tid),
+            style = MonitorTypography.machineText,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        // Nice and priority are one line: they are two views of the same number for an ordinary
+        // thread, and reading them apart tells nobody anything.
+        val nice = thread.nice
+        if (nice != null) {
+            LabeledValue(
+                label = stringResource(R.string.threads_nice),
+                value = thread.realTimePriority?.takeIf { it > 0 }
+                    ?.let { stringResource(R.string.threads_nice_with_rt, nice, it) }
+                    ?: nice.toString()
+            )
+        }
+
+        val affinity = thread.affinity
+        if (!affinity.isNullOrEmpty() && affinity != snapshot.processAffinity) {
+            // Only when it differs from the process mask: repeating "0-7" on every thread of an
+            // eight-core device is a column of noise.
+            LabeledValue(label = stringResource(R.string.threads_affinity), value = affinity)
+        }
+
+        thread.lastCpu?.let {
+            LabeledValue(label = stringResource(R.string.threads_last_cpu), value = it.toString())
+        }
+    }
+}
+
+@Composable
+private fun ThreadTag(text: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(percent = 50),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            maxLines = 1,
+            modifier = Modifier.padding(horizontal = Spacing.Medium, vertical = Spacing.ExtraSmall)
+        )
+    }
+}
+
+private val ThreadState.labelRes: Int
+    @StringRes
+    get() = when (this) {
+        ThreadState.Running -> R.string.thread_state_running
+        ThreadState.Sleeping -> R.string.thread_state_sleeping
+        ThreadState.DiskSleep -> R.string.thread_state_disk_sleep
+        ThreadState.Stopped -> R.string.thread_state_stopped
+        ThreadState.TracingStop -> R.string.thread_state_tracing
+        ThreadState.Zombie -> R.string.thread_state_zombie
+        ThreadState.Idle -> R.string.thread_state_idle
+        ThreadState.Unknown -> R.string.thread_state_unknown
+    }
+
+private val SchedulerPolicy.labelRes: Int
+    @StringRes
+    get() = when (this) {
+        SchedulerPolicy.Other -> R.string.thread_policy_other
+        SchedulerPolicy.Fifo -> R.string.thread_policy_fifo
+        SchedulerPolicy.RoundRobin -> R.string.thread_policy_rr
+        SchedulerPolicy.Batch -> R.string.thread_policy_batch
+        SchedulerPolicy.Idle -> R.string.thread_policy_idle
+        SchedulerPolicy.Deadline -> R.string.thread_policy_deadline
+        SchedulerPolicy.Unknown -> R.string.thread_policy_unknown
+    }
+
+@Preview(name = "Threads", showBackground = true)
+@Preview(name = "Threads (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ThreadsPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        ThreadsContent(
+            uiState = ThreadsUiState(
+                snapshot = ThreadSnapshot(
+                    threads = listOf(
+                        ThreadInfo(
+                            tid = 4821,
+                            name = "scoremonitor",
+                            state = ThreadState.Running,
+                            userTicks = 120,
+                            systemTicks = 31,
+                            priority = 20,
+                            nice = 0,
+                            policy = SchedulerPolicy.Other,
+                            lastCpu = 3,
+                            affinity = "0-7",
+                            affinityCount = 8
+                        ),
+                        ThreadInfo(
+                            tid = 4855,
+                            name = "RenderThread",
+                            state = ThreadState.Sleeping,
+                            userTicks = 90,
+                            systemTicks = 14,
+                            priority = 16,
+                            nice = -4,
+                            policy = SchedulerPolicy.Other,
+                            lastCpu = 6,
+                            affinity = "4-7",
+                            affinityCount = 4
+                        ),
+                        ThreadInfo(
+                            tid = 4870,
+                            name = "HeapTaskDaemon",
+                            state = ThreadState.Sleeping,
+                            userTicks = 4,
+                            systemTicks = 1,
+                            priority = 20,
+                            nice = 0,
+                            policy = SchedulerPolicy.Other,
+                            lastCpu = 0,
+                            affinity = "0-7",
+                            affinityCount = 8
+                        )
+                    ),
+                    clockTicks = 100,
+                    cpuCount = 8,
+                    processAffinity = "0-7",
+                    processAffinityCount = 8
+                ),
+                hasLoaded = true
+            ),
+            onNavigateBack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/HalInfoViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/HalInfoViewModel.kt
@@ -23,7 +23,7 @@ class HalInfoViewModel(context: Context) : ViewModel() {
         val EMPTY = HalInterfaceCollector.HalData(
             halInterfaces = Collected.real(emptyList()),
             hwServices = Collected.real(emptyList()),
-            vndkInfo = HalInterfaceCollector.VndkInfo(version = "—", libraries = emptyList())
+            vndkInfo = HalInterfaceCollector.VndkInfo(version = null)
         )
     }
 }

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/KernelCountersViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/KernelCountersViewModel.kt
@@ -1,6 +1,5 @@
 package com.aoscoremonitor.ui.viewmodel
 
-import android.os.Process
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.aoscoremonitor.diagnostics.jni.NativeSystemMonitor
@@ -9,12 +8,16 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
 
-/** The three groups of counters the native monitor screen shows. */
-data class NativeSystemMonitorUiState(
-    val cpu: Map<String, Long> = emptyMap(),
-    val memory: Map<String, Long> = emptyMap(),
-    val process: Map<String, String> = emptyMap()
-)
+/**
+ * The two groups of system-wide counters the kernel counters screen shows.
+ *
+ * There was a third holding this process's own /proc/self/status. It read the same file the memory
+ * map screen reads, only unfiltered, so the two screens carried the same counters under different
+ * headings. This screen is system-wide and that one is per-process; the split follows that line
+ * now, which is also why the screen is no longer called "Native System Monitor" — the name said
+ * how the reading is taken rather than what it is of.
+ */
+data class KernelCountersUiState(val cpu: Map<String, Long> = emptyMap(), val memory: Map<String, Long> = emptyMap())
 
 /**
  * Polls [NativeSystemMonitor] once a second.
@@ -23,22 +26,21 @@ data class NativeSystemMonitorUiState(
  * rather than to whether anyone was looking: it kept reading /proc while the app sat in the
  * background. [WhileScreenVisible] ends the loop shortly after the screen stops.
  */
-class NativeSystemMonitorViewModel : ViewModel() {
+class KernelCountersViewModel : ViewModel() {
 
     private val monitor = NativeSystemMonitor()
 
-    val uiState: StateFlow<NativeSystemMonitorUiState> = flow {
+    val uiState: StateFlow<KernelCountersUiState> = flow {
         while (true) {
             emit(
-                NativeSystemMonitorUiState(
+                KernelCountersUiState(
                     cpu = monitor.getCpuInfo(),
-                    memory = monitor.getMemInfo(),
-                    process = monitor.getProcessInfo(Process.myPid())
+                    memory = monitor.getMemInfo()
                 )
             )
             delay(REFRESH_INTERVAL_MS)
         }
-    }.stateIn(viewModelScope, WhileScreenVisible, NativeSystemMonitorUiState())
+    }.stateIn(viewModelScope, WhileScreenVisible, KernelCountersUiState())
 
     private companion object {
         const val REFRESH_INTERVAL_MS = 1_000L

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/SensorsViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/SensorsViewModel.kt
@@ -1,0 +1,105 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.SensorInfo
+import com.aoscoremonitor.diagnostics.SensorReading
+import com.aoscoremonitor.diagnostics.readSensorInventory
+import com.aoscoremonitor.diagnostics.sensorId
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * The device's sensors, and the live values of the one the user opened.
+ *
+ * [selectedId] rather than a set: one sensor is registered at a time. Registering all of them would
+ * turn a screen that describes the hardware into one that drains the battery describing it, and the
+ * power cost of each is on the card as a number for exactly that reason.
+ */
+data class SensorsUiState(
+    val sensors: List<SensorInfo> = emptyList(),
+    val hasLoaded: Boolean = false,
+    val selectedId: String? = null,
+    val reading: SensorReading? = null
+)
+
+class SensorsViewModel(context: Context) : ViewModel() {
+
+    private val sensorManager = context.getSystemService(SensorManager::class.java)
+
+    /** Read once: the sensor list does not change under a running process, dynamic sensors aside. */
+    private val inventory = readSensorInventory(sensorManager)
+
+    private val selectedId = MutableStateFlow<String?>(null)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val uiState: StateFlow<SensorsUiState> = selectedId
+        // flatMapLatest, so selecting a second sensor closes the first flow and with it unregisters
+        // the listener. A merge would leave both running.
+        .flatMapLatest { id ->
+            val sensor = id?.let(::sensorFor)
+            val readings = if (sensor == null) flowOf(null) else readingsOf(sensor)
+            readings.map { reading ->
+                SensorsUiState(sensors = inventory, hasLoaded = true, selectedId = id, reading = reading)
+            }
+        }
+        .stateIn(viewModelScope, WhileScreenVisible, SensorsUiState(sensors = inventory, hasLoaded = true))
+
+    /** Opens a sensor, or closes the open one when it is tapped again. */
+    fun toggle(id: String) {
+        selectedId.value = if (selectedId.value == id) null else id
+    }
+
+    private val sensorsById: Map<String, Sensor> =
+        sensorManager?.getSensorList(Sensor.TYPE_ALL).orEmpty().associateBy(::sensorId)
+
+    private fun sensorFor(id: String): Sensor? = sensorsById[id]
+
+    /**
+     * Values from one sensor, for as long as anyone collects them.
+     *
+     * The event's `values` array is owned and reused by the framework, so it is copied here rather
+     * than passed on: held as-is, every reading in the UI would change under it on the next event.
+     */
+    private fun readingsOf(sensor: Sensor): Flow<SensorReading?> = callbackFlow {
+        // Cleared first, so the card does not show the previous sensor's numbers under the new
+        // sensor's name while waiting for the first event — which for an on-change sensor like
+        // proximity can be a long wait.
+        trySend(null)
+
+        val listener = object : SensorEventListener {
+            override fun onSensorChanged(event: SensorEvent) {
+                trySend(
+                    SensorReading(
+                        values = event.values.toList(),
+                        accuracy = event.accuracy,
+                        timestampNanos = event.timestamp
+                    )
+                )
+            }
+
+            override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+        }
+
+        val registered = sensorManager?.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_UI) == true
+        awaitClose { if (registered) sensorManager?.unregisterListener(listener) }
+    }
+        // An accelerometer at SENSOR_DELAY_UI produces events faster than the screen can draw them,
+        // and only the newest is worth drawing. Dropping the rest is the intent, not a side effect
+        // of a small buffer.
+        .conflate()
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/SensorsViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/SensorsViewModel.kt
@@ -39,7 +39,10 @@ data class SensorsUiState(
 
 class SensorsViewModel(context: Context) : ViewModel() {
 
-    private val sensorManager = context.getSystemService(SensorManager::class.java)
+    // Typed rather than left as the platform type getSystemService hands back: a device without the
+    // sensor service answers null, and inferring the type non-null would have turned the checks
+    // below into ones the compiler believes it can drop.
+    private val sensorManager: SensorManager? = context.getSystemService(SensorManager::class.java)
 
     /** Read once: the sensor list does not change under a running process, dynamic sensors aside. */
     private val inventory = readSensorInventory(sensorManager)
@@ -96,7 +99,9 @@ class SensorsViewModel(context: Context) : ViewModel() {
         }
 
         val registered = sensorManager?.registerListener(listener, sensor, SensorManager.SENSOR_DELAY_UI) == true
-        awaitClose { if (registered) sensorManager?.unregisterListener(listener) }
+        // No safe call on the way out: `registered` can only be true if the manager was there to
+        // register with, which the compiler follows back through the val.
+        awaitClose { if (registered) sensorManager.unregisterListener(listener) }
     }
         // An accelerometer at SENSOR_DELAY_UI produces events faster than the screen can draw them,
         // and only the newest is worth drawing. Dropping the rest is the intent, not a side effect

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/SystemDiagnosticsViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/SystemDiagnosticsViewModel.kt
@@ -26,7 +26,6 @@ class SystemDiagnosticsViewModel(context: Context) : ViewModel() {
     private companion object {
         val EMPTY = SystemDiagnosticsCollector.DiagnosticsInfo(
             runningProcesses = emptyList(),
-            availableMemory = "—",
             screenOn = false,
             dumpsysResult = ""
         )

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/ThreadsViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/ThreadsViewModel.kt
@@ -1,0 +1,37 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.jni.NativeThreadInspector
+import com.aoscoremonitor.diagnostics.jni.ThreadSnapshot
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * The thread list, and whether a reading has been taken yet.
+ *
+ * [hasLoaded] separates "still reading" from "the native library did not load", which look the same
+ * to a screen holding an empty snapshot and mean opposite things to whoever is looking at it.
+ */
+data class ThreadsUiState(val snapshot: ThreadSnapshot? = null, val hasLoaded: Boolean = false)
+
+/** Polls the thread list once a second. */
+class ThreadsViewModel : ViewModel() {
+
+    private val inspector = NativeThreadInspector()
+
+    val uiState: StateFlow<ThreadsUiState> = flow {
+        while (true) {
+            emit(ThreadsUiState(snapshot = inspector.read(), hasLoaded = true))
+            delay(REFRESH_INTERVAL_MS)
+        }
+    }.stateIn(viewModelScope, WhileScreenVisible, ThreadsUiState())
+
+    private companion object {
+        // Threads come and go in well under a second — a poll slower than this shows a list that
+        // was true a moment ago, which for a screen about what is running now is the wrong trade.
+        const val REFRESH_INTERVAL_MS = 1_000L
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,9 @@
     <string name="destination_security">Security</string>
     <string name="destination_framework">Framework</string>
     <string name="destination_hal">HAL Interface</string>
+    <string name="destination_sensors">Sensors</string>
     <string name="destination_kernel_counters">Kernel Counters</string>
+    <string name="destination_threads">Threads</string>
     <string name="destination_network_stats">Network Stats</string>
     <string name="destination_tcp_connections">TCP Connections</string>
     <string name="destination_cpu_cores">CPU Cores</string>
@@ -266,6 +268,87 @@
         <item quantity="one">%1$d loadable segment</item>
         <item quantity="other">%1$d loadable segments</item>
     </plurals>
+
+    <!-- Threads and scheduling -->
+    <string name="threads_title">Threads &amp; Scheduling</string>
+    <string name="threads_loading">Reading /proc/self/task…</string>
+    <string name="threads_unavailable">The native library did not load, so this process\'s threads cannot be listed.</string>
+    <string name="threads_summary_section">This process</string>
+    <plurals name="threads_summary">
+        <item quantity="one">%1$d thread</item>
+        <item quantity="other">%1$d threads</item>
+    </plurals>
+    <string name="threads_allowed_cpus">Allowed CPUs</string>
+    <string name="threads_affinity_unavailable">Not readable</string>
+    <string name="threads_real_time">Real-time scheduled</string>
+    <plurals name="threads_real_time_count">
+        <item quantity="one">%1$d thread</item>
+        <item quantity="other">%1$d threads</item>
+    </plurals>
+    <string name="threads_section">Threads</string>
+    <string name="threads_subtitle">Busiest first, by CPU time used since each thread started</string>
+    <string name="threads_unnamed">Thread %1$d</string>
+    <string name="threads_cpu_time">%1$,d ms</string>
+    <string name="threads_identity">tid %1$d</string>
+    <string name="threads_nice">Nice</string>
+    <string name="threads_nice_with_rt">%1$d · real-time priority %2$d</string>
+    <string name="threads_affinity">Allowed CPUs</string>
+    <string name="threads_last_cpu">Last ran on CPU</string>
+    <string name="thread_state_running">Running</string>
+    <string name="thread_state_sleeping">Sleeping</string>
+    <string name="thread_state_disk_sleep">Uninterruptible</string>
+    <string name="thread_state_stopped">Stopped</string>
+    <string name="thread_state_tracing">Traced</string>
+    <string name="thread_state_zombie">Zombie</string>
+    <string name="thread_state_idle">Idle</string>
+    <string name="thread_state_unknown">State unknown</string>
+    <string name="thread_policy_other">SCHED_OTHER</string>
+    <string name="thread_policy_fifo">SCHED_FIFO</string>
+    <string name="thread_policy_rr">SCHED_RR</string>
+    <string name="thread_policy_batch">SCHED_BATCH</string>
+    <string name="thread_policy_idle">SCHED_IDLE</string>
+    <string name="thread_policy_deadline">SCHED_DEADLINE</string>
+    <string name="thread_policy_unknown">Policy unknown</string>
+
+    <!-- Sensors -->
+    <string name="sensors_title">Sensors</string>
+    <string name="sensors_subtitle">What the sensor HAL reports about the parts in this device. Tap one to read it.</string>
+    <string name="sensors_loading">Reading the sensor list…</string>
+    <string name="sensors_empty">No sensors reported</string>
+    <string name="sensors_empty_hint">The platform returned an empty sensor list, which an emulator built without sensor support does.</string>
+    <string name="sensors_category_motion">Motion</string>
+    <string name="sensors_category_position">Position</string>
+    <string name="sensors_category_environment">Environment</string>
+    <string name="sensors_category_other">Other</string>
+    <string name="sensors_wakeup">Wake-up</string>
+    <string name="sensors_resolution">Resolution</string>
+    <string name="sensors_range">Maximum range</string>
+    <string name="sensors_power">Power</string>
+    <string name="sensors_milliamps">%1$.2f mA</string>
+    <string name="sensors_max_rate">Fastest rate</string>
+    <string name="sensors_hertz">%1$.0f Hz</string>
+    <string name="sensors_tap_to_read">Tap to read live values</string>
+    <string name="sensors_waiting">Waiting for the first event. A sensor that reports only on change may not send one for a while.</string>
+    <string name="sensors_value">Value</string>
+    <string name="sensors_value_indexed">Value %1$d</string>
+    <string name="sensors_value_with_unit">%1$s %2$s</string>
+    <string name="sensors_accuracy">Accuracy · %1$s</string>
+    <string name="sensors_accuracy_high">High</string>
+    <string name="sensors_accuracy_medium">Medium</string>
+    <string name="sensors_accuracy_low">Low</string>
+    <string name="sensors_accuracy_unreliable">Unreliable</string>
+    <string name="sensors_accuracy_no_contact">No contact</string>
+    <string name="sensors_unit_acceleration">m/s²</string>
+    <string name="sensors_unit_angular_rate">rad/s</string>
+    <string name="sensors_unit_magnetic">µT</string>
+    <string name="sensors_unit_lux">lx</string>
+    <string name="sensors_unit_pressure">hPa</string>
+    <string name="sensors_unit_centimetres">cm</string>
+    <!-- Not %%: this is read with getString and no arguments, which does no formatting at all. -->
+    <string name="sensors_unit_percent">%</string>
+    <string name="sensors_unit_celsius">°C</string>
+    <string name="sensors_unit_degrees">°</string>
+    <string name="sensors_unit_steps">steps</string>
 
     <!-- Storage and mounts -->
     <string name="storage_title">Storage</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,12 +19,12 @@
     <string name="destination_security">Security</string>
     <string name="destination_framework">Framework</string>
     <string name="destination_hal">HAL Interface</string>
-    <string name="destination_native_monitor">Native Monitor</string>
+    <string name="destination_kernel_counters">Kernel Counters</string>
     <string name="destination_network_stats">Network Stats</string>
     <string name="destination_tcp_connections">TCP Connections</string>
     <string name="destination_cpu_cores">CPU Cores</string>
     <string name="destination_memory_map">Memory Map</string>
-    <string name="destination_loaded_libraries">Libraries</string>
+    <string name="destination_loaded_libraries">Native Libraries</string>
     <string name="destination_storage">Storage</string>
 
     <!-- System logs -->
@@ -45,11 +45,11 @@
 
     <!-- System diagnostics -->
     <string name="diagnostics_title">System Diagnostics</string>
-    <string name="diagnostics_memory">Memory</string>
     <string name="diagnostics_screen_state">Screen State</string>
     <string name="diagnostics_screen_on">On</string>
     <string name="diagnostics_screen_off">Off</string>
-    <string name="diagnostics_running_processes">Running Processes</string>
+    <string name="diagnostics_running_processes">Processes Visible to This App</string>
+    <string name="diagnostics_processes_notice">Since Android 8, ActivityManager reports only the calling app\'s own process. Listing the rest needs root or a userdebug build.</string>
     <string name="diagnostics_no_processes">No process information available</string>
     <string name="diagnostics_dumpsys">Dumpsys Memory Info</string>
     <string name="diagnostics_loading">Loading…</string>
@@ -87,7 +87,7 @@
     <string name="framework_title">Framework Analysis</string>
     <string name="framework_tab_binder">Binder</string>
     <string name="framework_tab_api">API Calls</string>
-    <string name="framework_tab_services">Services</string>
+    <string name="framework_tab_services">App services</string>
     <string name="framework_binder_section">Binder Transactions</string>
     <string name="framework_binder_subtitle">Cross-process calls observed on this device</string>
     <string name="framework_binder_empty">No Binder transactions detected. Reading them needs root access or a userdebug build.</string>
@@ -118,41 +118,38 @@
     <!-- HAL interfaces -->
     <string name="hal_title">HAL Interfaces</string>
     <string name="hal_tab_interfaces">HAL</string>
-    <string name="hal_tab_services">Services</string>
+    <string name="hal_tab_services">Binder services</string>
     <string name="hal_tab_vndk">VNDK</string>
     <string name="hal_interfaces_section">Hardware Abstraction Layer</string>
     <string name="hal_interfaces_subtitle">HALs provide standardized interfaces to hardware components</string>
     <string name="hal_interfaces_empty">No HAL interface data available. Some of it needs elevated permissions.</string>
-    <string name="hal_services_section">Hardware Services</string>
-    <string name="hal_services_subtitle">System services that expose hardware functionality</string>
+    <string name="hal_services_section">Registered Binder Services</string>
+    <string name="hal_services_subtitle">Everything registered with servicemanager, as `service list` reports it</string>
     <string name="hal_services_empty">No hardware service data available.</string>
     <string name="hal_vndk_section">VNDK</string>
     <string name="hal_vndk_subtitle">Vendor Native Development Kit libraries</string>
     <string name="hal_vndk_version">VNDK version %1$s</string>
     <string name="hal_vndk_explainer">The VNDK is the set of libraries vendors build their HALs against. It keeps vendor implementations working across Android OS updates.</string>
-    <string name="hal_vndk_libraries">Libraries</string>
-    <string name="hal_vndk_empty">No VNDK library information available.</string>
+    <string name="hal_vndk_unset">ro.vndk.version is not set on this build. Android 15 removed the VNDK, so recent devices report no version at all.</string>
+    <string name="hal_vndk_libraries_hint">The shared libraries actually mapped into this process are listed on the Native Libraries screen.</string>
     <string name="hal_version">Version</string>
     <string name="hal_type">Type</string>
     <string name="hal_implementation">Implementation</string>
-    <string name="hal_service_server">Server</string>
-    <string name="hal_service_clients">Clients</string>
-    <string name="hal_service_no_clients">No clients bound</string>
+    <string name="hal_service_interface">Interface</string>
+    <string name="hal_service_no_interface">No interface descriptor reported</string>
     <string name="hal_sample_interfaces">lshal returned nothing on this device</string>
     <string name="hal_sample_services">`service list` returned nothing on this device</string>
 
-    <!-- Native system monitor -->
-    <string name="native_title">Native System Monitor</string>
-    <string name="native_cpu_section">CPU</string>
-    <string name="native_cpu_subtitle">System-wide counters from /proc/stat</string>
-    <string name="native_memory_section">Memory</string>
-    <string name="native_memory_subtitle">System-wide counters from /proc/meminfo</string>
-    <string name="native_process_section">This Process</string>
-    <string name="native_process_subtitle">Counters for the monitor app itself</string>
-    <string name="native_cpu_unavailable">System-wide CPU statistics come from /proc/stat, which SELinux does not let the app sandbox read on modern Android. Reading it needs a rooted or userdebug build. The per-process counters below stay available.</string>
-    <string name="native_memory_unavailable">No memory counters available.</string>
-    <string name="native_process_unavailable">No counters available for this process.</string>
-    <string name="native_kilobytes">%1$d kB</string>
+    <!-- Kernel counters -->
+    <string name="kernel_title">Kernel Counters</string>
+    <string name="kernel_subtitle">Raw system-wide counters, exactly as the kernel reports them. System Info summarises the same sources; this app\'s own counters are on the Memory Map screen.</string>
+    <string name="kernel_cpu_section">CPU</string>
+    <string name="kernel_cpu_subtitle">System-wide counters from /proc/stat</string>
+    <string name="kernel_memory_section">Memory</string>
+    <string name="kernel_memory_subtitle">System-wide counters from /proc/meminfo</string>
+    <string name="kernel_cpu_unavailable">System-wide CPU statistics come from /proc/stat, which SELinux does not let the app sandbox read on modern Android. Reading it needs a rooted or userdebug build.</string>
+    <string name="kernel_memory_unavailable">No memory counters available.</string>
+    <string name="kernel_kilobytes">%1$d kB</string>
 
     <!-- Network statistics -->
     <string name="network_title">Network Interfaces</string>
@@ -253,12 +250,12 @@
     <string name="memory_limit_open_files">Open files</string>
     <string name="memory_count">%1$d</string>
 
-    <!-- Loaded libraries -->
-    <string name="libraries_title">Loaded Libraries</string>
+    <!-- Native libraries -->
+    <string name="libraries_title">Native Libraries</string>
     <string name="libraries_loading">Walking the linker\'s module list…</string>
     <string name="libraries_unavailable">The native library did not load, so the linker\'s module list cannot be read.</string>
-    <string name="libraries_summary_section">Linked objects</string>
-    <string name="libraries_summary">%1$d objects · %2$s mapped</string>
+    <string name="libraries_summary_section">Loaded by the linker</string>
+    <string name="libraries_summary">%1$d objects · %2$s mapped into this process</string>
     <string name="libraries_load_events">%1$d loads · %2$d unloads since the process started</string>
     <string name="libraries_main_executable">(main executable)</string>
     <string name="libraries_build_id">Build ID %1$s</string>

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/SensorCategoryTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/SensorCategoryTest.kt
@@ -1,0 +1,97 @@
+package com.aoscoremonitor.diagnostics
+
+import android.hardware.Sensor
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Runs off-device: the `Sensor.TYPE_*` constants are compile-time integers, so the grouping and the
+ * units can be checked without the platform behind them. Everything else about a [Sensor] needs a
+ * device to answer, which is why neither of these reads one.
+ */
+class SensorCategoryTest {
+
+    @Test
+    fun motionSensorsGroupTogether() {
+        val motion = listOf(
+            Sensor.TYPE_ACCELEROMETER,
+            Sensor.TYPE_GYROSCOPE,
+            Sensor.TYPE_GRAVITY,
+            Sensor.TYPE_LINEAR_ACCELERATION,
+            Sensor.TYPE_STEP_COUNTER
+        )
+
+        motion.forEach { type ->
+            assertEquals("type $type", SensorCategory.Motion, sensorCategory(type))
+        }
+    }
+
+    @Test
+    fun theCompassAndTheProximitySensorAreAboutPosition() {
+        assertEquals(SensorCategory.Position, sensorCategory(Sensor.TYPE_MAGNETIC_FIELD))
+        assertEquals(SensorCategory.Position, sensorCategory(Sensor.TYPE_PROXIMITY))
+        assertEquals(SensorCategory.Position, sensorCategory(Sensor.TYPE_ROTATION_VECTOR))
+    }
+
+    @Test
+    fun theEnvironmentSensorsGroupTogether() {
+        assertEquals(SensorCategory.Environment, sensorCategory(Sensor.TYPE_LIGHT))
+        assertEquals(SensorCategory.Environment, sensorCategory(Sensor.TYPE_PRESSURE))
+        assertEquals(SensorCategory.Environment, sensorCategory(Sensor.TYPE_AMBIENT_TEMPERATURE))
+        assertEquals(SensorCategory.Environment, sensorCategory(Sensor.TYPE_RELATIVE_HUMIDITY))
+    }
+
+    @Test
+    fun aVendorTypeIsListedRatherThanDropped() {
+        // Types above the documented range are the vendor's own. The screen groups by this
+        // function, so a type it does not know has to land somewhere rather than nowhere.
+        assertEquals(SensorCategory.Other, sensorCategory(65_536))
+        assertEquals(SensorCategory.Other, sensorCategory(Sensor.TYPE_HEART_RATE))
+    }
+
+    @Test
+    fun eachSensorTypeReportsItsOwnUnit() {
+        assertEquals(SensorUnit.MetresPerSecondSquared, sensorUnit(Sensor.TYPE_ACCELEROMETER))
+        assertEquals(SensorUnit.RadiansPerSecond, sensorUnit(Sensor.TYPE_GYROSCOPE))
+        assertEquals(SensorUnit.MicroTesla, sensorUnit(Sensor.TYPE_MAGNETIC_FIELD))
+        assertEquals(SensorUnit.Lux, sensorUnit(Sensor.TYPE_LIGHT))
+        assertEquals(SensorUnit.HectoPascal, sensorUnit(Sensor.TYPE_PRESSURE))
+    }
+
+    @Test
+    fun aRotationVectorHasNoUnitToName() {
+        // Its values are components of a unit quaternion. Labelling them with anything would be
+        // making something up, which is the failure mode this app has been pulling out elsewhere.
+        assertNull(sensorUnit(Sensor.TYPE_ROTATION_VECTOR))
+        assertNull(sensorUnit(Sensor.TYPE_GAME_ROTATION_VECTOR))
+        assertNull(sensorUnit(65_536))
+    }
+
+    @Test
+    fun theFastestRateIsDerivedFromTheMinimumDelay() {
+        val continuous = sensorInfo(minDelayUs = 5_000)
+        val onChange = sensorInfo(minDelayUs = 0)
+
+        assertEquals(200f, continuous.maxRateHz)
+        // 0 means "reports only when the value changes", which is not a rate of any kind.
+        assertNull(onChange.maxRateHz)
+    }
+
+    private fun sensorInfo(minDelayUs: Int) = SensorInfo(
+        id = "1:test",
+        name = "test",
+        vendor = "test",
+        type = Sensor.TYPE_ACCELEROMETER,
+        stringType = "android.sensor.accelerometer",
+        version = 1,
+        maximumRange = 1f,
+        resolution = 1f,
+        power = 1f,
+        minDelayUs = minDelayUs,
+        maxDelayUs = 0,
+        isWakeUp = false,
+        isDynamic = false,
+        reportingMode = 0
+    )
+}

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/ThreadParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/ThreadParsingTest.kt
@@ -1,0 +1,125 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThreadParsingTest {
+
+    @Test
+    fun readsAThread() {
+        val snapshot = parseThreads(
+            """
+            {"clock_ticks":100,"cpu_count":8,"affinity":"0-7","affinity_count":8,
+             "threads":[{"tid":4821,"name":"scoremonitor","state":"R","utime_ticks":120,
+                         "stime_ticks":31,"priority":20,"nice":0,"last_cpu":3,"rt_priority":0,
+                         "policy":"other","affinity":"0-7","affinity_count":8}]}
+            """.trimIndent()
+        )
+
+        val thread = snapshot.threads.single()
+        assertEquals(4821, thread.tid)
+        assertEquals("scoremonitor", thread.name)
+        assertEquals(ThreadState.Running, thread.state)
+        assertEquals(SchedulerPolicy.Other, thread.policy)
+        assertEquals(151L, thread.cpuTicks)
+        assertEquals("0-7", snapshot.processAffinity)
+    }
+
+    @Test
+    fun ticksBecomeMillisecondsAtTheClockRateTheKernelReported() {
+        // The conversion is the reason clock_ticks crosses the boundary at all. At USER_HZ 100 a
+        // tick is 10ms; a kernel built with 250 would make the same count 4ms and the same
+        // arithmetic wrong.
+        val snapshot = parseThreads(
+            """{"clock_ticks":250,"threads":[{"tid":1,"utime_ticks":100,"stime_ticks":25}]}"""
+        )
+
+        assertEquals(500L, snapshot.cpuMillis(snapshot.threads.single()))
+    }
+
+    @Test
+    fun aClockRateOfZeroYieldsNoTimeRatherThanADivideByZero() {
+        val snapshot = parseThreads("""{"threads":[{"tid":1,"utime_ticks":100,"stime_ticks":25}]}""")
+
+        assertEquals(0L, snapshot.cpuMillis(snapshot.threads.single()))
+    }
+
+    @Test
+    fun busiestThreadComesFirst() {
+        val snapshot = parseThreads(
+            """
+            {"clock_ticks":100,"threads":[
+              {"tid":1,"name":"idle","utime_ticks":1,"stime_ticks":0},
+              {"tid":2,"name":"busy","utime_ticks":900,"stime_ticks":100},
+              {"tid":3,"name":"middling","utime_ticks":40,"stime_ticks":10}]}
+            """.trimIndent()
+        )
+
+        assertEquals(listOf("busy", "middling", "idle"), snapshot.threads.map { it.name })
+    }
+
+    @Test
+    fun everyStateLetterTheKernelUsesIsNamed() {
+        val states = listOf("R", "S", "D", "T", "t", "Z", "I", "X")
+            .map { letter -> ThreadState.of(letter) }
+
+        assertEquals(
+            listOf(
+                ThreadState.Running,
+                ThreadState.Sleeping,
+                ThreadState.DiskSleep,
+                ThreadState.Stopped,
+                ThreadState.TracingStop,
+                ThreadState.Zombie,
+                ThreadState.Idle,
+                // X is a state /proc can report and this app does not name, which is Unknown rather
+                // than a crash or a blank.
+                ThreadState.Unknown
+            ),
+            states
+        )
+    }
+
+    @Test
+    fun realTimePoliciesAreMarkedAndOrdinaryOnesAreNot() {
+        assertTrue(SchedulerPolicy.Fifo.isRealTime)
+        assertTrue(SchedulerPolicy.RoundRobin.isRealTime)
+        assertTrue(SchedulerPolicy.Deadline.isRealTime)
+        assertEquals(false, SchedulerPolicy.Other.isRealTime)
+        assertEquals(false, SchedulerPolicy.Idle.isRealTime)
+    }
+
+    @Test
+    fun aThreadWhosePolicyWasRefusedSaysWhy() {
+        val snapshot = parseThreads(
+            """{"threads":[{"tid":7,"policy_unavailable":"denied"}]}"""
+        )
+
+        val thread = snapshot.threads.single()
+        assertEquals(SchedulerPolicy.Unknown, thread.policy)
+        assertEquals(Unavailable.Denied, thread.policyUnavailable)
+    }
+
+    @Test
+    fun missingFieldsStayMissingRatherThanBecomingZero() {
+        // A nice of 0 and no nice at all are different readings: the first says the thread runs at
+        // the default priority, the second that /proc did not say.
+        val snapshot = parseThreads("""{"threads":[{"tid":7}]}""")
+
+        val thread = snapshot.threads.single()
+        assertNull(thread.nice)
+        assertNull(thread.priority)
+        assertNull(thread.lastCpu)
+        assertNull(thread.affinity)
+    }
+
+    @Test
+    fun anEmptyDocumentIsAnEmptySnapshot() {
+        val snapshot = parseThreads("{}")
+
+        assertTrue(snapshot.threads.isEmpty())
+        assertNull(snapshot.processAffinity)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ composeBom = "2026.06.01"
 nav3Core = "1.1.5"
 kotlinxSerializationCore = "1.11.0"
 orgJson = "20260719"
+ktlint = "14.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -41,3 +42,4 @@ org-json = { group = "org.json", name = "json", version.ref = "orgJson" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }


### PR DESCRIPTION
## Summary

13 screens → 15. Five facts were shown on two screens each, three of them
not readings at all.

**Deduplicated** — available memory (System Info and Diagnostics read the
same `availMem`), `/proc/self/status` (Kernel Counters showed it raw,
Memory Map curated), services (Framework and HAL under one name), library
lists (HAL's was hard-coded).

**Stopped fabricating** — `service list` entries were given an invented
server and clients; the VNDK tab substituted version "30" and five
hard-coded library names; Diagnostics called a list "Running Processes"
that Android 8 limited to one.

**Renamed** — Libraries → Native Libraries (it carried three names, none
saying whose), Native System Monitor → Kernel Counters.

**Added** — Threads & Scheduling (`/proc/self/task` with `sched_*` through
JNI) and Sensors (real hardware inventory, live values on tap).

Home tile icons now align when a label wraps. Java toolchain replaces a
template `compileOptions`; ktlint moves into the version catalog. 61 unit
tests, ktlint and lint clean; all four screens checked on an emulator.