### PR TITLE
feat: add four inspection screens - descriptors, credentials, display and frame pacing

### DIFF
--- a/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
+++ b/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
@@ -1,7 +1,10 @@
 package com.aoscoremonitor.diagnostics.jni
 
+import android.os.Process
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -95,6 +98,70 @@ class NativeInspectorTest {
             "No thread reports a scheduling policy",
             snapshot.threads.any { it.policy != SchedulerPolicy.Unknown }
         )
+    }
+
+    @Test
+    fun descriptorInspectorListsThisProcessesDescriptors() = runBlocking {
+        val snapshot = NativeDescriptorInspector().read()
+
+        assertNotNull("Descriptor table could not be read", snapshot)
+        assertTrue("No descriptors reported", snapshot!!.descriptors.isNotEmpty())
+        // Every process is handed the three standard streams, whatever else it holds.
+        assertTrue("fd 0 is missing, which cannot be", snapshot.descriptors.any { it.fd == 0 })
+        assertTrue("No soft limit reported", (snapshot.softLimit ?: 0) > 0)
+    }
+
+    /**
+     * The walk does not report the handle it walked with.
+     *
+     * `/proc/self/fd` is read through a descriptor that appears in its own listing, so a collector
+     * that reads and reports in one pass claims the process holds a descriptor on the very
+     * directory the reading came from. The two-pass design exists to make that unreachable; without
+     * this, nothing would notice it coming back.
+     */
+    @Test
+    fun descriptorInspectorDoesNotReportItsOwnDirectoryHandle() = runBlocking {
+        val snapshot = NativeDescriptorInspector().read()
+
+        assertNotNull("Descriptor table could not be read", snapshot)
+        assertTrue(
+            "The descriptor walk reported the directory it was walking",
+            snapshot!!.descriptors.none { it.target == "/proc/self/fd" }
+        )
+    }
+
+    @Test
+    fun credentialsInspectorReadsThisProcess() = runBlocking {
+        val credentials = NativeCredentialsInspector().read()
+
+        assertNotNull("Credentials could not be read", credentials)
+        assertEquals("Reported a different process", Process.myPid(), credentials!!.pid)
+        assertEquals("Reported a different user", Process.myUid(), credentials.user?.effective)
+        // The kernel prints all five sets on every Android kernel this app runs on; the effective
+        // one is the set that decides what a syscall is allowed to do, so its absence is a failure
+        // rather than a reading that is allowed to be missing.
+        assertNotNull("No effective capability set", credentials.capabilities["effective"])
+        assertNotNull("No bounding capability set", credentials.capabilities["bounding"])
+        assertTrue("No umask reported", credentials.umask?.isNotEmpty() == true)
+    }
+
+    /**
+     * The SELinux context is a context, not a stray byte.
+     *
+     * The kernel terminates what it writes to `/proc/self/attr/current`, and that NUL is not
+     * whitespace — left on, it crosses to Kotlin as part of the MLS level and the type would still
+     * parse out fine, so only the shape of the whole string catches it.
+     */
+    @Test
+    fun theSelinuxContextArrivesAsAContext() = runBlocking {
+        val credentials = NativeCredentialsInspector().read()
+        val context = credentials?.selinuxContext ?: return@runBlocking
+
+        assertTrue("Not a user:role:type context: $context", context.split(':').size >= 3)
+        assertFalse("The context carries the kernel's NUL terminator", context.contains('\u0000'))
+        // The domain itself is not pinned: a test app is untrusted_app on a stock build, but the
+        // same library runs in whatever domain the process it is loaded into was assigned.
+        assertTrue("No SELinux type in $context", credentials.selinuxType?.isNotEmpty() == true)
     }
 
     @Test

--- a/app/src/androidTest/java/com/aoscoremonitor/ui/navigation/MonitorNavigationTest.kt
+++ b/app/src/androidTest/java/com/aoscoremonitor/ui/navigation/MonitorNavigationTest.kt
@@ -1,10 +1,13 @@
 package com.aoscoremonitor.ui.navigation
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.NoActivityResumedException
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -27,12 +30,21 @@ class MonitorNavigationTest {
     @get:Rule
     val composeRule = createAndroidComposeRule<MainActivity>()
 
+    /**
+     * Every destination has a tile, including the ones past the bottom of the screen.
+     *
+     * Scrolled to rather than asserted on where it stands: the grid outgrew the screen, and a tile
+     * below the fold is not composed at all, so the assertion would fail on a phone while passing
+     * on a tall emulator. Scrolling to each in turn also pins that the grid can reach all of them.
+     */
     @Test
     fun homeListsEveryDestination() {
         awaitText(string(R.string.destination_system_info))
 
         HomeDestinations.forEach { destination ->
-            composeRule.onNodeWithText(string(destination.shortTitleRes)).assertIsDisplayed()
+            val label = string(destination.shortTitleRes)
+            composeRule.onNode(hasScrollAction()).performScrollToNode(hasText(label))
+            composeRule.onNodeWithText(label).assertIsDisplayed()
         }
     }
 

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(
     elf_modules.cpp
     storage_info.cpp
     thread_info.cpp
+    fd_info.cpp
+    process_creds.cpp
 )
 
 # The conversion warnings earn their place here: this code carries kernel counters — size_t,

--- a/app/src/main/cpp/fd_info.cpp
+++ b/app/src/main/cpp/fd_info.cpp
@@ -1,0 +1,236 @@
+#include <dirent.h>
+#include <fcntl.h>
+#include <jni.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <charconv>
+#include <climits>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "native_util.h"
+
+namespace {
+
+using aoscm::JsonWriter;
+
+/** Closes the directory however the scope is left, exception included. */
+using FdDir = std::unique_ptr<DIR, decltype([](DIR* dir) { closedir(dir); })>;
+
+/**
+ * The status flags worth naming, and the token each goes out under.
+ *
+ * Tested by masked equality rather than by a single bit, because O_SYNC is two bits on Linux — it
+ * carries O_DSYNC — and `flags & O_SYNC` is therefore true for a descriptor that only asked for
+ * data synchronisation.
+ */
+constexpr std::array<std::pair<int, const char*>, 6> kStatusFlags = {{
+    {O_APPEND, "append"},
+    {O_NONBLOCK, "nonblock"},
+    {O_DIRECT, "direct"},
+    {O_SYNC, "sync"},
+    {O_NOATIME, "noatime"},
+    {O_PATH, "path"},
+}};
+
+std::optional<int> FdNumber(std::string_view name) {
+  int value = 0;
+  const char* const first = name.data();
+  const char* const last = first + name.size();
+  const auto [end, error] = std::from_chars(first, last, value);
+  if (error != std::errc() || end != last) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+/**
+ * What the descriptor is open on, as the mode bits report it.
+ *
+ * Takes the bits as a `uint32_t` rather than as a `mode_t`, because `stat64::st_mode` is not one:
+ * on the 32-bit ABIs this ships for it is an `unsigned int` while `mode_t` is an `unsigned short`,
+ * so a `mode_t` parameter narrows the very field it exists to read.
+ */
+const char* TypeName(uint32_t mode) {
+  switch (mode & S_IFMT) {
+    case S_IFREG:
+      return "regular";
+    case S_IFDIR:
+      return "directory";
+    case S_IFCHR:
+      return "character";
+    case S_IFBLK:
+      return "block";
+    case S_IFIFO:
+      return "fifo";
+    case S_IFSOCK:
+      return "socket";
+    case S_IFLNK:
+      return "symlink";
+    default:
+      return "unknown";
+  }
+}
+
+const char* AccessName(int status_flags) {
+  switch (status_flags & O_ACCMODE) {
+    case O_RDONLY:
+      return "read";
+    case O_WRONLY:
+      return "write";
+    case O_RDWR:
+      return "readwrite";
+    default:
+      return "unknown";
+  }
+}
+
+/**
+ * Every descriptor number the process holds.
+ *
+ * Collected in full, and the directory closed, before anything is asked about any of them: the
+ * directory handle is itself an open descriptor and appears in its own listing. Closing it first
+ * means the second pass finds nothing at that number and drops it under the same rule that drops a
+ * descriptor another thread closed mid-read, rather than needing a special case for it.
+ *
+ * The second pass therefore uses only syscalls that take a descriptor — readlink on the /proc
+ * entry, fstat, fcntl, lseek — and opens no file of its own, so no number is taken and reported
+ * back as though the process had been holding it all along.
+ */
+std::vector<int> ListDescriptorNumbers() {
+  std::vector<int> numbers;
+  const FdDir descriptors{opendir("/proc/self/fd")};
+  if (!descriptors) {
+    return numbers;
+  }
+  while (const dirent* entry = readdir(descriptors.get())) {
+    if (const std::optional<int> fd = FdNumber(entry->d_name)) {
+      numbers.push_back(*fd);
+    }
+    // Anything else is "." or "..", which readdir reports alongside the numbers.
+  }
+  return numbers;
+}
+
+/**
+ * One descriptor, or nothing at all when the number no longer names one.
+ *
+ * A descriptor that closes between the two passes is left out entirely rather than listed as a
+ * blank row. One that closes partway through this function keeps whatever was read before it went;
+ * that race is inherent to reading a live process and costs a field, not a wrong reading.
+ */
+void WriteDescriptor(JsonWriter* writer, int fd) {
+  char link[PATH_MAX];
+  const std::string path = "/proc/self/fd/" + std::to_string(fd);
+  const ssize_t length = readlink(path.c_str(), link, sizeof(link));
+  const int link_error = length < 0 ? errno : 0;
+  if (link_error == ENOENT || link_error == EBADF) {
+    return;
+  }
+
+  writer->BeginObject();
+  writer->Field("fd", static_cast<uint64_t>(fd));
+
+  if (length >= 0) {
+    // readlink neither terminates what it writes nor fails when the buffer is short — it truncates
+    // — so the length it returns is the only thing that says where the target ends. PATH_MAX is
+    // what the kernel caps these links at, so the truncating case is unreachable here.
+    writer->Field("target", std::string_view(link, static_cast<size_t>(length)));
+  } else {
+    writer->Field("target_unavailable", aoscm::DescribeFailure(link_error));
+  }
+
+  struct stat64 info = {};
+  if (fstat64(fd, &info) != 0) {
+    writer->Field("stat_unavailable", aoscm::DescribeFailure(errno));
+  } else {
+    writer->Field("type", TypeName(info.st_mode));
+    writer->Field("inode", static_cast<uint64_t>(info.st_ino));
+    if (S_ISREG(info.st_mode)) {
+      // Only a regular file has a length worth reporting: a socket answers with zero and a device
+      // with whatever its driver felt like, neither of which is a size.
+      writer->Field("size_bytes", static_cast<uint64_t>(info.st_size));
+    }
+  }
+
+  const int status_flags = fcntl(fd, F_GETFL);
+  if (status_flags >= 0) {
+    writer->Field("access", AccessName(status_flags));
+    writer->Key("flags").BeginArray();
+    for (const auto& [bit, name] : kStatusFlags) {
+      if ((status_flags & bit) == bit) {
+        writer->Value(name);
+      }
+    }
+    writer->EndArray();
+  }
+
+  // The descriptor flag, which is not among the status flags above: close-on-exec belongs to the
+  // descriptor rather than to the open file it names, and F_GETFD is what reports it.
+  const int descriptor_flags = fcntl(fd, F_GETFD);
+  if (descriptor_flags >= 0) {
+    writer->Field("close_on_exec", (descriptor_flags & FD_CLOEXEC) != 0);
+  }
+
+  // Where the next read would start. Asking for the current offset moves nothing. A pipe or a
+  // socket has no offset at all, which lseek reports as ESPIPE; the key is then left out rather
+  // than sent as a zero, which would read as "at the beginning".
+  const off64_t offset = lseek64(fd, 0, SEEK_CUR);
+  if (offset >= 0) {
+    writer->Field("offset", static_cast<uint64_t>(offset));
+  }
+
+  writer->EndObject();
+}
+
+}  // namespace
+
+/**
+ * Every file, socket, pipe and device this process has open, and how close it is to its ceiling.
+ *
+ * `/proc/self/fd` is the process's own directory, so none of this can be refused the way the
+ * system-wide /proc files elsewhere in this library are. Java can list the numbers in that
+ * directory and go no further: the target of each entry needs `readlink` — `File.getCanonicalPath`
+ * throws on `socket:[12345]`, which is not a path — the kind needs `fstat`, the access mode and
+ * close-on-exec flag need `fcntl`, and the file offset needs `lseek`. None of the four has a
+ * counterpart in the Java API.
+ */
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_aoscoremonitor_diagnostics_jni_NativeDescriptorInspector_getDescriptorsNative(
+    JNIEnv* env, jobject /* this */) {
+  return aoscm::ReturnJson(env, [] {
+    JsonWriter writer;
+    writer.BeginObject();
+
+    rlimit limit = {};
+    if (getrlimit(RLIMIT_NOFILE, &limit) == 0) {
+      // An unlimited ceiling is left out rather than published as a sentinel, so the screen has
+      // nothing to draw a headroom bar against.
+      if (limit.rlim_cur != RLIM_INFINITY) {
+        writer.Field("limit_soft", static_cast<uint64_t>(limit.rlim_cur));
+      }
+      if (limit.rlim_max != RLIM_INFINITY) {
+        writer.Field("limit_hard", static_cast<uint64_t>(limit.rlim_max));
+      }
+    }
+
+    writer.Key("descriptors").BeginArray();
+    for (const int fd : ListDescriptorNumbers()) {
+      WriteDescriptor(&writer, fd);
+    }
+    writer.EndArray();
+
+    writer.EndObject();
+    return writer.Take();
+  });
+}

--- a/app/src/main/cpp/memory_map.cpp
+++ b/app/src/main/cpp/memory_map.cpp
@@ -204,9 +204,15 @@ Rollup ReadSmaps(const char* path, bool is_rollup_file) {
   return rollup;
 }
 
-/** The `/proc/self/status` lines the screen shows, in order. */
-constexpr std::array<const char*, 6> kStatusKeys = {
-    "VmSize", "VmRSS", "VmHWM", "VmSwap", "Threads", "FDSize",
+/**
+ * The `/proc/self/status` lines the screen shows, in order.
+ *
+ * FDSize was here and moved to the descriptor screen, which is about the descriptor table rather
+ * than about memory and reports the count against the limit it is approaching. Two screens showing
+ * the same figure is what that screen was added to stop, not to continue.
+ */
+constexpr std::array<const char*, 5> kStatusKeys = {
+    "VmSize", "VmRSS", "VmHWM", "VmSwap", "Threads",
 };
 
 void WriteStatus(JsonWriter* writer) {
@@ -311,7 +317,8 @@ Java_com_aoscoremonitor_diagnostics_jni_NativeMemoryInspector_getMemoryMapNative
     WriteLimit(&writer, "address_space", RLIMIT_AS);
     WriteLimit(&writer, "data", RLIMIT_DATA);
     WriteLimit(&writer, "stack", RLIMIT_STACK);
-    WriteLimit(&writer, "open_files", RLIMIT_NOFILE);
+    // RLIMIT_NOFILE was here. It bounds the descriptor table rather than the address space, and the
+    // descriptor screen shows it where the count it bounds is.
     writer.EndObject();
 
     writer.EndObject();

--- a/app/src/main/cpp/process_creds.cpp
+++ b/app/src/main/cpp/process_creds.cpp
@@ -1,0 +1,315 @@
+#include <jni.h>
+#include <sys/prctl.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <charconv>
+#include <cstdint>
+#include <fstream>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "native_util.h"
+
+namespace {
+
+using aoscm::JsonWriter;
+using aoscm::Reading;
+
+/**
+ * Capability names by bit, as the kernel numbers them.
+ *
+ * Written out rather than taken from <linux/capability.h>, which names the constants but offers no
+ * way to turn a bit back into its name. These are kernel identifiers, not prose, so they cross to
+ * Kotlin as-is and are shown verbatim — putting forty of them in strings.xml would ask a translator
+ * to translate CAP_SYS_ADMIN.
+ */
+constexpr std::array<const char*, 41> kCapabilityNames = {
+    "CAP_CHOWN",
+    "CAP_DAC_OVERRIDE",
+    "CAP_DAC_READ_SEARCH",
+    "CAP_FOWNER",
+    "CAP_FSETID",
+    "CAP_KILL",
+    "CAP_SETGID",
+    "CAP_SETUID",
+    "CAP_SETPCAP",
+    "CAP_LINUX_IMMUTABLE",
+    "CAP_NET_BIND_SERVICE",
+    "CAP_NET_BROADCAST",
+    "CAP_NET_ADMIN",
+    "CAP_NET_RAW",
+    "CAP_IPC_LOCK",
+    "CAP_IPC_OWNER",
+    "CAP_SYS_MODULE",
+    "CAP_SYS_RAWIO",
+    "CAP_SYS_CHROOT",
+    "CAP_SYS_PTRACE",
+    "CAP_SYS_PACCT",
+    "CAP_SYS_ADMIN",
+    "CAP_SYS_BOOT",
+    "CAP_SYS_NICE",
+    "CAP_SYS_RESOURCE",
+    "CAP_SYS_TIME",
+    "CAP_SYS_TTY_CONFIG",
+    "CAP_MKNOD",
+    "CAP_LEASE",
+    "CAP_AUDIT_WRITE",
+    "CAP_AUDIT_CONTROL",
+    "CAP_SETFCAP",
+    "CAP_MAC_OVERRIDE",
+    "CAP_MAC_ADMIN",
+    "CAP_SYSLOG",
+    "CAP_WAKE_ALARM",
+    "CAP_BLOCK_SUSPEND",
+    "CAP_AUDIT_READ",
+    "CAP_PERFMON",
+    "CAP_BPF",
+    "CAP_CHECKPOINT_RESTORE",
+};
+
+/** The five capability sets, as the JSON key each goes out under and the status line it comes from.
+ */
+constexpr std::array<std::pair<const char*, const char*>, 5> kCapabilitySets = {{
+    {"effective", "CapEff"},
+    {"permitted", "CapPrm"},
+    {"inheritable", "CapInh"},
+    {"bounding", "CapBnd"},
+    {"ambient", "CapAmb"},
+}};
+
+/**
+ * `/proc/self/status`, split into its name and value halves.
+ *
+ * A vector rather than a map: the file holds some sixty lines and this reads eight of them, so a
+ * linear scan is less machinery for the same answer.
+ */
+using StatusLines = std::vector<std::pair<std::string, std::string>>;
+
+StatusLines ReadStatus() {
+  StatusLines lines;
+  std::ifstream status("/proc/self/status");
+  std::string line;
+  while (std::getline(status, line)) {
+    const size_t colon = line.find(':');
+    if (colon == std::string::npos) {
+      continue;
+    }
+    const size_t value_start = line.find_first_not_of(" \t", colon + 1);
+    if (value_start == std::string::npos) {
+      continue;
+    }
+    lines.emplace_back(line.substr(0, colon), line.substr(value_start));
+  }
+  return lines;
+}
+
+const std::string* Find(const StatusLines& status, std::string_view key) {
+  for (const auto& [name, value] : status) {
+    if (name == key) {
+      return &value;
+    }
+  }
+  return nullptr;
+}
+
+std::optional<uint64_t> HexMask(const std::string& text) {
+  uint64_t value = 0;
+  const char* const first = text.data();
+  const auto [end, error] = std::from_chars(first, first + text.size(), value, 16);
+  if (error != std::errc() || end == first) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+/**
+ * One capability set, as the mask the kernel printed and the names the bits stand for.
+ *
+ * Both, rather than either alone: the names are what the set means, and the mask is what was
+ * actually read — a bit this build has no name for still shows up in it.
+ */
+void WriteCapabilitySet(JsonWriter* writer, const StatusLines& status, const char* key,
+                        const char* status_key) {
+  const std::string* text = Find(status, status_key);
+  if (text == nullptr) {
+    return;
+  }
+
+  writer->Key(key).BeginObject();
+  writer->Field("hex", *text);
+  if (const std::optional<uint64_t> mask = HexMask(*text)) {
+    writer->Key("names").BeginArray();
+    for (unsigned bit = 0; bit < 64; ++bit) {
+      if ((*mask & (uint64_t{1} << bit)) == 0) {
+        continue;
+      }
+      if (bit < kCapabilityNames.size()) {
+        writer->Value(kCapabilityNames[bit]);
+      } else {
+        // A capability this build predates. Named by its bit so the set still adds up, rather than
+        // dropped, which would show a non-empty mask alongside a shorter list than it holds.
+        writer->Value("CAP_" + std::to_string(bit));
+      }
+    }
+    writer->EndArray();
+  }
+  writer->EndObject();
+}
+
+/** Writes a `/proc/self/status` line that holds a plain decimal count. */
+void WriteStatusNumber(JsonWriter* writer, const StatusLines& status, const char* key,
+                       const char* status_key) {
+  const std::string* text = Find(status, status_key);
+  if (text == nullptr) {
+    return;
+  }
+  uint64_t value = 0;
+  const char* const first = text->data();
+  const auto [end, error] = std::from_chars(first, first + text->size(), value);
+  if (error == std::errc() && end != first) {
+    writer->Field(key, value);
+  }
+}
+
+void WriteUserIds(JsonWriter* writer) {
+  uid_t real = 0;
+  uid_t effective = 0;
+  uid_t saved = 0;
+  if (getresuid(&real, &effective, &saved) != 0) {
+    return;
+  }
+  writer->Key("uid").BeginObject();
+  writer->Field("real", static_cast<uint64_t>(real));
+  writer->Field("effective", static_cast<uint64_t>(effective));
+  writer->Field("saved", static_cast<uint64_t>(saved));
+  writer->EndObject();
+}
+
+void WriteGroupIds(JsonWriter* writer) {
+  gid_t real = 0;
+  gid_t effective = 0;
+  gid_t saved = 0;
+  if (getresgid(&real, &effective, &saved) != 0) {
+    return;
+  }
+  writer->Key("gid").BeginObject();
+  writer->Field("real", static_cast<uint64_t>(real));
+  writer->Field("effective", static_cast<uint64_t>(effective));
+  writer->Field("saved", static_cast<uint64_t>(saved));
+  writer->EndObject();
+}
+
+/**
+ * The supplementary groups, which on Android are how an app is granted whole capabilities of the
+ * platform — AID_INET for a socket, AID_EXT_STORAGE for the shared volume.
+ */
+void WriteSupplementaryGroups(JsonWriter* writer) {
+  const int count = getgroups(0, nullptr);
+  if (count < 0) {
+    writer->Field("groups_unavailable", aoscm::DescribeFailure(errno));
+    return;
+  }
+
+  std::vector<gid_t> groups(static_cast<size_t>(count));
+  // Asked for twice on purpose: setgroups can run between the two calls, and getgroups reports
+  // that as EINVAL rather than filling a short buffer.
+  const int filled = getgroups(count, groups.data());
+  if (filled < 0) {
+    writer->Field("groups_unavailable", aoscm::DescribeFailure(errno));
+    return;
+  }
+
+  writer->Key("groups").BeginArray();
+  for (int i = 0; i < filled; ++i) {
+    writer->Value(static_cast<uint64_t>(groups[static_cast<size_t>(i)]));
+  }
+  writer->EndArray();
+}
+
+/** A switch `prctl` answers with 0 or 1, or the reason it would not answer. */
+void WritePrctlFlag(JsonWriter* writer, const char* key, const char* unavailable_key, int option) {
+  const int value = prctl(option, 0, 0, 0, 0);
+  if (value < 0) {
+    writer->Field(unavailable_key, aoscm::DescribeFailure(errno));
+    return;
+  }
+  writer->Field(key, value != 0);
+}
+
+void WriteSelinuxContext(JsonWriter* writer) {
+  const Reading<std::string> context = aoscm::ReadTrimmedLine("/proc/self/attr/current");
+  if (!context.has_value()) {
+    writer->Field("selinux_context_unavailable", aoscm::DescribeFailure(context.error()));
+    return;
+  }
+  // The kernel terminates what it writes here, and a NUL is not whitespace, so it survives the trim
+  // and would otherwise cross to Kotlin escaped as \u0000 on the end of the domain name.
+  const std::string_view text(*context);
+  writer->Field("selinux_context", text.substr(0, text.find('\0')));
+}
+
+}  // namespace
+
+/**
+ * Who this process is to the kernel, and what the kernel will let it do.
+ *
+ * All of it is about this process rather than about the device, which is what separates it from the
+ * security screen: `getenforce` says whether SELinux is enforcing anywhere, and
+ * `/proc/self/attr/current` says which domain confines *this* app.
+ *
+ * None of it can be read from Java. `Process.myUid()` returns the effective uid and stops there:
+ * the real and saved ids, the supplementary groups, the five capability sets, the seccomp mode and
+ * the no_new_privs bit have no counterpart in the Java API, and the capability sets are not even a
+ * syscall away — they are printed by the kernel in `/proc/self/status` and nowhere else.
+ */
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_aoscoremonitor_diagnostics_jni_NativeCredentialsInspector_getCredentialsNative(
+    JNIEnv* env, jobject /* this */) {
+  return aoscm::ReturnJson(env, [] {
+    const StatusLines status = ReadStatus();
+
+    JsonWriter writer;
+    writer.BeginObject();
+
+    writer.Field("pid", static_cast<uint64_t>(getpid()));
+    writer.Field("ppid", static_cast<uint64_t>(getppid()));
+    writer.Field("pgid", static_cast<uint64_t>(getpgrp()));
+    if (const pid_t session = getsid(0); session >= 0) {
+      writer.Field("sid", static_cast<uint64_t>(session));
+    }
+
+    WriteUserIds(&writer);
+    WriteGroupIds(&writer);
+    WriteSupplementaryGroups(&writer);
+
+    writer.Key("capabilities").BeginObject();
+    for (const auto& [key, status_key] : kCapabilitySets) {
+      WriteCapabilitySet(&writer, status, key, status_key);
+    }
+    writer.EndObject();
+
+    WritePrctlFlag(&writer, "no_new_privs", "no_new_privs_unavailable", PR_GET_NO_NEW_PRIVS);
+    WritePrctlFlag(&writer, "dumpable", "dumpable_unavailable", PR_GET_DUMPABLE);
+
+    WriteStatusNumber(&writer, status, "seccomp", "Seccomp");
+    WriteStatusNumber(&writer, status, "seccomp_filters", "Seccomp_filters");
+
+    // As a string, not a number: a umask is octal, and 0077 published as 77 decimal is a different
+    // mask that happens to print plausibly.
+    if (const std::string* umask = Find(status, "Umask")) {
+      writer.Field("umask", *umask);
+    }
+
+    WriteSelinuxContext(&writer);
+
+    writer.EndObject();
+    return writer.Take();
+  });
+}

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/DisplayInventory.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/DisplayInventory.kt
@@ -1,0 +1,270 @@
+package com.aoscoremonitor.diagnostics
+
+import android.content.Context
+import android.hardware.display.DeviceProductInfo
+import android.hardware.display.DisplayManager
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.Display
+import android.view.Surface
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
+
+/** What the panel is doing, which is more than on or off: a dozing screen is still displaying. */
+enum class DisplayState {
+    On,
+    Off,
+
+    /** Showing an always-on or ambient image at a low rate. */
+    Doze,
+
+    /** Dozing with the CPU no longer driving it — the panel is holding the last image itself. */
+    DozeSuspended,
+
+    /** On, with the display pipeline suspended. */
+    OnSuspended,
+    Unknown;
+
+    internal companion object {
+        fun of(state: Int): DisplayState = when (state) {
+            Display.STATE_OFF -> Off
+            Display.STATE_ON -> On
+            Display.STATE_DOZE -> Doze
+            Display.STATE_DOZE_SUSPEND -> DozeSuspended
+            Display.STATE_ON_SUSPEND -> OnSuspended
+            else -> Unknown
+        }
+    }
+}
+
+/**
+ * A high dynamic range format the panel accepts.
+ *
+ * Kept as an enum rather than the platform's integer so the wording lives in strings.xml, the same
+ * arrangement the thread and sensor screens use for their kernel and HAL constants.
+ */
+enum class HdrType {
+    DolbyVision,
+    Hdr10,
+    Hlg,
+    Hdr10Plus,
+    Unknown;
+
+    internal companion object {
+        fun of(type: Int): HdrType = when (type) {
+            HDR_DOLBY_VISION -> DolbyVision
+            HDR_10 -> Hdr10
+            HDR_HLG -> Hlg
+            HDR_10_PLUS -> Hdr10Plus
+            else -> Unknown
+        }
+
+        // The values of Display.HdrCapabilities.HDR_TYPE_*, which are constants of a class
+        // deprecated in API 34 while the values they name are what both the old and the new API
+        // return.
+        const val HDR_DOLBY_VISION = 1
+        const val HDR_10 = 2
+        const val HDR_HLG = 3
+        const val HDR_10_PLUS = 4
+    }
+}
+
+/** How the panel is wired to the device. */
+enum class DisplayConnection {
+    /** The screen in the phone. */
+    BuiltIn,
+
+    /** Plugged straight in — HDMI, DisplayPort. */
+    Direct,
+
+    /** Reached through something else, as a display behind a receiver is. */
+    Transitive,
+    Unknown
+}
+
+/**
+ * What the panel says it is, from the EDID the platform parsed.
+ *
+ * Absent on most phones: a built-in panel has no EDID to read, and the platform answers with null
+ * rather than with blanks. Reported when it is there because it is the one place the device says
+ * who made the screen.
+ */
+data class DisplayProduct(
+    val manufacturerPnpId: String? = null,
+    val productId: String? = null,
+    val manufactureYear: Int? = null,
+    val connection: DisplayConnection = DisplayConnection.Unknown
+) {
+    val hasIdentity: Boolean get() = manufacturerPnpId != null || productId != null || manufactureYear != null
+}
+
+/** One mode the panel can be driven in. */
+data class DisplayMode(val id: Int, val widthPixels: Int, val heightPixels: Int, val refreshRateHz: Float) {
+    /** What one frame is worth at this rate, which is what a dropped frame is measured against. */
+    val frameIntervalNanos: Long get() = if (refreshRateHz > 0f) (NANOS_PER_SECOND / refreshRateHz).toLong() else 0
+
+    private companion object {
+        const val NANOS_PER_SECOND = 1_000_000_000f
+    }
+}
+
+/** The area a cutout takes out of the display, as the insets that keep content clear of it. */
+data class CutoutInsets(val left: Int, val top: Int, val right: Int, val bottom: Int, val boundingRects: Int)
+
+/**
+ * The default display, as the platform describes it.
+ *
+ * Read through [DisplayManager] rather than through a window: the collectors here are handed the
+ * application context, which has no window and no display of its own, and asking it for one throws.
+ * The manager answers for the display itself, which is what this screen is about anyway.
+ */
+data class DisplayInfo(
+    val name: String,
+    val displayId: Int,
+    val state: DisplayState,
+    val rotationDegrees: Int,
+    val currentMode: DisplayMode?,
+    val modes: List<DisplayMode> = emptyList(),
+    val densityDpi: Int = 0,
+    val density: Float = 0f,
+    val xDpi: Float = 0f,
+    val yDpi: Float = 0f,
+    val fontScale: Float = 0f,
+    val hdrTypes: List<HdrType> = emptyList(),
+    val isWideColorGamut: Boolean = false,
+    val cutout: CutoutInsets? = null,
+    val isSecure: Boolean = false,
+    val isRound: Boolean = false,
+    val supportsMinimalPostProcessing: Boolean = false,
+    val appVsyncOffsetNanos: Long = 0,
+    val presentationDeadlineNanos: Long = 0,
+    val product: DisplayProduct = DisplayProduct()
+) {
+    /** The rate the panel is being driven at now, which the frame screen measures against. */
+    val refreshRateHz: Float get() = currentMode?.refreshRateHz ?: 0f
+
+    val frameIntervalNanos: Long get() = currentMode?.frameIntervalNanos ?: 0
+}
+
+/**
+ * Reads the default display.
+ *
+ * Returns null only where there is no display service at all, which no device this app runs on is;
+ * everything a particular panel does not report is left null inside the reading rather than
+ * collapsing the whole of it.
+ */
+fun readDisplayInfo(context: Context): DisplayInfo? {
+    val displayManager = context.getSystemService(DisplayManager::class.java) ?: return null
+    val display = displayManager.getDisplay(Display.DEFAULT_DISPLAY) ?: return null
+    val metrics = context.resources.displayMetrics
+    val current = display.mode
+
+    return DisplayInfo(
+        name = display.name.orEmpty(),
+        displayId = display.displayId,
+        state = DisplayState.of(display.state),
+        rotationDegrees = rotationDegrees(display.rotation),
+        currentMode = current?.let(::toMode),
+        modes = display.supportedModes.orEmpty().map(::toMode),
+        densityDpi = metrics.densityDpi,
+        density = metrics.density,
+        xDpi = metrics.xdpi,
+        yDpi = metrics.ydpi,
+        fontScale = context.resources.configuration.fontScale,
+        hdrTypes = readHdrTypes(display, current),
+        isWideColorGamut = display.isWideColorGamut,
+        cutout = display.cutout?.let { cutout ->
+            CutoutInsets(
+                left = cutout.safeInsetLeft,
+                top = cutout.safeInsetTop,
+                right = cutout.safeInsetRight,
+                bottom = cutout.safeInsetBottom,
+                boundingRects = cutout.boundingRects.size
+            )
+        },
+        isSecure = display.flags and Display.FLAG_SECURE != 0,
+        isRound = display.flags and Display.FLAG_ROUND != 0,
+        supportsMinimalPostProcessing = display.isMinimalPostProcessingSupported,
+        appVsyncOffsetNanos = display.appVsyncOffsetNanos,
+        presentationDeadlineNanos = display.presentationDeadlineNanos,
+        product = display.deviceProductInfo?.let(::toProduct) ?: DisplayProduct()
+    )
+}
+
+/**
+ * The display, and every change to it.
+ *
+ * A listener rather than a poll: rotation, a mode switch and the screen going to doze are events
+ * the platform already publishes, and polling for them would either miss them or spend a wake-up
+ * every second finding nothing changed.
+ */
+fun displayChanges(context: Context): Flow<DisplayInfo?> = callbackFlow {
+    trySend(readDisplayInfo(context))
+
+    val displayManager = context.getSystemService(DisplayManager::class.java)
+    val listener = object : DisplayManager.DisplayListener {
+        override fun onDisplayAdded(displayId: Int) = Unit
+
+        override fun onDisplayRemoved(displayId: Int) = Unit
+
+        override fun onDisplayChanged(displayId: Int) {
+            if (displayId == Display.DEFAULT_DISPLAY) {
+                trySend(readDisplayInfo(context))
+            }
+        }
+    }
+
+    // The main looper, not the collecting thread's: this flow is collected from wherever a view
+    // model happens to be, and registerDisplayListener needs a handler for a thread that has one.
+    displayManager?.registerDisplayListener(listener, Handler(Looper.getMainLooper()))
+    awaitClose { displayManager?.unregisterDisplayListener(listener) }
+}
+    // Several changes can land in one turn — a rotation reports the size and the mode separately —
+    // and only the newest reading is worth drawing.
+    .conflate()
+
+private fun toMode(mode: Display.Mode) = DisplayMode(
+    id = mode.modeId,
+    widthPixels = mode.physicalWidth,
+    heightPixels = mode.physicalHeight,
+    refreshRateHz = mode.refreshRate
+)
+
+private fun toProduct(info: DeviceProductInfo) = DisplayProduct(
+    manufacturerPnpId = info.manufacturerPnpId.takeIf { it.isNotEmpty() },
+    productId = info.productId.takeIf { it.isNotEmpty() },
+    manufactureYear = info.manufactureYear.takeIf { it > 0 },
+    connection = when (info.connectionToSinkType) {
+        DeviceProductInfo.CONNECTION_TO_SINK_BUILT_IN -> DisplayConnection.BuiltIn
+        DeviceProductInfo.CONNECTION_TO_SINK_DIRECT -> DisplayConnection.Direct
+        DeviceProductInfo.CONNECTION_TO_SINK_TRANSITIVE -> DisplayConnection.Transitive
+        else -> DisplayConnection.Unknown
+    }
+)
+
+/**
+ * Which HDR formats the panel accepts.
+ *
+ * The list moved from the display to the mode in API 34, because a panel can accept HDR in one mode
+ * and not in another, and the old call was deprecated rather than made to say which mode it meant.
+ * Both are read here: the app supports devices on either side of that change.
+ */
+private fun readHdrTypes(display: Display, mode: Display.Mode?): List<HdrType> {
+    val types = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && mode != null) {
+        mode.supportedHdrTypes
+    } else {
+        @Suppress("DEPRECATION")
+        display.hdrCapabilities?.supportedHdrTypes ?: IntArray(0)
+    }
+    return types.map(HdrType::of).distinct()
+}
+
+private fun rotationDegrees(rotation: Int): Int = when (rotation) {
+    Surface.ROTATION_90 -> 90
+    Surface.ROTATION_180 -> 180
+    Surface.ROTATION_270 -> 270
+    else -> 0
+}

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/FramePacing.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/FramePacing.kt
@@ -1,0 +1,86 @@
+package com.aoscoremonitor.diagnostics
+
+import kotlin.math.max
+import kotlin.math.roundToInt
+
+/**
+ * How well this app is being served frames.
+ *
+ * Built from the gaps between successive `Choreographer` callbacks. A gap is measured in frame
+ * slots rather than in milliseconds, because a gap that means everything is fine on a 60 Hz panel —
+ * 16.7 ms — means a frame was missed on a 120 Hz one. [periodNanos] is what a slot is worth, taken
+ * from the display's current mode.
+ *
+ * Kept apart from the callback that feeds it so the arithmetic can be exercised without a display:
+ * every field here follows from the sequence of gaps and nothing else.
+ */
+data class FramePacing(
+    val periodNanos: Long = 0,
+    val intervals: Int = 0,
+    val elapsedNanos: Long = 0,
+    val worstIntervalNanos: Long = 0,
+    val histogram: Map<Int, Int> = emptyMap()
+) {
+
+    /**
+     * Frames the app was late for.
+     *
+     * A gap of one slot delivered one frame; a gap of three delivered one and missed two. Summed
+     * this way rather than counted as "janky gaps", because a single stall of half a second is not
+     * the same event as one late frame.
+     */
+    val droppedFrames: Int get() = histogram.entries.sumOf { (slots, count) -> (slots - 1) * count }
+
+    /** The share of gaps that were longer than one slot. */
+    val jankFraction: Float?
+        get() {
+            if (intervals == 0) return null
+            val late = histogram.entries.filter { (slots, _) -> slots > 1 }.sumOf { it.value }
+            return late.toFloat() / intervals
+        }
+
+    /**
+     * The rate frames actually arrived at.
+     *
+     * Measured rather than taken from the mode: a panel that reports 120 Hz still delivers 60 when
+     * the app cannot keep up, and the difference between the two numbers is the whole point of the
+     * screen.
+     */
+    val measuredFps: Float? get() = if (elapsedNanos <= 0) null else intervals * NANOS_PER_SECOND / elapsedNanos
+
+    /** The worst gap, in slots, for a screen that wants to say how bad the worst stall was. */
+    val worstSlots: Int get() = slotsFor(worstIntervalNanos)
+
+    /** The histogram in slot order, so the bars do not reshuffle as counts change. */
+    val distribution: List<Pair<Int, Int>> get() = histogram.entries.sortedBy { it.key }.map { it.key to it.value }
+
+    /**
+     * Folds one gap in.
+     *
+     * Gaps shorter than half a slot are dropped rather than counted: `Choreographer` can deliver
+     * two callbacks for one vsync when a frame is scheduled while one is already pending, and
+     * counting that as a frame would report a rate above what the panel can display.
+     */
+    fun plus(intervalNanos: Long): FramePacing {
+        if (periodNanos <= 0 || intervalNanos * 2 < periodNanos) {
+            return this
+        }
+        val slots = slotsFor(intervalNanos)
+        return copy(
+            intervals = intervals + 1,
+            elapsedNanos = elapsedNanos + intervalNanos,
+            worstIntervalNanos = max(worstIntervalNanos, intervalNanos),
+            histogram = histogram + (slots to (histogram[slots] ?: 0) + 1)
+        )
+    }
+
+    /** How many frame slots a gap spans, rounded, so that ordinary jitter is not read as a miss. */
+    private fun slotsFor(intervalNanos: Long): Int {
+        if (periodNanos <= 0) return 0
+        return max(1, (intervalNanos.toDouble() / periodNanos).roundToInt())
+    }
+
+    private companion object {
+        const val NANOS_PER_SECOND = 1_000_000_000f
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/SystemDiagnosticsCollector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/SystemDiagnosticsCollector.kt
@@ -2,7 +2,6 @@ package com.aoscoremonitor.diagnostics
 
 import android.app.ActivityManager
 import android.content.Context
-import android.os.PowerManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -14,6 +13,10 @@ import kotlinx.coroutines.withContext
 
 /**
  * A class that analyzes system state using public APIs of AOSP internal services.
+ *
+ * The screen state was read here too, from `PowerManager.isInteractive`. It says what the display
+ * is doing, so it is read and shown by the display screen, which distinguishes dozing from off
+ * where a boolean could not.
  */
 class SystemDiagnosticsCollector(private val context: Context, private val onUpdate: (DiagnosticsInfo) -> Unit) {
     /**
@@ -23,7 +26,7 @@ class SystemDiagnosticsCollector(private val context: Context, private val onUpd
      * system info collector reads a second earlier. Two collectors polling one API for one figure
      * put the same number on two screens, so the figure lives on the system info screen alone now.
      */
-    data class DiagnosticsInfo(val runningProcesses: List<String>, val screenOn: Boolean, val dumpsysResult: String)
+    data class DiagnosticsInfo(val runningProcesses: List<String>, val dumpsysResult: String)
 
     // Maintain CoroutineScope at class level
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -40,7 +43,6 @@ class SystemDiagnosticsCollector(private val context: Context, private val onUpd
             try {
                 val activityManager =
                     context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-                val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
 
                 while (isActive) {
                     // --- Get running process information from ActivityManager ---
@@ -49,16 +51,12 @@ class SystemDiagnosticsCollector(private val context: Context, private val onUpd
                     val runningAppProcesses = activityManager.runningAppProcesses
                     val processNames = runningAppProcesses?.map { it.processName } ?: emptyList()
 
-                    // --- Get screen state from PowerManager ---
-                    val screenOn = powerManager.isInteractive
-
                     // --- Get dumpsys command result ---
                     val dumpsysResult = readDumpsysResult()
 
                     // --- Notify diagnostic information ---
                     val diagnosticsInfo = DiagnosticsInfo(
                         runningProcesses = processNames,
-                        screenOn = screenOn,
                         dumpsysResult = dumpsysResult
                     )
 

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/JsonReading.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/JsonReading.kt
@@ -46,6 +46,14 @@ internal fun JSONObject.intOrNull(key: String): Int? = if (has(key)) optInt(key)
 
 internal fun JSONObject.stringOrNull(key: String): String? = if (has(key)) optString(key) else null
 
+/**
+ * The same, for switches the kernel would not answer for.
+ *
+ * `optBoolean` answers false both for a switch that is off and for one that could not be read, and
+ * "no_new_privs is not set" is a different statement from "this kernel would not say".
+ */
+internal fun JSONObject.booleanOrNull(key: String): Boolean? = if (has(key)) optBoolean(key) else null
+
 /** Iterates a JSON array of objects, skipping entries that are not objects. */
 internal inline fun <T> JSONArray.mapObjects(transform: (JSONObject) -> T): List<T> =
     (0 until length()).mapNotNull { index -> optJSONObject(index)?.let(transform) }

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeCredentialsInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeCredentialsInspector.kt
@@ -1,0 +1,207 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/** A uid or gid in its three forms. Only [effective] decides what a syscall is allowed to do. */
+data class CredentialIds(val real: Int, val effective: Int, val saved: Int) {
+    /** Whether the process could switch back to another identity, which for an app it cannot. */
+    val allTheSame: Boolean get() = real == effective && effective == saved
+}
+
+/**
+ * One capability set.
+ *
+ * [hex] is the mask the kernel printed and [names] the bits it stands for. Both are kept: the names
+ * are what the set means, and the mask is what was read — including a bit this build of the app has
+ * no name for, which arrives as `CAP_41` rather than being dropped.
+ */
+data class CapabilitySet(val hex: String, val names: List<String> = emptyList()) {
+    val isEmpty: Boolean get() = names.isEmpty()
+}
+
+/** How much of the kernel's syscall surface is filtered away. */
+enum class SeccompMode {
+    /** No filter. For an app on a stock build, this is not what is expected. */
+    Disabled,
+
+    /** `SECCOMP_MODE_STRICT`: read, write, exit and sigreturn, and nothing else. */
+    Strict,
+
+    /** `SECCOMP_MODE_FILTER`: a BPF program decides, which is what zygote installs. */
+    Filter,
+    Unknown;
+
+    internal companion object {
+        fun of(value: Int?): SeccompMode = when (value) {
+            0 -> Disabled
+            1 -> Strict
+            2 -> Filter
+            else -> Unknown
+        }
+    }
+}
+
+/**
+ * Who this process is to the kernel, and what the kernel will let it do.
+ *
+ * Every field is nullable or defaulted because each comes from a separate syscall or status line,
+ * and a kernel that does not report one — `Umask` predates no kernel Android ships, but `CapAmb`
+ * postdates several — should cost that one line rather than the screen.
+ */
+data class ProcessCredentials(
+    val pid: Int = 0,
+    val parentPid: Int = 0,
+    val processGroup: Int = 0,
+    val session: Int? = null,
+    val user: CredentialIds? = null,
+    val group: CredentialIds? = null,
+    val supplementaryGroups: List<Int> = emptyList(),
+    val groupsUnavailable: Unavailable? = null,
+    val capabilities: Map<String, CapabilitySet> = emptyMap(),
+    val noNewPrivs: Boolean? = null,
+    val dumpable: Boolean? = null,
+    val seccomp: SeccompMode = SeccompMode.Unknown,
+    val seccompFilters: Int? = null,
+    val umask: String? = null,
+    val selinuxContext: String? = null,
+    val selinuxUnavailable: Unavailable? = null
+) {
+    /** The multi-user id Android packed into the uid: 0 on a single-user device. */
+    val androidUserId: Int? get() = user?.let { it.effective / PER_USER_RANGE }
+
+    /** The per-user app id, which is what `ro.` properties and package records call the app. */
+    val appId: Int? get() = user?.let { it.effective % PER_USER_RANGE }
+
+    /** Whether the effective uid is an ordinary installed app rather than a platform identity. */
+    val isAppUid: Boolean get() = appId?.let { it in APP_ID_RANGE } == true
+
+    /**
+     * The SELinux type, pulled out of `user:role:type:level`.
+     *
+     * The type is the part that says what the process may touch — `untrusted_app` against
+     * `platform_app` is the whole difference — so it is worth stating on its own rather than
+     * leaving it in the middle of a context string that runs to a hundred characters of categories.
+     */
+    val selinuxType: String? get() = selinuxContext?.split(':')?.getOrNull(SELINUX_TYPE_FIELD)
+
+    private companion object {
+        /** Android's `PER_USER_RANGE`: uid = userId * 100000 + appId. */
+        const val PER_USER_RANGE = 100_000
+
+        /** `AID_APP_START`..`AID_APP_END` from AOSP's android_filesystem_config.h. */
+        val APP_ID_RANGE = 10_000..19_999
+        const val SELINUX_TYPE_FIELD = 2
+    }
+}
+
+/**
+ * The name AOSP gives a supplementary group, where it has one.
+ *
+ * Only the ones an ordinary app is actually granted are listed; the full table runs to hundreds of
+ * platform identities an app will never hold, and a number with no name is shown as a number. The
+ * source is `android_filesystem_config.h`, and the ranges below it are from the same file.
+ */
+fun androidGroupName(gid: Int): String? = when (gid) {
+    1015 -> "sdcard_rw"
+    1023 -> "media_rw"
+    1028 -> "sdcard_r"
+    1077 -> "ext_data_rw"
+    1078 -> "ext_obb_rw"
+    3001 -> "net_bt_admin"
+    3002 -> "net_bt"
+    3003 -> "inet"
+    3004 -> "net_raw"
+    3005 -> "net_admin"
+    3006 -> "net_bw_stats"
+    3007 -> "net_bw_acct"
+    3009 -> "readproc"
+    3011 -> "uhid"
+    9997 -> "everybody"
+    9998 -> "misc"
+    else -> when (gid) {
+        in 20_000..29_999 -> "cache"
+        in 40_000..49_999 -> "shared_gid"
+        in 50_000..59_999 -> "shared_gid"
+        in 99_000..99_999 -> "isolated"
+        else -> null
+    }
+}
+
+/**
+ * Reads this process's credentials through JNI.
+ *
+ * `Process.myUid()` returns the effective uid and stops there. The real and saved ids, the
+ * supplementary groups, the five capability sets, the seccomp mode and the no_new_privs bit have no
+ * counterpart in the Java API — and the capability sets are not even a syscall away, being printed
+ * by the kernel in `/proc/self/status` and nowhere else.
+ */
+class NativeCredentialsInspector {
+
+    external fun getCredentialsNative(): String
+
+    suspend fun read(): ProcessCredentials? = withContext(Dispatchers.IO) {
+        if (!NativeLibrary.isAvailable) return@withContext null
+        try {
+            parseCredentials(getCredentialsNative())
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing process credentials", e)
+            null
+        }
+    }
+
+    private companion object {
+        const val TAG = "NativeCredentialsInspector"
+    }
+}
+
+/** The order the screen shows the capability sets in, which is the order they constrain each other. */
+internal val CapabilitySetKeys = listOf("effective", "permitted", "inheritable", "bounding", "ambient")
+
+/** Kept apart from the JNI call so it can be exercised without a device. */
+internal fun parseCredentials(json: String): ProcessCredentials {
+    val root = JSONObject(json)
+
+    val capabilities = root.optJSONObject("capabilities")?.let { sets ->
+        CapabilitySetKeys.mapNotNull { key ->
+            val set = sets.optJSONObject(key) ?: return@mapNotNull null
+            val names = set.optJSONArray("names")?.let { array ->
+                (0 until array.length()).map { array.optString(it) }.filter { it.isNotEmpty() }
+            }.orEmpty()
+            key to CapabilitySet(hex = set.optString("hex"), names = names)
+        }.toMap()
+    }.orEmpty()
+
+    val groups = root.optJSONArray("groups")?.let { array ->
+        (0 until array.length()).map { array.optInt(it) }
+    }.orEmpty()
+
+    return ProcessCredentials(
+        pid = root.optInt("pid"),
+        parentPid = root.optInt("ppid"),
+        processGroup = root.optInt("pgid"),
+        session = root.intOrNull("sid"),
+        user = root.optJSONObject("uid")?.toCredentialIds(),
+        group = root.optJSONObject("gid")?.toCredentialIds(),
+        // Sorted so that the platform identities an app is granted — 3003 inet, 9997 everybody —
+        // read in a fixed order rather than in whatever order getgroups filled the array.
+        supplementaryGroups = groups.sorted(),
+        groupsUnavailable = root.unavailable("groups_unavailable"),
+        capabilities = capabilities,
+        noNewPrivs = root.booleanOrNull("no_new_privs"),
+        dumpable = root.booleanOrNull("dumpable"),
+        seccomp = SeccompMode.of(root.intOrNull("seccomp")),
+        seccompFilters = root.intOrNull("seccomp_filters"),
+        umask = root.stringOrNull("umask"),
+        selinuxContext = root.stringOrNull("selinux_context"),
+        selinuxUnavailable = root.unavailable("selinux_context_unavailable")
+    )
+}
+
+private fun JSONObject.toCredentialIds() = CredentialIds(
+    real = optInt("real"),
+    effective = optInt("effective"),
+    saved = optInt("saved")
+)

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeDescriptorInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeDescriptorInspector.kt
@@ -1,0 +1,199 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/**
+ * What a descriptor is open on.
+ *
+ * Derived here rather than sent by the native collector: the kernel reports a type and a link
+ * target, and which of those matters differs by case — an eventfd and a regular file are both
+ * `S_IFREG` to `fstat` and are told apart only by the target text, while a socket is a socket
+ * whatever its target says. Deciding it here also means changing the grouping does not mean
+ * rebuilding the library.
+ */
+enum class DescriptorKind {
+    /** An ordinary file: an APK, a font, a dex the runtime has mapped. */
+    File,
+    Directory,
+    Socket,
+
+    /** A pipe, named or otherwise. */
+    Pipe,
+
+    /** eventfd, epoll, timerfd, dmabuf — a kernel object with no name in any filesystem. */
+    AnonInode,
+
+    /** A character or block device: /dev/binder, /dev/null, /dev/ashmem. */
+    Device,
+    Other
+}
+
+/** How the file was opened, from the access mode the descriptor carries. */
+enum class DescriptorAccess {
+    Read,
+    Write,
+    ReadWrite,
+    Unknown;
+
+    internal companion object {
+        fun of(token: String?): DescriptorAccess = when (token) {
+            "read" -> Read
+            "write" -> Write
+            "readwrite" -> ReadWrite
+            else -> Unknown
+        }
+    }
+}
+
+/**
+ * One open descriptor.
+ *
+ * [target] is the link text from `/proc/self/fd`, which is a path only some of the time: a socket
+ * reads as `socket:[12345]` and an eventfd as `anon_inode:[eventfd]`. It is kept verbatim because
+ * those forms are what identifies the object, and [targetUnavailable] says why it is empty when the
+ * link could not be read at all.
+ *
+ * [offset] is null for anything with no position to be at — a socket, a pipe — rather than zero,
+ * which would read as "at the beginning".
+ */
+data class OpenDescriptor(
+    val fd: Int,
+    val target: String = "",
+    val targetUnavailable: Unavailable? = null,
+    val type: String? = null,
+    val typeUnavailable: Unavailable? = null,
+    val access: DescriptorAccess = DescriptorAccess.Unknown,
+    val flags: List<String> = emptyList(),
+    val closeOnExec: Boolean = false,
+    val inode: Long? = null,
+    val sizeBytes: Long? = null,
+    val offset: Long? = null
+) {
+    val kind: DescriptorKind
+        get() = when {
+            target.startsWith(ANON_INODE_PREFIX) -> DescriptorKind.AnonInode
+            type == "socket" -> DescriptorKind.Socket
+            type == "fifo" -> DescriptorKind.Pipe
+            type == "directory" -> DescriptorKind.Directory
+            type == "character" || type == "block" -> DescriptorKind.Device
+            type == "regular" -> DescriptorKind.File
+            else -> DescriptorKind.Other
+        }
+
+    /**
+     * The short label for the list.
+     *
+     * A long path is shown by its file name, because the process holds a dozen descriptors under
+     * /apex/com.android.art/javalib and the directory is the same for all of them. A short one is
+     * shown whole: splitting /dev/null leaves a card headed "null" over a line reading "/dev",
+     * which is two lines to say what fitted on one.
+     *
+     * Anything that is not a path — `socket:[12345]`, `anon_inode:[eventfd]` — has no file name to
+     * split off and is always shown whole.
+     */
+    val displayName: String get() = if (isSplit) target.substringAfterLast('/') else target
+
+    /** The directory a long path was opened from, and empty for anything shown whole. */
+    val directory: String get() = if (isSplit) target.substringBeforeLast('/', "") else ""
+
+    private val isSplit: Boolean get() = target.startsWith('/') && target.length > SHORT_PATH
+
+    private companion object {
+        const val ANON_INODE_PREFIX = "anon_inode:"
+
+        /** Roughly what fits on one line of a card beside the two tags, on a phone. */
+        const val SHORT_PATH = 24
+    }
+}
+
+/**
+ * The descriptor table, and the ceiling it is filling up against.
+ *
+ * [softLimit] is null when the limit is unbounded, which the native side leaves out rather than
+ * sending a sentinel that would be drawn as a nearly-empty bar.
+ */
+data class DescriptorSnapshot(
+    val descriptors: List<OpenDescriptor> = emptyList(),
+    val softLimit: Long? = null,
+    val hardLimit: Long? = null
+) {
+    val count: Int get() = descriptors.size
+
+    /** How much of the soft limit is spent, for a headroom bar. */
+    val usedFraction: Float?
+        get() {
+            val limit = softLimit ?: return null
+            if (limit <= 0) return null
+            return (count.toFloat() / limit.toFloat()).coerceIn(0f, 1f)
+        }
+
+    /** How many descriptors of each kind, in a fixed order so the breakdown does not reshuffle. */
+    val breakdown: List<Pair<DescriptorKind, Int>>
+        get() = DescriptorKind.entries
+            .map { kind -> kind to descriptors.count { it.kind == kind } }
+            .filter { (_, count) -> count > 0 }
+}
+
+/**
+ * Lists what this process has open.
+ *
+ * Java can name the numbers in `/proc/self/fd` and go no further. The target of each needs
+ * `readlink` — `File.getCanonicalPath` throws on `socket:[12345]`, which is not a path — the kind
+ * needs `fstat`, the access mode and close-on-exec flag need `fcntl`, and the file offset needs
+ * `lseek`. None of the four has a counterpart in the Java API.
+ */
+class NativeDescriptorInspector {
+
+    external fun getDescriptorsNative(): String
+
+    suspend fun read(): DescriptorSnapshot? = withContext(Dispatchers.IO) {
+        if (!NativeLibrary.isAvailable) return@withContext null
+        try {
+            parseDescriptors(getDescriptorsNative())
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing descriptor list", e)
+            null
+        }
+    }
+
+    private companion object {
+        const val TAG = "NativeDescriptorInspector"
+    }
+}
+
+/** Kept apart from the JNI call so it can be exercised without a device. */
+internal fun parseDescriptors(json: String): DescriptorSnapshot {
+    val root = JSONObject(json)
+
+    val descriptors = root.optJSONArray("descriptors")?.mapObjects { descriptor ->
+        val flags = descriptor.optJSONArray("flags")?.let { array ->
+            (0 until array.length()).map { array.optString(it) }.filter { it.isNotEmpty() }
+        }.orEmpty()
+
+        OpenDescriptor(
+            fd = descriptor.optInt("fd"),
+            target = descriptor.stringOrNull("target").orEmpty(),
+            targetUnavailable = descriptor.unavailable("target_unavailable"),
+            type = descriptor.stringOrNull("type"),
+            typeUnavailable = descriptor.unavailable("stat_unavailable"),
+            access = DescriptorAccess.of(descriptor.stringOrNull("access")),
+            flags = flags,
+            closeOnExec = descriptor.optBoolean("close_on_exec"),
+            inode = descriptor.longOrNull("inode"),
+            sizeBytes = descriptor.longOrNull("size_bytes"),
+            offset = descriptor.longOrNull("offset")
+        )
+    }.orEmpty()
+
+    return DescriptorSnapshot(
+        // By number, which is the order the kernel hands them out in and the only order that says
+        // anything: 0, 1 and 2 are the standard streams on every process, and a high number is a
+        // descriptor opened late.
+        descriptors = descriptors.sortedBy { it.fd },
+        softLimit = root.longOrNull("limit_soft"),
+        hardLimit = root.longOrNull("limit_hard")
+    )
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/components/MonitorTag.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/components/MonitorTag.kt
@@ -1,0 +1,34 @@
+package com.aoscoremonitor.ui.components
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.aoscoremonitor.ui.theme.Spacing
+
+/**
+ * A word about the thing next to it: a filesystem's type, a descriptor's kind.
+ *
+ * One classifying word, set apart from the reading it qualifies. It carries no state — use
+ * [StatusRow] or a [MonitorCard] status for anything that says whether something is in good shape,
+ * since a pill that changes colour says nothing to TalkBack.
+ */
+@Composable
+fun MonitorTag(text: String, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        shape = RoundedCornerShape(percent = 50),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            maxLines = 1,
+            modifier = Modifier.padding(horizontal = Spacing.Medium, vertical = Spacing.ExtraSmall)
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Cloud
 import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.DataUsage
+import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.DeveloperBoard
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Memory
@@ -17,6 +18,7 @@ import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Sensors
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Storage
+import androidx.compose.material.icons.filled.VerifiedUser
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation3.runtime.NavKey
 import com.aoscoremonitor.R
@@ -173,6 +175,22 @@ sealed interface Destination : NavKey {
         @Transient
         override val icon: ImageVector = Icons.Default.Storage
     }
+
+    @Serializable
+    data object Descriptors : Destination {
+        override val titleRes get() = R.string.descriptors_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.Description
+    }
+
+    @Serializable
+    data object ProcessCredentials : Destination {
+        override val titleRes get() = R.string.credentials_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.VerifiedUser
+    }
 }
 
 /**
@@ -182,6 +200,10 @@ sealed interface Destination : NavKey {
  * rather than the arbitrary order the grid grew in. The four screens added last read the CPU,
  * the process's own address space, the linker and the mount table, so they continue the native
  * run rather than starting a group of their own.
+ *
+ * Within the native run the order goes outwards from the process: what it is running (CPU,
+ * threads), what it is holding (memory, libraries, descriptors), who it is (credentials), and what
+ * it can reach (storage, network).
  */
 val HomeDestinations: List<Destination> = listOf(
     Destination.SystemInfo,
@@ -196,6 +218,8 @@ val HomeDestinations: List<Destination> = listOf(
     Destination.Threads,
     Destination.MemoryMap,
     Destination.LoadedLibraries,
+    Destination.Descriptors,
+    Destination.ProcessCredentials,
     Destination.StorageMounts,
     Destination.NetworkStats,
     Destination.TcpConnections
@@ -221,4 +245,6 @@ val Destination.shortTitleRes: Int
         Destination.MemoryMap -> R.string.destination_memory_map
         Destination.LoadedLibraries -> R.string.destination_loaded_libraries
         Destination.StorageMounts -> R.string.destination_storage
+        Destination.Descriptors -> R.string.destination_descriptors
+        Destination.ProcessCredentials -> R.string.destination_credentials
     }

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
@@ -13,10 +13,12 @@ import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.DeveloperBoard
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.Monitor
 import androidx.compose.material.icons.filled.NetworkCell
 import androidx.compose.material.icons.filled.Security
 import androidx.compose.material.icons.filled.Sensors
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.VerifiedUser
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -191,6 +193,22 @@ sealed interface Destination : NavKey {
         @Transient
         override val icon: ImageVector = Icons.Default.VerifiedUser
     }
+
+    @Serializable
+    data object DisplayPanel : Destination {
+        override val titleRes get() = R.string.display_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.Monitor
+    }
+
+    @Serializable
+    data object FramePacing : Destination {
+        override val titleRes get() = R.string.frames_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.Speed
+    }
 }
 
 /**
@@ -203,7 +221,8 @@ sealed interface Destination : NavKey {
  *
  * Within the native run the order goes outwards from the process: what it is running (CPU,
  * threads), what it is holding (memory, libraries, descriptors), who it is (credentials), and what
- * it can reach (storage, network).
+ * it can reach (storage, network). The display and the frames it is served close the list, being
+ * the one layer the app can watch itself being drawn onto.
  */
 val HomeDestinations: List<Destination> = listOf(
     Destination.SystemInfo,
@@ -222,7 +241,9 @@ val HomeDestinations: List<Destination> = listOf(
     Destination.ProcessCredentials,
     Destination.StorageMounts,
     Destination.NetworkStats,
-    Destination.TcpConnections
+    Destination.TcpConnections,
+    Destination.DisplayPanel,
+    Destination.FramePacing
 )
 
 /** The short label the home grid uses, which is not always the app bar title. */
@@ -247,4 +268,6 @@ val Destination.shortTitleRes: Int
         Destination.StorageMounts -> R.string.destination_storage
         Destination.Descriptors -> R.string.destination_descriptors
         Destination.ProcessCredentials -> R.string.destination_credentials
+        Destination.DisplayPanel -> R.string.destination_display
+        Destination.FramePacing -> R.string.destination_frames
     }

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
@@ -17,10 +17,12 @@ import com.aoscoremonitor.ui.screens.SensorsScreen
 import com.aoscoremonitor.ui.screens.SystemDiagnosticsScreen
 import com.aoscoremonitor.ui.screens.SystemInfoScreen
 import com.aoscoremonitor.ui.screens.jni.CpuCoresScreen
+import com.aoscoremonitor.ui.screens.jni.DescriptorsScreen
 import com.aoscoremonitor.ui.screens.jni.KernelCountersScreen
 import com.aoscoremonitor.ui.screens.jni.LoadedLibrariesScreen
 import com.aoscoremonitor.ui.screens.jni.MemoryMapScreen
 import com.aoscoremonitor.ui.screens.jni.NetworkStatsScreen
+import com.aoscoremonitor.ui.screens.jni.ProcessCredentialsScreen
 import com.aoscoremonitor.ui.screens.jni.StorageMountsScreen
 import com.aoscoremonitor.ui.screens.jni.TcpConnectionsScreen
 import com.aoscoremonitor.ui.screens.jni.ThreadsScreen
@@ -85,6 +87,8 @@ fun MonitorNavHost(modifier: Modifier = Modifier) {
                 entry<Destination.MemoryMap> { MemoryMapScreen(onNavigateBack = goBack) }
                 entry<Destination.LoadedLibraries> { LoadedLibrariesScreen(onNavigateBack = goBack) }
                 entry<Destination.StorageMounts> { StorageMountsScreen(onNavigateBack = goBack) }
+                entry<Destination.Descriptors> { DescriptorsScreen(onNavigateBack = goBack) }
+                entry<Destination.ProcessCredentials> { ProcessCredentialsScreen(onNavigateBack = goBack) }
             }
         }
     )

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
@@ -8,6 +8,8 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import com.aoscoremonitor.ui.screens.DisplayScreen
+import com.aoscoremonitor.ui.screens.FramePacingScreen
 import com.aoscoremonitor.ui.screens.FrameworkAnalysisScreen
 import com.aoscoremonitor.ui.screens.HalInfoScreen
 import com.aoscoremonitor.ui.screens.HomeScreen
@@ -89,6 +91,8 @@ fun MonitorNavHost(modifier: Modifier = Modifier) {
                 entry<Destination.StorageMounts> { StorageMountsScreen(onNavigateBack = goBack) }
                 entry<Destination.Descriptors> { DescriptorsScreen(onNavigateBack = goBack) }
                 entry<Destination.ProcessCredentials> { ProcessCredentialsScreen(onNavigateBack = goBack) }
+                entry<Destination.DisplayPanel> { DisplayScreen(onNavigateBack = goBack) }
+                entry<Destination.FramePacing> { FramePacingScreen(onNavigateBack = goBack) }
             }
         }
     )

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/DisplayScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/DisplayScreen.kt
@@ -1,0 +1,364 @@
+package com.aoscoremonitor.ui.screens
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AspectRatio
+import androidx.compose.material.icons.filled.Monitor
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.CutoutInsets
+import com.aoscoremonitor.diagnostics.DisplayConnection
+import com.aoscoremonitor.diagnostics.DisplayInfo
+import com.aoscoremonitor.diagnostics.DisplayMode
+import com.aoscoremonitor.diagnostics.DisplayProduct
+import com.aoscoremonitor.diagnostics.DisplayState
+import com.aoscoremonitor.diagnostics.HdrType
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.LabeledValue
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.MonitorTag
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.DisplayUiState
+import com.aoscoremonitor.ui.viewmodel.DisplayViewModel
+import com.aoscoremonitor.ui.viewmodel.monitorViewModel
+
+@Composable
+fun DisplayScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: DisplayViewModel = monitorViewModel { DisplayViewModel(it) }
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    DisplayContent(uiState = uiState, onNavigateBack = onNavigateBack, modifier = modifier)
+}
+
+@Composable
+private fun DisplayContent(uiState: DisplayUiState, onNavigateBack: () -> Unit, modifier: Modifier = Modifier) {
+    MonitorScaffold(
+        title = stringResource(R.string.display_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier
+    ) { innerPadding ->
+        val display = uiState.display
+        if (display == null) {
+            FullScreenMessage(
+                message = stringResource(if (uiState.hasLoaded) R.string.display_unavailable else R.string.display_loading),
+                icon = Icons.Default.Monitor,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            item(key = "panel-header") {
+                SectionHeader(
+                    title = stringResource(R.string.display_panel_section),
+                    subtitle = stringResource(R.string.display_panel_subtitle),
+                    icon = Icons.Default.Monitor
+                )
+            }
+            item(key = "panel") { PanelCard(display) }
+
+            item(key = "geometry-header") {
+                SectionHeader(
+                    title = stringResource(R.string.display_geometry_section),
+                    subtitle = stringResource(R.string.display_geometry_subtitle),
+                    icon = Icons.Default.AspectRatio
+                )
+            }
+            item(key = "geometry") { GeometryCard(display) }
+
+            item(key = "modes-header") {
+                SectionHeader(
+                    title = stringResource(R.string.display_modes_section),
+                    subtitle = stringResource(R.string.display_modes_subtitle),
+                    icon = Icons.Default.Refresh
+                )
+            }
+            items(display.modes, key = { mode -> mode.id }) { mode ->
+                ModeCard(mode = mode, isCurrent = mode.id == display.currentMode?.id)
+            }
+
+            item(key = "capabilities-header") {
+                SectionHeader(
+                    title = stringResource(R.string.display_capabilities_section),
+                    subtitle = stringResource(R.string.display_capabilities_subtitle),
+                    icon = Icons.Default.Palette
+                )
+            }
+            item(key = "capabilities") { CapabilitiesCard(display) }
+        }
+    }
+}
+
+@Composable
+private fun PanelCard(display: DisplayInfo, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        LabeledValue(label = stringResource(R.string.display_name), value = display.name)
+        LabeledValue(
+            label = stringResource(R.string.display_state),
+            value = stringResource(stateLabel(display.state)),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        LabeledValue(
+            label = stringResource(R.string.display_rotation),
+            value = stringResource(R.string.display_degrees, display.rotationDegrees),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        LabeledValue(
+            label = stringResource(R.string.display_id),
+            value = display.displayId.toString(),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        ProductRows(display.product)
+    }
+}
+
+/**
+ * What the panel says about itself, when it says anything.
+ *
+ * A screen built into a phone has no EDID for the platform to parse, so this is empty on most
+ * devices and says why rather than showing four blank rows.
+ */
+@Composable
+private fun ProductRows(product: DisplayProduct) {
+    if (!product.hasIdentity) {
+        Text(
+            text = stringResource(R.string.display_product_absent),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        return
+    }
+
+    product.manufacturerPnpId?.let { manufacturer ->
+        LabeledValue(
+            label = stringResource(R.string.display_product_manufacturer),
+            value = manufacturer,
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+    }
+    product.productId?.let { id ->
+        LabeledValue(
+            label = stringResource(R.string.display_product_id),
+            value = id,
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+    }
+    product.manufactureYear?.let { year ->
+        LabeledValue(
+            label = stringResource(R.string.display_product_year),
+            value = year.toString(),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+    }
+    LabeledValue(
+        label = stringResource(R.string.display_product_connection),
+        value = stringResource(connectionLabel(product.connection)),
+        modifier = Modifier.padding(top = Spacing.Small)
+    )
+}
+
+@Composable
+private fun GeometryCard(display: DisplayInfo, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        display.currentMode?.let { mode ->
+            LabeledValue(
+                label = stringResource(R.string.display_resolution),
+                value = stringResource(R.string.display_pixels, mode.widthPixels, mode.heightPixels)
+            )
+        }
+        LabeledValue(
+            label = stringResource(R.string.display_density),
+            value = stringResource(R.string.display_density_value, display.densityDpi, display.density),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        // The dpi the panel reports, as against the bucket Android rounded it into above: the two
+        // differ on most devices, and only the first is a physical measurement.
+        LabeledValue(
+            label = stringResource(R.string.display_physical_density),
+            value = stringResource(R.string.display_physical_density_value, display.xDpi, display.yDpi),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        LabeledValue(
+            label = stringResource(R.string.display_font_scale),
+            value = stringResource(R.string.display_font_scale_value, display.fontScale),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+    }
+}
+
+@Composable
+private fun ModeCard(mode: DisplayMode, isCurrent: Boolean, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.display_pixels, mode.widthPixels, mode.heightPixels),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.Small)) {
+                if (isCurrent) MonitorTag(stringResource(R.string.display_mode_current))
+                MonitorTag(stringResource(R.string.display_mode_hz, mode.refreshRateHz))
+            }
+        }
+        Text(
+            text = stringResource(R.string.display_mode_id, mode.id),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun CapabilitiesCard(display: DisplayInfo, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.display_hdr),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        if (display.hdrTypes.isEmpty()) {
+            Text(text = stringResource(R.string.display_hdr_none), style = MaterialTheme.typography.bodyMedium)
+        } else {
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.Small),
+                verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+            ) {
+                display.hdrTypes.forEach { type -> MonitorTag(stringResource(hdrLabel(type))) }
+            }
+        }
+
+        SupportRow(R.string.display_wide_gamut, display.isWideColorGamut)
+        SupportRow(R.string.display_minimal_post_processing, display.supportsMinimalPostProcessing)
+        SupportRow(R.string.display_secure, display.isSecure)
+        SupportRow(R.string.display_round, display.isRound)
+
+        LabeledValue(
+            label = stringResource(R.string.display_cutout),
+            value = cutoutDescription(display.cutout),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        display.cutout?.let { cutout ->
+            Text(
+                text = pluralStringResource(R.plurals.display_cutout_rects, cutout.boundingRects, cutout.boundingRects),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun SupportRow(@StringRes label: Int, supported: Boolean) {
+    LabeledValue(
+        label = stringResource(label),
+        value = stringResource(if (supported) R.string.display_supported else R.string.display_not_supported),
+        modifier = Modifier.padding(top = Spacing.Small)
+    )
+}
+
+@Composable
+private fun cutoutDescription(cutout: CutoutInsets?): String = if (cutout == null) {
+    stringResource(R.string.display_cutout_none)
+} else {
+    stringResource(R.string.display_cutout_insets, cutout.top, cutout.bottom, cutout.left, cutout.right)
+}
+
+@StringRes
+private fun stateLabel(state: DisplayState): Int = when (state) {
+    DisplayState.On -> R.string.display_state_on
+    DisplayState.Off -> R.string.display_state_off
+    DisplayState.Doze -> R.string.display_state_doze
+    DisplayState.DozeSuspended -> R.string.display_state_doze_suspended
+    DisplayState.OnSuspended -> R.string.display_state_on_suspended
+    DisplayState.Unknown -> R.string.display_state_unknown
+}
+
+@StringRes
+private fun connectionLabel(connection: DisplayConnection): Int = when (connection) {
+    DisplayConnection.BuiltIn -> R.string.display_connection_built_in
+    DisplayConnection.Direct -> R.string.display_connection_direct
+    DisplayConnection.Transitive -> R.string.display_connection_transitive
+    DisplayConnection.Unknown -> R.string.display_connection_unknown
+}
+
+@StringRes
+private fun hdrLabel(type: HdrType): Int = when (type) {
+    HdrType.DolbyVision -> R.string.display_hdr_dolby_vision
+    HdrType.Hdr10 -> R.string.display_hdr_hdr10
+    HdrType.Hlg -> R.string.display_hdr_hlg
+    HdrType.Hdr10Plus -> R.string.display_hdr_hdr10_plus
+    HdrType.Unknown -> R.string.display_hdr_unknown
+}
+
+@Preview(name = "Display", showBackground = true)
+@Preview(name = "Display (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun DisplayPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        DisplayContent(
+            uiState = DisplayUiState(
+                display = DisplayInfo(
+                    name = "Built-in Screen",
+                    displayId = 0,
+                    state = DisplayState.On,
+                    rotationDegrees = 0,
+                    currentMode = DisplayMode(1, 1080, 2400, 120f),
+                    modes = listOf(
+                        DisplayMode(1, 1080, 2400, 120f),
+                        DisplayMode(2, 1080, 2400, 60f)
+                    ),
+                    densityDpi = 420,
+                    density = 2.625f,
+                    xDpi = 425.6f,
+                    yDpi = 424.1f,
+                    fontScale = 1f,
+                    hdrTypes = listOf(HdrType.Hdr10, HdrType.Hlg),
+                    isWideColorGamut = true,
+                    cutout = CutoutInsets(left = 0, top = 118, right = 0, bottom = 0, boundingRects = 1),
+                    supportsMinimalPostProcessing = true,
+                    appVsyncOffsetNanos = 1_000_000,
+                    presentationDeadlineNanos = 12_000_000
+                ),
+                hasLoaded = true
+            ),
+            onNavigateBack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/FramePacingScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/FramePacingScreen.kt
@@ -1,0 +1,314 @@
+package com.aoscoremonitor.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BarChart
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.DisplayInfo
+import com.aoscoremonitor.diagnostics.DisplayMode
+import com.aoscoremonitor.diagnostics.DisplayState
+import com.aoscoremonitor.diagnostics.FramePacing
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.LabeledValue
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.ReadingStatus
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.FramePacingUiState
+import com.aoscoremonitor.ui.viewmodel.FramePacingViewModel
+import com.aoscoremonitor.ui.viewmodel.monitorViewModel
+
+@Composable
+fun FramePacingScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: FramePacingViewModel = monitorViewModel { FramePacingViewModel(it) }
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    FramePacingContent(uiState = uiState, onNavigateBack = onNavigateBack, modifier = modifier)
+}
+
+@Composable
+private fun FramePacingContent(uiState: FramePacingUiState, onNavigateBack: () -> Unit, modifier: Modifier = Modifier) {
+    MonitorScaffold(
+        title = stringResource(R.string.frames_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier
+    ) { innerPadding ->
+        val display = uiState.display
+        if (display == null) {
+            FullScreenMessage(
+                message = stringResource(if (uiState.hasLoaded) R.string.frames_unavailable else R.string.frames_loading),
+                icon = Icons.Default.Speed,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        val pacing = uiState.pacing
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            item(key = "rate-header") {
+                SectionHeader(
+                    title = stringResource(R.string.frames_rate_section),
+                    subtitle = stringResource(R.string.frames_rate_subtitle),
+                    icon = Icons.Default.Speed
+                )
+            }
+            item(key = "rate") { RateCard(display = display, pacing = pacing) }
+
+            item(key = "jank-header") {
+                SectionHeader(
+                    title = stringResource(R.string.frames_jank_section),
+                    subtitle = stringResource(R.string.frames_jank_subtitle),
+                    icon = Icons.Default.Warning
+                )
+            }
+            item(key = "jank") { JankCard(pacing) }
+
+            if (pacing.distribution.isNotEmpty()) {
+                item(key = "distribution-header") {
+                    SectionHeader(
+                        title = stringResource(R.string.frames_distribution_section),
+                        subtitle = stringResource(R.string.frames_distribution_subtitle),
+                        icon = Icons.Default.BarChart
+                    )
+                }
+                item(key = "distribution") { DistributionCard(pacing) }
+            }
+
+            item(key = "timing-header") {
+                SectionHeader(
+                    title = stringResource(R.string.frames_timing_section),
+                    subtitle = stringResource(R.string.frames_timing_subtitle),
+                    icon = Icons.Default.Schedule
+                )
+            }
+            item(key = "timing") { TimingCard(display) }
+        }
+    }
+}
+
+/**
+ * The rate frames actually arrived at, against the rate the panel is being driven at.
+ *
+ * Both numbers, because either alone says nothing: 60 fps is the whole of what a 60 Hz panel can
+ * give and half of what a 120 Hz one can.
+ */
+@Composable
+private fun RateCard(display: DisplayInfo, pacing: FramePacing, modifier: Modifier = Modifier) {
+    val measured = pacing.measuredFps
+
+    MonitorCard(modifier = modifier) {
+        Text(
+            text = if (measured == null) {
+                stringResource(R.string.frames_waiting)
+            } else {
+                stringResource(R.string.frames_fps, measured)
+            },
+            style = MaterialTheme.typography.headlineSmall
+        )
+        Text(
+            text = if (display.refreshRateHz > 0f) {
+                stringResource(
+                    R.string.frames_target,
+                    display.refreshRateHz,
+                    stringResource(R.string.frames_millis, millis(display.frameIntervalNanos))
+                )
+            } else {
+                stringResource(R.string.frames_target_unknown)
+            },
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        if (pacing.intervals > 0) {
+            Text(
+                text = stringResource(
+                    R.string.frames_counted,
+                    pacing.intervals,
+                    stringResource(R.string.frames_seconds, seconds(pacing.elapsedNanos))
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+/**
+ * What was missed.
+ *
+ * The card turns amber once late gaps pass one in twenty, which is where a scroll starts to look
+ * uneven rather than merely imperfect.
+ */
+@Composable
+private fun JankCard(pacing: FramePacing, modifier: Modifier = Modifier) {
+    val jank = pacing.jankFraction
+    val status = if (jank != null && jank >= NOTICEABLE_JANK) ReadingStatus.Warning else ReadingStatus.Neutral
+
+    MonitorCard(modifier = modifier, status = status) {
+        if (pacing.intervals == 0) {
+            Text(text = stringResource(R.string.frames_waiting), style = MaterialTheme.typography.bodyMedium)
+            return@MonitorCard
+        }
+        if (pacing.droppedFrames == 0) {
+            Text(text = stringResource(R.string.frames_none_missed), style = MaterialTheme.typography.bodyMedium)
+            return@MonitorCard
+        }
+
+        LabeledValue(
+            label = stringResource(R.string.frames_dropped),
+            value = pluralStringResource(R.plurals.frames_dropped_value, pacing.droppedFrames, pacing.droppedFrames)
+        )
+        LabeledValue(
+            label = stringResource(R.string.frames_jank_rate),
+            value = stringResource(R.string.frames_jank_rate_value, (jank ?: 0f) * PERCENT, pacing.intervals),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        LabeledValue(
+            label = stringResource(R.string.frames_worst),
+            value = stringResource(
+                R.string.frames_worst_value,
+                stringResource(R.string.frames_millis, millis(pacing.worstIntervalNanos)),
+                pacing.worstSlots
+            ),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+    }
+}
+
+/**
+ * Every gap, grouped by how many frames wide it was.
+ *
+ * A bar per width rather than an average: an average hides the shape, and the shape is the reading
+ * — a hundred gaps of one frame and one of thirty is a very different experience from a hundred
+ * gaps of two.
+ */
+@Composable
+private fun DistributionCard(pacing: FramePacing, modifier: Modifier = Modifier) {
+    val total = pacing.intervals.coerceAtLeast(1)
+
+    MonitorCard(modifier = modifier) {
+        pacing.distribution.forEach { (slots, count) ->
+            val share = count.toFloat() / total
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = Spacing.ExtraSmall),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = if (slots == 1) {
+                        stringResource(R.string.frames_slot_on_time)
+                    } else {
+                        pluralStringResource(R.plurals.frames_slot_label, slots, slots)
+                    },
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Text(
+                    text = stringResource(R.string.frames_slot_count, count, (share * PERCENT).toInt()),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            LinearProgressIndicator(
+                progress = { share },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = Spacing.ExtraSmall)
+            )
+        }
+    }
+}
+
+/**
+ * How far ahead of the panel the app is asked to work.
+ *
+ * Both come from the display rather than from the measurement: the offset is when the app's vsync
+ * is delivered relative to the panel's, and the deadline is when a frame has to be finished to make
+ * that scan-out. They are the budget every gap above is measured against.
+ */
+@Composable
+private fun TimingCard(display: DisplayInfo, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        LabeledValue(
+            label = stringResource(R.string.frames_vsync_offset),
+            value = stringResource(R.string.frames_millis, millis(display.appVsyncOffsetNanos))
+        )
+        LabeledValue(
+            label = stringResource(R.string.frames_presentation_deadline),
+            value = stringResource(R.string.frames_millis, millis(display.presentationDeadlineNanos)),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+    }
+}
+
+private fun millis(nanos: Long): Float = nanos / NANOS_PER_MILLI
+
+private fun seconds(nanos: Long): Float = nanos / NANOS_PER_SECOND
+
+private const val NANOS_PER_MILLI = 1_000_000f
+private const val NANOS_PER_SECOND = 1_000_000_000f
+private const val PERCENT = 100f
+private const val NOTICEABLE_JANK = 0.05f
+
+@Preview(name = "Frame pacing", showBackground = true)
+@Preview(name = "Frame pacing (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun FramePacingPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        FramePacingContent(
+            uiState = FramePacingUiState(
+                display = DisplayInfo(
+                    name = "Built-in Screen",
+                    displayId = 0,
+                    state = DisplayState.On,
+                    rotationDegrees = 0,
+                    currentMode = DisplayMode(1, 1080, 2400, 60f),
+                    appVsyncOffsetNanos = 1_000_000,
+                    presentationDeadlineNanos = 12_000_000
+                ),
+                pacing = FramePacing(
+                    periodNanos = 16_666_666,
+                    intervals = 412,
+                    elapsedNanos = 7_100_000_000,
+                    worstIntervalNanos = 83_000_000,
+                    histogram = mapOf(1 to 396, 2 to 12, 3 to 3, 5 to 1)
+                ),
+                hasLoaded = true
+            ),
+            onNavigateBack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/SystemDiagnosticsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/SystemDiagnosticsScreen.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Terminal
-import androidx.compose.material.icons.filled.Visibility
-import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -19,7 +17,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.aoscoremonitor.R
 import com.aoscoremonitor.diagnostics.SystemDiagnosticsCollector
 import com.aoscoremonitor.ui.components.ExpandableTextCard
-import com.aoscoremonitor.ui.components.InfoCard
 import com.aoscoremonitor.ui.components.MonitorScaffold
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
 import com.aoscoremonitor.ui.theme.Spacing
@@ -59,17 +56,6 @@ private fun SystemDiagnosticsContent(
             contentPadding = PaddingValues(Spacing.Large),
             verticalArrangement = Arrangement.spacedBy(Spacing.Medium)
         ) {
-            item(key = "screen") {
-                InfoCard(
-                    title = stringResource(R.string.diagnostics_screen_state),
-                    value = stringResource(
-                        if (diagnostics.screenOn) R.string.diagnostics_screen_on else R.string.diagnostics_screen_off
-                    ),
-                    // Deliberately no status: the screen being on is not a health signal, and
-                    // painting the whole card green said it was.
-                    icon = if (diagnostics.screenOn) Icons.Default.Visibility else Icons.Default.VisibilityOff
-                )
-            }
             item(key = "processes") {
                 ExpandableTextCard(
                     title = stringResource(R.string.diagnostics_running_processes),
@@ -101,7 +87,6 @@ private fun SystemDiagnosticsPreview() {
         SystemDiagnosticsContent(
             diagnostics = SystemDiagnosticsCollector.DiagnosticsInfo(
                 runningProcesses = listOf("com.aoscoremonitor"),
-                screenOn = true,
                 dumpsysResult = "Applications Memory Usage (in Kilobytes):\nUptime: 843211 Realtime: 843211"
             ),
             onNavigateBack = {}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/DescriptorsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/DescriptorsScreen.kt
@@ -1,0 +1,341 @@
+package com.aoscoremonitor.ui.screens.jni
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Inventory
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.formatBytes
+import com.aoscoremonitor.diagnostics.jni.DescriptorAccess
+import com.aoscoremonitor.diagnostics.jni.DescriptorKind
+import com.aoscoremonitor.diagnostics.jni.DescriptorSnapshot
+import com.aoscoremonitor.diagnostics.jni.OpenDescriptor
+import com.aoscoremonitor.diagnostics.jni.Unavailable
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.MonitorTag
+import com.aoscoremonitor.ui.components.ReadingStatus
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.MonitorTypography
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.DescriptorsUiState
+import com.aoscoremonitor.ui.viewmodel.DescriptorsViewModel
+
+@Composable
+fun DescriptorsScreen(onNavigateBack: () -> Unit, modifier: Modifier = Modifier, viewModel: DescriptorsViewModel = viewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    DescriptorsContent(uiState = uiState, onNavigateBack = onNavigateBack, modifier = modifier)
+}
+
+@Composable
+private fun DescriptorsContent(uiState: DescriptorsUiState, onNavigateBack: () -> Unit, modifier: Modifier = Modifier) {
+    MonitorScaffold(
+        title = stringResource(R.string.descriptors_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier
+    ) { innerPadding ->
+        val snapshot = uiState.snapshot
+        if (snapshot == null || snapshot.descriptors.isEmpty()) {
+            FullScreenMessage(
+                message = stringResource(emptyMessage(uiState.hasLoaded, snapshot)),
+                icon = Icons.Default.Description,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            item(key = "summary-header") {
+                SectionHeader(
+                    title = stringResource(R.string.descriptors_summary_section),
+                    icon = Icons.Default.Inventory
+                )
+            }
+            item(key = "summary") { SummaryCard(snapshot) }
+
+            item(key = "list-header") {
+                SectionHeader(
+                    title = stringResource(R.string.descriptors_list_section),
+                    subtitle = stringResource(R.string.descriptors_list_subtitle),
+                    icon = Icons.Default.Description
+                )
+            }
+            items(snapshot.descriptors, key = { descriptor -> descriptor.fd }) { descriptor ->
+                DescriptorCard(descriptor)
+            }
+        }
+    }
+}
+
+/**
+ * How full the descriptor table is, and what is filling it.
+ *
+ * The bar is against the soft limit rather than the hard one: the soft limit is what a further
+ * `open` is refused at, and a process that raises it has to mean to. It turns amber at nine tenths
+ * through [ReadingStatus], the same threshold the storage screen warns at.
+ */
+@Composable
+private fun SummaryCard(snapshot: DescriptorSnapshot, modifier: Modifier = Modifier) {
+    val fraction = snapshot.usedFraction
+    val status = if (fraction != null && fraction >= NEARLY_FULL) ReadingStatus.Warning else ReadingStatus.Neutral
+
+    MonitorCard(modifier = modifier, status = status) {
+        Text(
+            text = pluralStringResource(R.plurals.descriptors_open, snapshot.count, snapshot.count),
+            style = MaterialTheme.typography.headlineSmall
+        )
+
+        val softLimit = snapshot.softLimit
+        if (fraction != null && softLimit != null) {
+            LinearProgressIndicator(
+                progress = { fraction },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = Spacing.ExtraSmall)
+            )
+            Text(
+                text = stringResource(R.string.descriptors_limit, snapshot.count, softLimit),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        } else {
+            Text(
+                text = stringResource(R.string.descriptors_no_limit),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+
+        snapshot.hardLimit?.let { hardLimit ->
+            Text(
+                text = stringResource(R.string.descriptors_hard_limit, hardLimit),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        FlowRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = Spacing.ExtraSmall),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.Small),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            snapshot.breakdown.forEach { (kind, count) ->
+                MonitorTag(stringResource(R.string.descriptors_breakdown_entry, count, stringResource(kindLabel(kind))))
+            }
+        }
+    }
+}
+
+/**
+ * One descriptor.
+ *
+ * The file name leads and the directory follows underneath, because a process holds a dozen
+ * descriptors on the same /apex directory and the part that differs is the part worth reading
+ * first. Anything that is not a path — `socket:[12345]`, `anon_inode:[eventfd]` — has no file name
+ * to split off and is shown whole.
+ */
+@Composable
+private fun DescriptorCard(descriptor: OpenDescriptor, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = descriptor.displayName.ifEmpty { stringResource(targetReason(descriptor.targetUnavailable)) },
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier
+                    .weight(1f, fill = false)
+                    .padding(end = Spacing.Small)
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(Spacing.Small)) {
+                MonitorTag(stringResource(R.string.descriptors_number, descriptor.fd))
+                MonitorTag(stringResource(kindLabel(descriptor.kind)))
+            }
+        }
+
+        if (descriptor.directory.isNotEmpty()) {
+            Text(
+                text = descriptor.directory,
+                style = MonitorTypography.machineText,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+
+        Text(
+            text = describe(descriptor),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        if (descriptor.flags.isNotEmpty()) {
+            // Shown as the kernel's own tokens rather than translated: they name the O_ constants
+            // the descriptor was opened with, which is what someone reading this screen is matching
+            // against their own open() call.
+            Text(
+                text = descriptor.flags.joinToString(" "),
+                style = MonitorTypography.machineText,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+/**
+ * The one-line detail row: how it was opened, how big it is, where it is, and whether it survives
+ * an exec.
+ *
+ * Assembled from the parts that were actually read, so a socket — which has no size and no offset —
+ * gets a short line rather than a line of blanks.
+ */
+@Composable
+private fun describe(descriptor: OpenDescriptor): String {
+    val parts = listOfNotNull(
+        stringResource(accessLabel(descriptor.access)),
+        // What fstat would have said. Without this the card silently reads "Other" with no inode,
+        // which looks like a descriptor on nothing rather than like a refused reading.
+        if (descriptor.type == null) stringResource(statReason(descriptor.typeUnavailable)) else null,
+        descriptor.sizeBytes?.let { formatBytes(it) },
+        descriptor.offset?.let { stringResource(R.string.descriptors_offset, it) },
+        descriptor.inode?.let { stringResource(R.string.descriptors_inode, it) },
+        stringResource(if (descriptor.closeOnExec) R.string.descriptors_cloexec else R.string.descriptors_kept_on_exec)
+    )
+    return parts.joinToString(SEPARATOR)
+}
+
+@StringRes
+private fun emptyMessage(hasLoaded: Boolean, snapshot: DescriptorSnapshot?): Int = when {
+    !hasLoaded -> R.string.descriptors_loading
+    snapshot == null -> R.string.descriptors_unavailable
+    else -> R.string.descriptors_empty
+}
+
+@StringRes
+private fun kindLabel(kind: DescriptorKind): Int = when (kind) {
+    DescriptorKind.File -> R.string.descriptors_kind_file
+    DescriptorKind.Directory -> R.string.descriptors_kind_directory
+    DescriptorKind.Socket -> R.string.descriptors_kind_socket
+    DescriptorKind.Pipe -> R.string.descriptors_kind_pipe
+    DescriptorKind.AnonInode -> R.string.descriptors_kind_anon
+    DescriptorKind.Device -> R.string.descriptors_kind_device
+    DescriptorKind.Other -> R.string.descriptors_kind_other
+}
+
+@StringRes
+private fun accessLabel(access: DescriptorAccess): Int = when (access) {
+    DescriptorAccess.Read -> R.string.descriptors_access_read
+    DescriptorAccess.Write -> R.string.descriptors_access_write
+    DescriptorAccess.ReadWrite -> R.string.descriptors_access_readwrite
+    DescriptorAccess.Unknown -> R.string.descriptors_access_unknown
+}
+
+/** Why the kind and inode are missing, when fstat said why. */
+@StringRes
+private fun statReason(reason: Unavailable?): Int = when (reason) {
+    Unavailable.Denied -> R.string.descriptors_stat_denied
+    Unavailable.Absent -> R.string.descriptors_stat_absent
+    else -> R.string.descriptors_stat_unavailable
+}
+
+/** Why the target is missing, when readlink said why. */
+@StringRes
+private fun targetReason(reason: Unavailable?): Int = when (reason) {
+    Unavailable.Denied -> R.string.descriptors_target_denied
+    else -> R.string.descriptors_target_unavailable
+}
+
+private const val NEARLY_FULL = 0.9f
+private const val SEPARATOR = " · "
+
+@Preview(name = "Descriptors", showBackground = true)
+@Preview(name = "Descriptors (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun DescriptorsPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        DescriptorsContent(
+            uiState = DescriptorsUiState(
+                snapshot = DescriptorSnapshot(
+                    descriptors = listOf(
+                        OpenDescriptor(
+                            fd = 0,
+                            target = "/dev/null",
+                            type = "character",
+                            access = DescriptorAccess.ReadWrite,
+                            inode = 6,
+                            offset = 0
+                        ),
+                        OpenDescriptor(
+                            fd = 12,
+                            target = "/apex/com.android.art/javalib/core-oj.jar",
+                            type = "regular",
+                            access = DescriptorAccess.Read,
+                            flags = listOf("nonblock"),
+                            closeOnExec = true,
+                            inode = 288_734,
+                            sizeBytes = 4_194_304,
+                            offset = 0
+                        ),
+                        OpenDescriptor(
+                            fd = 27,
+                            target = "socket:[52831]",
+                            type = "socket",
+                            access = DescriptorAccess.ReadWrite,
+                            closeOnExec = true,
+                            inode = 52_831
+                        ),
+                        OpenDescriptor(
+                            fd = 31,
+                            target = "anon_inode:[eventfd]",
+                            type = "regular",
+                            access = DescriptorAccess.ReadWrite,
+                            flags = listOf("nonblock"),
+                            closeOnExec = true,
+                            inode = 12_450,
+                            offset = 0
+                        )
+                    ),
+                    softLimit = 32_768,
+                    hardLimit = 1_048_576
+                ),
+                hasLoaded = true
+            ),
+            onNavigateBack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/MemoryMapScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/MemoryMapScreen.kt
@@ -159,7 +159,7 @@ private fun MemoryMapContent(uiState: MemoryMapUiState, onNavigateBack: () -> Un
                         icon = Icons.Default.Lock
                     )
                 }
-                item(key = "limits") { ByteReadingsCard(memory.limits, LimitLabels, countKeys = setOf("open_files")) }
+                item(key = "limits") { ByteReadingsCard(memory.limits, LimitLabels) }
             }
         }
     }
@@ -232,23 +232,11 @@ private fun CategoryCard(category: RegionCategory, mappedKb: Long, modifier: Mod
  * is left out on purpose: an unlabelled key would reach the screen as a bare identifier.
  */
 @Composable
-private fun ByteReadingsCard(
-    readings: Map<String, Long>,
-    labels: List<Pair<String, Int>>,
-    modifier: Modifier = Modifier,
-    countKeys: Set<String> = emptySet()
-) {
+private fun ByteReadingsCard(readings: Map<String, Long>, labels: List<Pair<String, Int>>, modifier: Modifier = Modifier) {
     MonitorCard(modifier = modifier) {
         labels.forEach { (key, labelRes) ->
             val value = readings[key] ?: return@forEach
-            LabeledValue(
-                label = stringResource(labelRes),
-                value = if (key in countKeys) {
-                    stringResource(R.string.memory_count, value)
-                } else {
-                    formatBytes(value)
-                }
-            )
+            LabeledValue(label = stringResource(labelRes), value = formatBytes(value))
         }
     }
 }
@@ -263,11 +251,12 @@ private val MallocLabels = listOf(
     "free_chunks" to R.string.memory_malloc_free_chunks
 )
 
+// RLIMIT_NOFILE was here. It bounds the descriptor table rather than the address space, so it is
+// shown on the descriptor screen, next to the count that is filling it.
 private val LimitLabels = listOf(
     "address_space" to R.string.memory_limit_address_space,
     "data" to R.string.memory_limit_data,
-    "stack" to R.string.memory_limit_stack,
-    "open_files" to R.string.memory_limit_open_files
+    "stack" to R.string.memory_limit_stack
 )
 
 /** The display name for a category key the native collector emits. */
@@ -301,7 +290,7 @@ private fun MemoryMapPreview() {
                         swapPssKb = 0,
                         fromRollupFile = true
                     ),
-                    status = mapOf("VmSize" to "14 GB", "VmRSS" to "98304 kB", "Threads" to "21"),
+                    status = mapOf("VmSize" to "14680064 kB", "VmRSS" to "98304 kB", "Threads" to "21"),
                     totalRegions = 1832,
                     categories = listOf(
                         RegionCategory("native_lib", 412, 198_340),
@@ -309,7 +298,7 @@ private fun MemoryMapPreview() {
                         RegionCategory("native_heap", 40, 22_528)
                     ),
                     malloc = mapOf("in_use" to 6_291_456L, "free" to 2_097_152L, "arena" to 8_388_608L),
-                    limits = mapOf("open_files" to 32_768L, "stack" to 8_388_608L)
+                    limits = mapOf("address_space" to 137_438_953_472L, "stack" to 8_388_608L)
                 ),
                 hasLoaded = true
             ),

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/ProcessCredentialsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/ProcessCredentialsScreen.kt
@@ -1,0 +1,433 @@
+package com.aoscoremonitor.ui.screens.jni
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Badge
+import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Shield
+import androidx.compose.material.icons.filled.VerifiedUser
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.jni.CapabilitySet
+import com.aoscoremonitor.diagnostics.jni.CapabilitySetKeys
+import com.aoscoremonitor.diagnostics.jni.CredentialIds
+import com.aoscoremonitor.diagnostics.jni.ProcessCredentials
+import com.aoscoremonitor.diagnostics.jni.SeccompMode
+import com.aoscoremonitor.diagnostics.jni.Unavailable
+import com.aoscoremonitor.diagnostics.jni.androidGroupName
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.LabeledValue
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.MonitorTag
+import com.aoscoremonitor.ui.components.ReadingStatus
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.MonitorTypography
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.ProcessCredentialsUiState
+import com.aoscoremonitor.ui.viewmodel.ProcessCredentialsViewModel
+
+@Composable
+fun ProcessCredentialsScreen(
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ProcessCredentialsViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    ProcessCredentialsContent(uiState = uiState, onNavigateBack = onNavigateBack, modifier = modifier)
+}
+
+@Composable
+private fun ProcessCredentialsContent(uiState: ProcessCredentialsUiState, onNavigateBack: () -> Unit, modifier: Modifier = Modifier) {
+    MonitorScaffold(
+        title = stringResource(R.string.credentials_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier
+    ) { innerPadding ->
+        val credentials = uiState.credentials
+        if (credentials == null) {
+            FullScreenMessage(
+                message = stringResource(if (uiState.hasLoaded) R.string.credentials_unavailable else R.string.credentials_loading),
+                icon = Icons.Default.VerifiedUser,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            item(key = "context-header") {
+                SectionHeader(
+                    title = stringResource(R.string.credentials_context_section),
+                    subtitle = stringResource(R.string.credentials_context_subtitle),
+                    icon = Icons.Default.Shield
+                )
+            }
+            item(key = "context") { ContextCard(credentials) }
+
+            item(key = "user-header") {
+                SectionHeader(
+                    title = stringResource(R.string.credentials_user_section),
+                    subtitle = stringResource(R.string.credentials_user_subtitle),
+                    icon = Icons.Default.Badge
+                )
+            }
+            item(key = "user") { UserCard(credentials) }
+
+            item(key = "groups-header") {
+                SectionHeader(
+                    title = stringResource(R.string.credentials_groups),
+                    icon = Icons.Default.Group
+                )
+            }
+            item(key = "groups") { GroupsCard(credentials) }
+
+            item(key = "capabilities-header") {
+                SectionHeader(
+                    title = stringResource(R.string.credentials_capabilities_section),
+                    subtitle = stringResource(R.string.credentials_capabilities_subtitle),
+                    icon = Icons.Default.VerifiedUser
+                )
+            }
+            CapabilitySetKeys.forEach { key ->
+                val set = credentials.capabilities[key] ?: return@forEach
+                item(key = "capability-$key") { CapabilityCard(key = key, set = set) }
+            }
+
+            item(key = "sandbox-header") {
+                SectionHeader(
+                    title = stringResource(R.string.credentials_sandbox_section),
+                    subtitle = stringResource(R.string.credentials_sandbox_subtitle),
+                    icon = Icons.Default.Lock
+                )
+            }
+            item(key = "sandbox") { SandboxCard(credentials) }
+
+            item(key = "identity-header") {
+                SectionHeader(title = stringResource(R.string.credentials_identity_section))
+            }
+            item(key = "identity") { IdentityCard(credentials) }
+        }
+    }
+}
+
+/**
+ * The SELinux domain, with the type pulled out of the middle of it.
+ *
+ * The type is where the whole meaning is — `untrusted_app` against `platform_app` is the difference
+ * between two very different sets of rights — and it would otherwise be the third field of a string
+ * that runs to a hundred characters of MLS categories.
+ */
+@Composable
+private fun ContextCard(credentials: ProcessCredentials, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        val context = credentials.selinuxContext
+        if (context == null) {
+            Text(
+                text = stringResource(contextReason(credentials.selinuxUnavailable)),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            return@MonitorCard
+        }
+
+        credentials.selinuxType?.let { type ->
+            Text(text = type, style = MaterialTheme.typography.headlineSmall)
+            Text(
+                text = stringResource(R.string.credentials_context_type),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Text(
+            text = context,
+            style = MonitorTypography.machineText,
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+    }
+}
+
+@Composable
+private fun UserCard(credentials: ProcessCredentials, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        credentials.user?.let { user ->
+            LabeledValue(label = stringResource(R.string.credentials_uid), value = describe(user))
+            Text(
+                text = if (credentials.isAppUid) {
+                    stringResource(R.string.credentials_app_uid, credentials.androidUserId ?: 0, credentials.appId ?: 0)
+                } else {
+                    stringResource(R.string.credentials_platform_uid)
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        credentials.group?.let { group ->
+            LabeledValue(
+                label = stringResource(R.string.credentials_gid),
+                value = describe(group),
+                modifier = Modifier.padding(top = Spacing.Small)
+            )
+        }
+    }
+}
+
+/**
+ * The supplementary groups, which is how Android grants an app a platform capability: an app with
+ * INTERNET is in AID_INET, and one without it is not, with the kernel enforcing the difference at
+ * the socket call rather than the framework enforcing it at an API.
+ */
+@Composable
+private fun GroupsCard(credentials: ProcessCredentials, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        if (credentials.supplementaryGroups.isEmpty()) {
+            Text(
+                text = stringResource(
+                    if (credentials.groupsUnavailable != null) {
+                        R.string.credentials_groups_unavailable
+                    } else {
+                        R.string.credentials_groups_none
+                    }
+                ),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            return@MonitorCard
+        }
+
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.Small),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            credentials.supplementaryGroups.forEach { gid ->
+                val name = androidGroupName(gid)
+                MonitorTag(
+                    if (name != null) stringResource(R.string.credentials_group_named, gid, name) else gid.toString()
+                )
+            }
+        }
+    }
+}
+
+/**
+ * One capability set.
+ *
+ * The effective set holding anything is worth pointing at: an app process is forked from zygote
+ * with every capability dropped, so a non-empty effective set means this is not running as an
+ * ordinary app. The other four sets are reported without judgement — a full bounding set is the
+ * normal state of affairs and says only that nothing has narrowed the ceiling.
+ */
+@Composable
+private fun CapabilityCard(key: String, set: CapabilitySet, modifier: Modifier = Modifier) {
+    val status = if (key == EFFECTIVE_SET && !set.isEmpty) ReadingStatus.Warning else ReadingStatus.Neutral
+
+    MonitorCard(modifier = modifier, status = status) {
+        Text(text = stringResource(capabilityLabel(key)), style = MaterialTheme.typography.titleMedium)
+        Text(
+            text = stringResource(capabilityNote(key)),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        if (set.isEmpty) {
+            Text(
+                text = stringResource(R.string.credentials_cap_none),
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier.padding(top = Spacing.ExtraSmall)
+            )
+        } else {
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = Spacing.ExtraSmall),
+                horizontalArrangement = Arrangement.spacedBy(Spacing.Small),
+                verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+            ) {
+                // The names as the kernel spells them, so they match the CAP_ constants and the
+                // audit lines someone reading this screen would be comparing against.
+                set.names.forEach { name -> MonitorTag(name) }
+            }
+        }
+
+        Text(
+            text = stringResource(R.string.credentials_cap_mask, set.hex),
+            style = MonitorTypography.machineText,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.padding(top = Spacing.ExtraSmall)
+        )
+    }
+}
+
+@Composable
+private fun SandboxCard(credentials: ProcessCredentials, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        LabeledValue(
+            label = stringResource(R.string.credentials_seccomp),
+            value = seccompDescription(credentials)
+        )
+        LabeledValue(
+            label = stringResource(R.string.credentials_no_new_privs),
+            value = stringResource(
+                when (credentials.noNewPrivs) {
+                    true -> R.string.credentials_no_new_privs_set
+                    false -> R.string.credentials_no_new_privs_clear
+                    null -> R.string.credentials_unknown
+                }
+            ),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        LabeledValue(
+            label = stringResource(R.string.credentials_dumpable),
+            value = stringResource(
+                when (credentials.dumpable) {
+                    true -> R.string.credentials_dumpable_on
+                    false -> R.string.credentials_dumpable_off
+                    null -> R.string.credentials_unknown
+                }
+            ),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        LabeledValue(
+            label = stringResource(R.string.credentials_umask),
+            value = credentials.umask ?: stringResource(R.string.credentials_unknown),
+            valueStyle = MonitorTypography.machineText,
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+    }
+}
+
+@Composable
+private fun IdentityCard(credentials: ProcessCredentials, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        LabeledValue(label = stringResource(R.string.credentials_pid), value = credentials.pid.toString())
+        LabeledValue(
+            label = stringResource(R.string.credentials_ppid),
+            value = credentials.parentPid.toString(),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        LabeledValue(
+            label = stringResource(R.string.credentials_pgid),
+            value = credentials.processGroup.toString(),
+            modifier = Modifier.padding(top = Spacing.Small)
+        )
+        credentials.session?.let { session ->
+            LabeledValue(
+                label = stringResource(R.string.credentials_session),
+                value = session.toString(),
+                modifier = Modifier.padding(top = Spacing.Small)
+            )
+        }
+    }
+}
+
+/** The three ids, collapsed to one number when they agree — which for an app they always do. */
+@Composable
+private fun describe(ids: CredentialIds): String = if (ids.allTheSame) {
+    stringResource(R.string.credentials_ids_uniform, ids.effective)
+} else {
+    stringResource(R.string.credentials_ids, ids.real, ids.effective, ids.saved)
+}
+
+@Composable
+private fun seccompDescription(credentials: ProcessCredentials): String {
+    val filters = credentials.seccompFilters
+    return when (credentials.seccomp) {
+        SeccompMode.Disabled -> stringResource(R.string.credentials_seccomp_disabled)
+        SeccompMode.Strict -> stringResource(R.string.credentials_seccomp_strict)
+        SeccompMode.Filter -> if (filters != null && filters > 1) {
+            stringResource(R.string.credentials_seccomp_filter_count, filters)
+        } else {
+            stringResource(R.string.credentials_seccomp_filter)
+        }
+        SeccompMode.Unknown -> stringResource(R.string.credentials_seccomp_unknown)
+    }
+}
+
+@StringRes
+private fun capabilityLabel(key: String): Int = when (key) {
+    "effective" -> R.string.credentials_cap_effective
+    "permitted" -> R.string.credentials_cap_permitted
+    "inheritable" -> R.string.credentials_cap_inheritable
+    "bounding" -> R.string.credentials_cap_bounding
+    else -> R.string.credentials_cap_ambient
+}
+
+@StringRes
+private fun capabilityNote(key: String): Int = when (key) {
+    "effective" -> R.string.credentials_cap_effective_note
+    "permitted" -> R.string.credentials_cap_permitted_note
+    "inheritable" -> R.string.credentials_cap_inheritable_note
+    "bounding" -> R.string.credentials_cap_bounding_note
+    else -> R.string.credentials_cap_ambient_note
+}
+
+/** Why the context is missing, when the read said why. */
+@StringRes
+private fun contextReason(reason: Unavailable?): Int = when (reason) {
+    Unavailable.Denied -> R.string.credentials_context_denied
+    Unavailable.Absent -> R.string.credentials_context_absent
+    else -> R.string.credentials_context_unavailable
+}
+
+private const val EFFECTIVE_SET = "effective"
+
+@Preview(name = "Credentials", showBackground = true)
+@Preview(name = "Credentials (dark)", showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ProcessCredentialsPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        ProcessCredentialsContent(
+            uiState = ProcessCredentialsUiState(
+                credentials = ProcessCredentials(
+                    pid = 8_421,
+                    parentPid = 731,
+                    processGroup = 8_421,
+                    session = 8_421,
+                    user = CredentialIds(10_213, 10_213, 10_213),
+                    group = CredentialIds(10_213, 10_213, 10_213),
+                    supplementaryGroups = listOf(3_003, 9_997, 20_213, 50_213),
+                    capabilities = mapOf(
+                        "effective" to CapabilitySet("0000000000000000"),
+                        "permitted" to CapabilitySet("0000000000000000"),
+                        "inheritable" to CapabilitySet("0000000000000000"),
+                        "bounding" to CapabilitySet(
+                            "000001ffffffffff",
+                            listOf("CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_NET_RAW", "CAP_SYS_ADMIN")
+                        ),
+                        "ambient" to CapabilitySet("0000000000000000")
+                    ),
+                    noNewPrivs = false,
+                    dumpable = true,
+                    seccomp = SeccompMode.Filter,
+                    seccompFilters = 1,
+                    umask = "0077",
+                    selinuxContext = "u:r:untrusted_app:s0:c213,c256,c512,c768"
+                ),
+                hasLoaded = true
+            ),
+            onNavigateBack = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/jni/StorageMountsScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/jni/StorageMountsScreen.kt
@@ -9,13 +9,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -33,6 +31,7 @@ import com.aoscoremonitor.diagnostics.jni.Unavailable
 import com.aoscoremonitor.ui.components.FullScreenMessage
 import com.aoscoremonitor.ui.components.MonitorCard
 import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.MonitorTag
 import com.aoscoremonitor.ui.components.ReadingStatus
 import com.aoscoremonitor.ui.components.SectionHeader
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
@@ -125,8 +124,8 @@ private fun MountCard(mount: MountPoint, modifier: Modifier = Modifier) {
                 modifier = Modifier.padding(end = Spacing.Small)
             )
             Row(horizontalArrangement = Arrangement.spacedBy(Spacing.Small)) {
-                if (mount.readOnly) MountTag(stringResource(R.string.storage_readonly))
-                MountTag(mount.fsType)
+                if (mount.readOnly) MonitorTag(stringResource(R.string.storage_readonly))
+                MonitorTag(mount.fsType)
             }
         }
 
@@ -199,25 +198,8 @@ private fun PseudoMountRow(mount: MountPoint, modifier: Modifier = Modifier) {
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(end = Spacing.Small)
             )
-            MountTag(mount.fsType)
+            MonitorTag(mount.fsType)
         }
-    }
-}
-
-@Composable
-private fun MountTag(text: String, modifier: Modifier = Modifier) {
-    Surface(
-        modifier = modifier,
-        shape = RoundedCornerShape(percent = 50),
-        color = MaterialTheme.colorScheme.secondaryContainer,
-        contentColor = MaterialTheme.colorScheme.onSecondaryContainer
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.labelMedium,
-            maxLines = 1,
-            modifier = Modifier.padding(horizontal = Spacing.Medium, vertical = Spacing.ExtraSmall)
-        )
     }
 }
 

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/DescriptorsViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/DescriptorsViewModel.kt
@@ -1,0 +1,39 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.jni.DescriptorSnapshot
+import com.aoscoremonitor.diagnostics.jni.NativeDescriptorInspector
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+
+/**
+ * The descriptor table as it stands.
+ *
+ * [hasLoaded] separates "still reading" from "read, and there is nothing" — without it the screen
+ * cannot word its empty state, because a process that reports no descriptors at all has either not
+ * been asked yet or has answered something impossible.
+ */
+data class DescriptorsUiState(val snapshot: DescriptorSnapshot? = null, val hasLoaded: Boolean = false)
+
+/** Polls the descriptor table every three seconds. */
+class DescriptorsViewModel : ViewModel() {
+
+    private val inspector = NativeDescriptorInspector()
+
+    val uiState: StateFlow<DescriptorsUiState> = flow {
+        while (true) {
+            emit(DescriptorsUiState(snapshot = inspector.read(), hasLoaded = true))
+            delay(REFRESH_INTERVAL_MS)
+        }
+    }.stateIn(viewModelScope, WhileScreenVisible, DescriptorsUiState())
+
+    private companion object {
+        // Descriptors open and close as the app loads assets and talks to binder, so this moves
+        // faster than the mount table. Each pass is four syscalls per descriptor and there are
+        // rarely more than a hundred, so three seconds is not work worth spreading out further.
+        const val REFRESH_INTERVAL_MS = 3_000L
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/DisplayViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/DisplayViewModel.kt
@@ -1,0 +1,26 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.DisplayInfo
+import com.aoscoremonitor.diagnostics.displayChanges
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+data class DisplayUiState(val display: DisplayInfo? = null, val hasLoaded: Boolean = false)
+
+/**
+ * The panel, and every change to it.
+ *
+ * No timer: rotating the device, switching mode and letting the screen doze are the only things
+ * that change any of this, and the platform reports all three. What a poll would add is a wake-up
+ * per second to find that a panel is still the same panel.
+ */
+class DisplayViewModel(context: Context) : ViewModel() {
+
+    val uiState: StateFlow<DisplayUiState> = displayChanges(context)
+        .map { display -> DisplayUiState(display = display, hasLoaded = true) }
+        .stateIn(viewModelScope, WhileScreenVisible, DisplayUiState())
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/FramePacingViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/FramePacingViewModel.kt
@@ -1,0 +1,89 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import android.content.Context
+import android.view.Choreographer
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.DisplayInfo
+import com.aoscoremonitor.diagnostics.FramePacing
+import com.aoscoremonitor.diagnostics.displayChanges
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+data class FramePacingUiState(val display: DisplayInfo? = null, val pacing: FramePacing = FramePacing(), val hasLoaded: Boolean = false)
+
+/**
+ * Measures how well this app is being served frames.
+ *
+ * The measurement is of vsync callbacks arriving, not of drawing: a `Choreographer` callback that
+ * re-posts itself is delivered on every vsync whether or not anything changed, so a gap longer than
+ * one frame means the main thread was not there to take it. That is the same thing the system means
+ * by a dropped frame, seen from inside the app.
+ *
+ * It measures the app it runs in, which includes this screen's own updates. That is not a flaw to
+ * be worked around — it is the only frame pipeline an app can see — but it is why the screen says
+ * so rather than presenting the number as the device's.
+ *
+ * Collection is bounded by [WhileScreenVisible] for a stronger reason than the other screens: a
+ * self-reposting frame callback asks for a vsync forever, so leaving it running in the background
+ * would hold the display pipeline awake for a reading nobody is looking at.
+ */
+class FramePacingViewModel(context: Context) : ViewModel() {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val uiState: StateFlow<FramePacingUiState> = displayChanges(context)
+        // flatMapLatest, so a mode switch starts the measurement over. A slot is worth what the
+        // current mode says it is worth, and a histogram half in 60 Hz slots and half in 120 Hz
+        // ones counts two different things in one column.
+        .flatMapLatest { display ->
+            framePacing(display?.frameIntervalNanos ?: 0).map { pacing ->
+                FramePacingUiState(display = display, pacing = pacing, hasLoaded = true)
+            }
+        }
+        .stateIn(viewModelScope, WhileScreenVisible, FramePacingUiState())
+
+    private fun framePacing(periodNanos: Long): Flow<FramePacing> = callbackFlow {
+        var pacing = FramePacing(periodNanos = periodNanos)
+        var previousFrameNanos = 0L
+        val choreographer = Choreographer.getInstance()
+
+        val callback = object : Choreographer.FrameCallback {
+            override fun doFrame(frameTimeNanos: Long) {
+                // Re-posted first, so a stall in the arithmetic below cannot cost the next frame.
+                choreographer.postFrameCallback(this)
+                if (previousFrameNanos != 0L) {
+                    pacing = pacing.plus(frameTimeNanos - previousFrameNanos)
+                    // Not every frame: at 120 Hz that would ask the screen to recompose 120 times a
+                    // second to report on how well it is recomposing.
+                    if (pacing.intervals % FRAMES_PER_EMIT == 0) {
+                        trySend(pacing)
+                    }
+                }
+                previousFrameNanos = frameTimeNanos
+            }
+        }
+
+        // So the screen can say it is measuring before it has anything to report.
+        trySend(pacing)
+        choreographer.postFrameCallback(callback)
+        awaitClose { choreographer.removeFrameCallback(callback) }
+    }
+        // Choreographer belongs to the thread it was asked for, and only the main thread's is
+        // driven by the display.
+        .flowOn(Dispatchers.Main)
+        .conflate()
+
+    private companion object {
+        /** Four updates a second at 60 Hz, eight at 120. */
+        const val FRAMES_PER_EMIT = 15
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/ProcessCredentialsViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/ProcessCredentialsViewModel.kt
@@ -1,0 +1,28 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.jni.NativeCredentialsInspector
+import com.aoscoremonitor.diagnostics.jni.ProcessCredentials
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+
+data class ProcessCredentialsUiState(val credentials: ProcessCredentials? = null, val hasLoaded: Boolean = false)
+
+/**
+ * Reads the process's credentials once.
+ *
+ * Alone among the native screens this does not poll. Nothing here can change while the app runs: an
+ * app process is forked from zygote with its uid, its groups, its seccomp filter and its SELinux
+ * domain already set, and it holds no capability that would let it change any of them. A timer
+ * would re-read the same answer every few seconds and say so by making the screen flicker.
+ */
+class ProcessCredentialsViewModel : ViewModel() {
+
+    private val inspector = NativeCredentialsInspector()
+
+    val uiState: StateFlow<ProcessCredentialsUiState> = flow {
+        emit(ProcessCredentialsUiState(credentials = inspector.read(), hasLoaded = true))
+    }.stateIn(viewModelScope, WhileScreenVisible, ProcessCredentialsUiState())
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/SystemDiagnosticsViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/SystemDiagnosticsViewModel.kt
@@ -26,7 +26,6 @@ class SystemDiagnosticsViewModel(context: Context) : ViewModel() {
     private companion object {
         val EMPTY = SystemDiagnosticsCollector.DiagnosticsInfo(
             runningProcesses = emptyList(),
-            screenOn = false,
             dumpsysResult = ""
         )
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="destination_memory_map">Memory Map</string>
     <string name="destination_loaded_libraries">Native Libraries</string>
     <string name="destination_storage">Storage</string>
+    <string name="destination_descriptors">Descriptors</string>
+    <string name="destination_credentials">Credentials</string>
 
     <!-- System logs -->
     <string name="logs_title">System Logs</string>
@@ -249,8 +251,6 @@
     <string name="memory_limit_address_space">Address space</string>
     <string name="memory_limit_data">Data segment</string>
     <string name="memory_limit_stack">Stack</string>
-    <string name="memory_limit_open_files">Open files</string>
-    <string name="memory_count">%1$d</string>
 
     <!-- Native libraries -->
     <string name="libraries_title">Native Libraries</string>
@@ -366,4 +366,101 @@
     <string name="storage_readonly">Read-only</string>
     <string name="storage_source">Device · %1$s</string>
     <string name="storage_inodes">Inodes · %1$s free of %2$s</string>
+
+    <!-- Open descriptors -->
+    <string name="descriptors_title">Open Descriptors</string>
+    <string name="descriptors_loading">Walking /proc/self/fd…</string>
+    <string name="descriptors_unavailable">The native library did not load, so this process\'s descriptors cannot be listed.</string>
+    <string name="descriptors_empty">No descriptors were readable for this process.</string>
+    <string name="descriptors_summary_section">This process</string>
+    <plurals name="descriptors_open">
+        <item quantity="one">%1$d descriptor open</item>
+        <item quantity="other">%1$d descriptors open</item>
+    </plurals>
+    <string name="descriptors_limit">%1$,d of the %2$,d this process may hold</string>
+    <string name="descriptors_hard_limit">The hard limit it could raise that to is %1$,d.</string>
+    <string name="descriptors_no_limit">No ceiling is set on how many this process may open.</string>
+    <string name="descriptors_list_section">Descriptors</string>
+    <string name="descriptors_list_subtitle">By number, which is the order the kernel hands them out in</string>
+    <string name="descriptors_number">fd %1$d</string>
+    <string name="descriptors_target_unavailable">Target not readable</string>
+    <string name="descriptors_target_denied">Target: the sandbox may not read it</string>
+    <string name="descriptors_stat_unavailable">Kind not readable</string>
+    <string name="descriptors_stat_denied">Kind: the sandbox may not read it</string>
+    <string name="descriptors_stat_absent">Kind: nothing left at this number to read</string>
+    <string name="descriptors_offset">Offset %1$,d</string>
+    <string name="descriptors_inode">Inode %1$,d</string>
+    <string name="descriptors_cloexec">Closed on exec</string>
+    <string name="descriptors_kept_on_exec">Kept across exec</string>
+    <string name="descriptors_kind_file">File</string>
+    <string name="descriptors_kind_directory">Directory</string>
+    <string name="descriptors_kind_socket">Socket</string>
+    <string name="descriptors_kind_pipe">Pipe</string>
+    <string name="descriptors_kind_anon">Kernel object</string>
+    <string name="descriptors_kind_device">Device</string>
+    <string name="descriptors_kind_other">Other</string>
+    <string name="descriptors_access_read">Read</string>
+    <string name="descriptors_access_write">Write</string>
+    <string name="descriptors_access_readwrite">Read/write</string>
+    <string name="descriptors_access_unknown">Access unknown</string>
+    <string name="descriptors_breakdown_entry">%1$d %2$s</string>
+
+    <!-- Process credentials -->
+    <string name="credentials_title">Process Credentials</string>
+    <string name="credentials_loading">Reading this process\'s credentials…</string>
+    <string name="credentials_unavailable">The native library did not load, so this process\'s credentials cannot be read.</string>
+    <string name="credentials_context_section">Security context</string>
+    <string name="credentials_context_subtitle">The SELinux domain confining this process, which is narrower than what the device enforces</string>
+    <string name="credentials_context_type">Domain</string>
+    <string name="credentials_context_full">Full context</string>
+    <string name="credentials_context_unavailable">The context could not be read.</string>
+    <string name="credentials_context_denied">The sandbox may not read this process\'s SELinux context.</string>
+    <string name="credentials_context_absent">This kernel reports no SELinux context for the process.</string>
+    <string name="credentials_identity_section">Identity</string>
+    <string name="credentials_pid">Process ID</string>
+    <string name="credentials_ppid">Parent process</string>
+    <string name="credentials_pgid">Process group</string>
+    <string name="credentials_session">Session</string>
+    <string name="credentials_user_section">User and groups</string>
+    <string name="credentials_user_subtitle">Real, effective and saved. Only the effective pair decides what a syscall is allowed to do.</string>
+    <string name="credentials_uid">UID</string>
+    <string name="credentials_gid">GID</string>
+    <string name="credentials_ids">%1$d real · %2$d effective · %3$d saved</string>
+    <string name="credentials_ids_uniform">%1$d, the same in all three</string>
+    <string name="credentials_app_uid">Android user %1$d, app ID %2$d</string>
+    <string name="credentials_platform_uid">A platform identity rather than an installed app</string>
+    <string name="credentials_groups">Supplementary groups</string>
+    <string name="credentials_groups_none">None held</string>
+    <string name="credentials_groups_unavailable">The group list could not be read.</string>
+    <string name="credentials_group_named">%1$d %2$s</string>
+    <string name="credentials_capabilities_section">Capabilities</string>
+    <string name="credentials_capabilities_subtitle">What this process may do beyond the rights of its user. An ordinary app holds none.</string>
+    <string name="credentials_cap_effective">Effective</string>
+    <string name="credentials_cap_effective_note">In force right now</string>
+    <string name="credentials_cap_permitted">Permitted</string>
+    <string name="credentials_cap_permitted_note">May be raised into the effective set</string>
+    <string name="credentials_cap_inheritable">Inheritable</string>
+    <string name="credentials_cap_inheritable_note">Survives an exec into a new program</string>
+    <string name="credentials_cap_bounding">Bounding</string>
+    <string name="credentials_cap_bounding_note">The ceiling nothing here can rise above</string>
+    <string name="credentials_cap_ambient">Ambient</string>
+    <string name="credentials_cap_ambient_note">Granted to an unprivileged program on exec</string>
+    <string name="credentials_cap_none">None</string>
+    <string name="credentials_cap_mask">Mask %1$s</string>
+    <string name="credentials_sandbox_section">Sandbox switches</string>
+    <string name="credentials_sandbox_subtitle">The per-process restrictions zygote set before this app\'s code ran</string>
+    <string name="credentials_seccomp">Seccomp</string>
+    <string name="credentials_seccomp_disabled">No filter installed</string>
+    <string name="credentials_seccomp_strict">Strict: read, write, exit and sigreturn only</string>
+    <string name="credentials_seccomp_filter">Filtered by a BPF program</string>
+    <string name="credentials_seccomp_filter_count">Filtered by %1$d BPF programs</string>
+    <string name="credentials_seccomp_unknown">This kernel does not report a seccomp mode.</string>
+    <string name="credentials_no_new_privs">no_new_privs</string>
+    <string name="credentials_no_new_privs_set">Set: no exec can gain privileges</string>
+    <string name="credentials_no_new_privs_clear">Not set</string>
+    <string name="credentials_dumpable">Core dumps</string>
+    <string name="credentials_dumpable_on">Dumpable: this process can be traced and dumped</string>
+    <string name="credentials_dumpable_off">Not dumpable</string>
+    <string name="credentials_umask">umask</string>
+    <string name="credentials_unknown">Not reported</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="destination_storage">Storage</string>
     <string name="destination_descriptors">Descriptors</string>
     <string name="destination_credentials">Credentials</string>
+    <string name="destination_display">Display</string>
+    <string name="destination_frames">Frame Pacing</string>
 
     <!-- System logs -->
     <string name="logs_title">System Logs</string>
@@ -49,9 +51,6 @@
 
     <!-- System diagnostics -->
     <string name="diagnostics_title">System Diagnostics</string>
-    <string name="diagnostics_screen_state">Screen State</string>
-    <string name="diagnostics_screen_on">On</string>
-    <string name="diagnostics_screen_off">Off</string>
     <string name="diagnostics_running_processes">Processes Visible to This App</string>
     <string name="diagnostics_processes_notice">Since Android 8, ActivityManager reports only the calling app\'s own process. Listing the rest needs root or a userdebug build.</string>
     <string name="diagnostics_no_processes">No process information available</string>
@@ -463,4 +462,106 @@
     <string name="credentials_dumpable_off">Not dumpable</string>
     <string name="credentials_umask">umask</string>
     <string name="credentials_unknown">Not reported</string>
+
+    <!-- Display -->
+    <string name="display_title">Display</string>
+    <string name="display_loading">Reading the display\'s description…</string>
+    <string name="display_unavailable">This device reports no default display.</string>
+    <string name="display_panel_section">Panel</string>
+    <string name="display_panel_subtitle">What the platform says the default display is</string>
+    <string name="display_name">Name</string>
+    <string name="display_id">Display ID</string>
+    <string name="display_state">State</string>
+    <string name="display_state_on">On</string>
+    <string name="display_state_off">Off</string>
+    <string name="display_state_doze">Dozing</string>
+    <string name="display_state_doze_suspended">Dozing, pipeline suspended</string>
+    <string name="display_state_on_suspended">On, pipeline suspended</string>
+    <string name="display_state_unknown">Not reported</string>
+    <string name="display_rotation">Rotation</string>
+    <string name="display_degrees">%1$d°</string>
+    <string name="display_product_manufacturer">Manufacturer (PnP ID)</string>
+    <string name="display_product_id">Product ID</string>
+    <string name="display_product_year">Manufactured</string>
+    <string name="display_product_connection">Connection</string>
+    <string name="display_connection_built_in">Built into the device</string>
+    <string name="display_connection_direct">Connected directly</string>
+    <string name="display_connection_transitive">Reached through another device</string>
+    <string name="display_connection_unknown">Not reported</string>
+    <string name="display_product_absent">The panel publishes no EDID, which a screen built into the device usually does not.</string>
+    <string name="display_geometry_section">Resolution and density</string>
+    <string name="display_geometry_subtitle">The physical pixels of the current mode, and what a dp is worth on them</string>
+    <string name="display_resolution">Resolution</string>
+    <string name="display_pixels">%1$d × %2$d</string>
+    <string name="display_density">Density</string>
+    <string name="display_density_value">%1$d dpi · %2$.2f× scale</string>
+    <string name="display_physical_density">Physical density</string>
+    <string name="display_physical_density_value">%1$.0f × %2$.0f dpi</string>
+    <string name="display_font_scale">Font scale</string>
+    <string name="display_font_scale_value">%1$.2f×</string>
+    <string name="display_modes_section">Modes</string>
+    <string name="display_modes_subtitle">Every resolution and rate the panel can be driven at</string>
+    <string name="display_mode_current">Current</string>
+    <string name="display_mode_hz">%1$.2f Hz</string>
+    <string name="display_mode_id">Mode %1$d</string>
+    <string name="display_capabilities_section">Capabilities</string>
+    <string name="display_capabilities_subtitle">What the panel accepts beyond ordinary colour</string>
+    <string name="display_hdr">HDR formats</string>
+    <string name="display_hdr_none">None reported</string>
+    <string name="display_hdr_dolby_vision">Dolby Vision</string>
+    <string name="display_hdr_hdr10">HDR10</string>
+    <string name="display_hdr_hlg">HLG</string>
+    <string name="display_hdr_hdr10_plus">HDR10+</string>
+    <string name="display_hdr_unknown">Unrecognised format</string>
+    <string name="display_wide_gamut">Wide colour gamut</string>
+    <string name="display_minimal_post_processing">Minimal post-processing</string>
+    <string name="display_secure">Secure surfaces</string>
+    <string name="display_round">Round display</string>
+    <string name="display_supported">Supported</string>
+    <string name="display_not_supported">Not supported</string>
+    <string name="display_cutout">Cutout</string>
+    <string name="display_cutout_insets">Keeps content %1$d px from the top, %2$d from the bottom, %3$d from the left and %4$d from the right</string>
+    <plurals name="display_cutout_rects">
+        <item quantity="one">%1$d cutout area</item>
+        <item quantity="other">%1$d cutout areas</item>
+    </plurals>
+    <string name="display_cutout_none">This display has no cutout.</string>
+
+    <!-- Frame pacing -->
+    <string name="frames_title">Frame Pacing</string>
+    <string name="frames_loading">Waiting for the first frames…</string>
+    <string name="frames_unavailable">No display was reported, so there is no frame rate to measure against.</string>
+    <string name="frames_rate_section">Frames arriving</string>
+    <string name="frames_rate_subtitle">Measured on this app\'s own vsync callbacks, this screen\'s updates included</string>
+    <string name="frames_fps">%1$.1f fps</string>
+    <string name="frames_target">Target %1$.1f fps · one frame every %2$s</string>
+    <string name="frames_target_unknown">The display reports no refresh rate to measure against.</string>
+    <string name="frames_counted">%1$,d frames over %2$s</string>
+    <string name="frames_waiting">Measuring…</string>
+    <string name="frames_jank_section">Frames missed</string>
+    <string name="frames_jank_subtitle">A gap longer than one frame means the main thread was not there to take it</string>
+    <string name="frames_dropped">Dropped</string>
+    <plurals name="frames_dropped_value">
+        <item quantity="one">%1$d frame</item>
+        <item quantity="other">%1$d frames</item>
+    </plurals>
+    <string name="frames_jank_rate">Late gaps</string>
+    <string name="frames_jank_rate_value">%1$.1f%% of %2$,d</string>
+    <string name="frames_worst">Worst gap</string>
+    <string name="frames_worst_value">%1$s · %2$d frames wide</string>
+    <string name="frames_none_missed">Every frame arrived on time.</string>
+    <string name="frames_distribution_section">Gaps by width</string>
+    <string name="frames_distribution_subtitle">How many frames each gap between callbacks spanned</string>
+    <plurals name="frames_slot_label">
+        <item quantity="one">%1$d frame</item>
+        <item quantity="other">%1$d frames</item>
+    </plurals>
+    <string name="frames_slot_count">%1$,d · %2$d%%</string>
+    <string name="frames_slot_on_time">on time</string>
+    <string name="frames_timing_section">Pipeline timing</string>
+    <string name="frames_timing_subtitle">How far ahead of the panel the app is asked to work</string>
+    <string name="frames_vsync_offset">App vsync offset</string>
+    <string name="frames_presentation_deadline">Presentation deadline</string>
+    <string name="frames_millis">%1$.2f ms</string>
+    <string name="frames_seconds">%1$.1f s</string>
 </resources>

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/FramePacingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/FramePacingTest.kt
@@ -1,0 +1,96 @@
+package com.aoscoremonitor.diagnostics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FramePacingTest {
+
+    @Test
+    fun framesArrivingOnTimeMissNothing() {
+        val pacing = fold(FramePacing(periodNanos = SIXTY_HZ), List(10) { SIXTY_HZ })
+
+        assertEquals(10, pacing.intervals)
+        assertEquals(0, pacing.droppedFrames)
+        assertEquals(0f, pacing.jankFraction)
+        assertEquals(listOf(1 to 10), pacing.distribution)
+    }
+
+    @Test
+    fun aGapOfThreeFramesMissedTwo() {
+        // Not "one janky frame": a gap that spans three slots delivered one frame and missed the
+        // two the panel was ready to show in between.
+        val pacing = fold(FramePacing(periodNanos = SIXTY_HZ), listOf(SIXTY_HZ, SIXTY_HZ * 3))
+
+        assertEquals(2, pacing.droppedFrames)
+        assertEquals(listOf(1 to 1, 3 to 1), pacing.distribution)
+        assertEquals(3, pacing.worstSlots)
+    }
+
+    @Test
+    fun ordinaryJitterIsNotReadAsAMiss() {
+        // A vsync delivered 2 ms late is still that vsync. Rounding rather than truncating is what
+        // keeps a panel that is keeping up from reading as one that misses every frame.
+        val pacing = fold(FramePacing(periodNanos = SIXTY_HZ), List(5) { SIXTY_HZ + 2_000_000 })
+
+        assertEquals(0, pacing.droppedFrames)
+        assertEquals(listOf(1 to 5), pacing.distribution)
+    }
+
+    @Test
+    fun aDoubleCallbackForOneVsyncIsDropped() {
+        // Choreographer can deliver two callbacks for one vsync. Counted, the second would push the
+        // measured rate above what the panel can display, which is a reading that cannot be true.
+        val pacing = fold(FramePacing(periodNanos = SIXTY_HZ), listOf(SIXTY_HZ, 200_000, SIXTY_HZ))
+
+        assertEquals(2, pacing.intervals)
+        assertEquals(SIXTY_HZ * 2, pacing.elapsedNanos)
+    }
+
+    @Test
+    fun theRateIsMeasuredRatherThanAssumed() {
+        // Half the frames arrive: a 60 Hz panel serving 30 fps, which is the case the whole screen
+        // exists to show.
+        val pacing = fold(FramePacing(periodNanos = SIXTY_HZ), List(30) { SIXTY_HZ * 2 })
+
+        assertEquals(30f, pacing.measuredFps!!, 0.5f)
+        assertEquals(30, pacing.droppedFrames)
+        assertEquals(1f, pacing.jankFraction)
+    }
+
+    @Test
+    fun nothingIsCountedBeforeTheFirstGap() {
+        val pacing = FramePacing(periodNanos = SIXTY_HZ)
+
+        assertNull(pacing.measuredFps)
+        assertNull(pacing.jankFraction)
+        assertEquals(0, pacing.droppedFrames)
+    }
+
+    @Test
+    fun gapsAreIgnoredUntilTheFrameLengthIsKnown() {
+        // The period is zero until the display has been read. A slot of no width would make every
+        // gap infinitely many frames.
+        val pacing = fold(FramePacing(), listOf(SIXTY_HZ, SIXTY_HZ))
+
+        assertEquals(0, pacing.intervals)
+        assertEquals(0, pacing.droppedFrames)
+    }
+
+    @Test
+    fun theWorstGapSurvivesLaterCalmFrames() {
+        val pacing = fold(FramePacing(periodNanos = SIXTY_HZ), listOf(SIXTY_HZ * 5, SIXTY_HZ, SIXTY_HZ))
+
+        assertEquals(SIXTY_HZ * 5, pacing.worstIntervalNanos)
+        assertEquals(5, pacing.worstSlots)
+    }
+
+    private fun fold(initial: FramePacing, intervals: List<Long>): FramePacing = intervals.fold(initial) { pacing, interval ->
+        pacing.plus(interval)
+    }
+
+    private companion object {
+        /** One frame at 60 Hz, in nanoseconds. */
+        const val SIXTY_HZ = 16_666_666L
+    }
+}

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/CredentialsParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/CredentialsParsingTest.kt
@@ -1,0 +1,125 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CredentialsParsingTest {
+
+    @Test
+    fun readsWhoTheProcessIs() {
+        val credentials = parseCredentials(
+            """
+            {"pid":8421,"ppid":731,"pgid":8421,"sid":8421,
+             "uid":{"real":10213,"effective":10213,"saved":10213},
+             "gid":{"real":10213,"effective":10213,"saved":10213},
+             "groups":[9997,3003,20213],
+             "umask":"0077",
+             "selinux_context":"u:r:untrusted_app:s0:c213,c256"}
+            """.trimIndent()
+        )
+
+        assertEquals(8_421, credentials.pid)
+        assertEquals(731, credentials.parentPid)
+        assertEquals(8_421, credentials.session)
+        assertEquals(10_213, credentials.user?.effective)
+        assertTrue(credentials.user!!.allTheSame)
+        assertEquals("0077", credentials.umask)
+        // Sorted, because getgroups fills the array in whatever order the kernel holds it.
+        assertEquals(listOf(3_003, 9_997, 20_213), credentials.supplementaryGroups)
+    }
+
+    @Test
+    fun anAppUidIsSplitIntoItsAndroidUserAndItsAppId() {
+        val credentials = parseCredentials("""{"uid":{"real":110213,"effective":110213,"saved":110213}}""")
+
+        assertEquals(1, credentials.androidUserId)
+        assertEquals(10_213, credentials.appId)
+        assertTrue(credentials.isAppUid)
+    }
+
+    @Test
+    fun aPlatformUidIsNotReportedAsAnApp() {
+        // AID_SYSTEM is below the app range, and calling it "app ID 1000" would be a wrong reading
+        // rather than a missing one.
+        val credentials = parseCredentials("""{"uid":{"real":1000,"effective":1000,"saved":1000}}""")
+
+        assertFalse(credentials.isAppUid)
+    }
+
+    @Test
+    fun theSelinuxTypeIsPulledOutOfTheContext() {
+        val credentials = parseCredentials(
+            """{"selinux_context":"u:r:untrusted_app:s0:c213,c256,c512,c768"}"""
+        )
+
+        assertEquals("untrusted_app", credentials.selinuxType)
+    }
+
+    @Test
+    fun aContextTheSandboxRefusedSaysSo() {
+        val credentials = parseCredentials("""{"selinux_context_unavailable":"denied"}""")
+
+        assertNull(credentials.selinuxContext)
+        assertNull(credentials.selinuxType)
+        assertEquals(Unavailable.Denied, credentials.selinuxUnavailable)
+    }
+
+    @Test
+    fun capabilitySetsCarryBothTheirMaskAndTheirNames() {
+        val credentials = parseCredentials(
+            """
+            {"capabilities":{
+               "effective":{"hex":"0000000000000000","names":[]},
+               "permitted":{"hex":"0000000000000000","names":[]},
+               "bounding":{"hex":"0000000000002000","names":["CAP_NET_RAW"]}}}
+            """.trimIndent()
+        )
+
+        val bounding = credentials.capabilities["bounding"]!!
+        assertEquals("0000000000002000", bounding.hex)
+        assertEquals(listOf("CAP_NET_RAW"), bounding.names)
+        assertTrue(credentials.capabilities["effective"]!!.isEmpty)
+        // A set the kernel did not print is absent rather than empty: "this kernel has no ambient
+        // set" is not "the ambient set is empty".
+        assertNull(credentials.capabilities["ambient"])
+    }
+
+    @Test
+    fun theSeccompModeIsNamedRatherThanNumbered() {
+        assertEquals(SeccompMode.Filter, parseCredentials("""{"seccomp":2}""").seccomp)
+        assertEquals(SeccompMode.Strict, parseCredentials("""{"seccomp":1}""").seccomp)
+        assertEquals(SeccompMode.Disabled, parseCredentials("""{"seccomp":0}""").seccomp)
+        // Absent, not zero: a kernel that does not report the mode has not reported "no filter".
+        assertEquals(SeccompMode.Unknown, parseCredentials("{}").seccomp)
+    }
+
+    @Test
+    fun aSwitchThatWasNotReportedIsNotReportedAsOff() {
+        val reported = parseCredentials("""{"no_new_privs":false,"dumpable":true}""")
+        assertEquals(false, reported.noNewPrivs)
+        assertEquals(true, reported.dumpable)
+
+        val unreported = parseCredentials("""{"no_new_privs_unavailable":"error"}""")
+        assertNull(unreported.noNewPrivs)
+        assertNull(unreported.dumpable)
+    }
+
+    @Test
+    fun aGroupListThatCouldNotBeReadIsNotAnEmptyOne() {
+        val credentials = parseCredentials("""{"groups_unavailable":"error"}""")
+
+        assertTrue(credentials.supplementaryGroups.isEmpty())
+        assertEquals(Unavailable.Error, credentials.groupsUnavailable)
+    }
+
+    @Test
+    fun theGroupsAnAppIsGrantedAreNamed() {
+        assertEquals("inet", androidGroupName(3003))
+        assertEquals("everybody", androidGroupName(9997))
+        assertEquals("cache", androidGroupName(20213))
+        assertNull(androidGroupName(4242))
+    }
+}

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/DescriptorParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/DescriptorParsingTest.kt
@@ -1,0 +1,143 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DescriptorParsingTest {
+
+    @Test
+    fun readsAnOpenFile() {
+        val snapshot = parseDescriptors(
+            """
+            {"limit_soft":32768,"limit_hard":1048576,
+             "descriptors":[{"fd":12,"target":"/apex/com.android.art/javalib/core-oj.jar",
+                             "type":"regular","inode":288734,"size_bytes":4194304,
+                             "access":"read","flags":["nonblock"],"close_on_exec":true,"offset":0}]}
+            """.trimIndent()
+        )
+
+        val descriptor = snapshot.descriptors.single()
+        assertEquals(12, descriptor.fd)
+        assertEquals(DescriptorKind.File, descriptor.kind)
+        assertEquals(DescriptorAccess.Read, descriptor.access)
+        assertEquals("core-oj.jar", descriptor.displayName)
+        assertEquals("/apex/com.android.art/javalib", descriptor.directory)
+        assertEquals(4_194_304L, descriptor.sizeBytes)
+        assertEquals(0L, descriptor.offset)
+        assertTrue(descriptor.closeOnExec)
+        assertEquals(listOf("nonblock"), descriptor.flags)
+    }
+
+    @Test
+    fun aSocketHasNoSizeAndNoPlaceInTheFile() {
+        // The native side leaves both keys out for anything lseek reports as having no position.
+        // Nothing downstream may turn that into a zero, which would read as "at the beginning".
+        val snapshot = parseDescriptors(
+            """{"descriptors":[{"fd":27,"target":"socket:[52831]","type":"socket","inode":52831,"access":"readwrite"}]}"""
+        )
+
+        val descriptor = snapshot.descriptors.single()
+        assertEquals(DescriptorKind.Socket, descriptor.kind)
+        assertNull(descriptor.offset)
+        assertNull(descriptor.sizeBytes)
+        assertEquals("socket:[52831]", descriptor.displayName)
+        assertEquals("", descriptor.directory)
+    }
+
+    @Test
+    fun aShortPathIsShownWholeRatherThanSplit() {
+        // Splitting /dev/null leaves a card headed "null" over a line reading "/dev", which is two
+        // lines to say what fitted on one.
+        val snapshot = parseDescriptors("""{"descriptors":[{"fd":0,"target":"/dev/null","type":"character"}]}""")
+
+        val descriptor = snapshot.descriptors.single()
+        assertEquals("/dev/null", descriptor.displayName)
+        assertEquals("", descriptor.directory)
+    }
+
+    @Test
+    fun aKernelObjectIsToldApartByItsTargetRatherThanByItsType() {
+        // An eventfd is S_IFREG to fstat, exactly as an APK is. Only the link text separates them,
+        // which is why the kind is decided here rather than from the mode bits alone.
+        val snapshot = parseDescriptors(
+            """{"descriptors":[{"fd":31,"target":"anon_inode:[eventfd]","type":"regular","access":"readwrite"}]}"""
+        )
+
+        assertEquals(DescriptorKind.AnonInode, snapshot.descriptors.single().kind)
+    }
+
+    @Test
+    fun deviceNodesAreKeptApartFromFiles() {
+        val snapshot = parseDescriptors(
+            """
+            {"descriptors":[{"fd":0,"target":"/dev/null","type":"character"},
+                            {"fd":3,"target":"/dev/block/dm-9","type":"block"},
+                            {"fd":4,"target":"pipe:[9182]","type":"fifo"},
+                            {"fd":5,"target":"/data/user/0/com.aoscoremonitor","type":"directory"}]}
+            """.trimIndent()
+        )
+
+        assertEquals(
+            listOf(DescriptorKind.Device, DescriptorKind.Device, DescriptorKind.Pipe, DescriptorKind.Directory),
+            snapshot.descriptors.map { it.kind }
+        )
+    }
+
+    @Test
+    fun descriptorsAreOrderedByNumber() {
+        val snapshot = parseDescriptors(
+            """{"descriptors":[{"fd":31,"target":"x"},{"fd":2,"target":"y"},{"fd":12,"target":"z"}]}"""
+        )
+
+        assertEquals(listOf(2, 12, 31), snapshot.descriptors.map { it.fd })
+    }
+
+    @Test
+    fun theBreakdownCountsEachKindOnce() {
+        val snapshot = parseDescriptors(
+            """
+            {"descriptors":[{"fd":0,"target":"/dev/null","type":"character"},
+                            {"fd":1,"target":"/dev/null","type":"character"},
+                            {"fd":9,"target":"socket:[1]","type":"socket"}]}
+            """.trimIndent()
+        )
+
+        // In the kinds' own declared order rather than by count, so that a descriptor opening or
+        // closing does not reshuffle the row of counts under the reader.
+        assertEquals(listOf(DescriptorKind.Socket to 1, DescriptorKind.Device to 2), snapshot.breakdown)
+    }
+
+    @Test
+    fun headroomIsMeasuredAgainstTheSoftLimit() {
+        val snapshot = parseDescriptors(
+            """{"limit_soft":8,"descriptors":[{"fd":0,"target":"a"},{"fd":1,"target":"b"}]}"""
+        )
+
+        assertEquals(2, snapshot.count)
+        assertEquals(0.25f, snapshot.usedFraction)
+    }
+
+    @Test
+    fun anUnboundedLimitIsNotDrawnAsAnEmptyBar() {
+        // The native side omits a limit of RLIM_INFINITY rather than sending a sentinel, so there
+        // is nothing here to draw a fraction against.
+        val snapshot = parseDescriptors("""{"descriptors":[{"fd":0,"target":"a"}]}""")
+
+        assertNull(snapshot.softLimit)
+        assertNull(snapshot.usedFraction)
+    }
+
+    @Test
+    fun aDescriptorWhoseTargetWasRefusedKeepsItsNumberAndSaysWhy() {
+        val snapshot = parseDescriptors(
+            """{"descriptors":[{"fd":6,"target_unavailable":"denied","type":"regular"}]}"""
+        )
+
+        val descriptor = snapshot.descriptors.single()
+        assertEquals(6, descriptor.fd)
+        assertEquals(Unavailable.Denied, descriptor.targetUnavailable)
+        assertEquals("", descriptor.displayName)
+    }
+}

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/MemoryMapParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/MemoryMapParsingTest.kt
@@ -19,7 +19,7 @@ class MemoryMapParsingTest {
              "regions":{"total":3,"categories":[{"key":"anon","count":2,"size_kb":1024},
                                                 {"key":"native_lib","count":1,"size_kb":8192}]},
              "malloc":{"arena":8388608,"in_use":6291456},
-             "limits":{"open_files":32768}}
+             "limits":{"address_space":137438953472}}
             """.trimIndent()
         )
 
@@ -28,7 +28,7 @@ class MemoryMapParsingTest {
         assertEquals(3, snapshot.totalRegions)
         assertEquals("98304 kB", snapshot.status["VmRSS"])
         assertEquals(8_388_608L, snapshot.malloc["arena"])
-        assertEquals(32_768L, snapshot.limits["open_files"])
+        assertEquals(137_438_953_472L, snapshot.limits["address_space"])
     }
 
     @Test


### PR DESCRIPTION
## Description

Four screens, each with one subject the app did not previously cover.

**Open Descriptors** (C++) walks `/proc/self/fd` and reports each descriptor's
target, kind, access mode, flags, inode, size and offset against the
`RLIMIT_NOFILE` ceiling. Numbers are collected and the directory closed before
anything is asked about them, so the handle doing the walk is not reported as a
descriptor the process holds.

**Process Credentials** (C++) reports the real, effective and saved ids, the
supplementary groups, the five capability sets, the seccomp mode, no_new_privs,
dumpable, umask and the SELinux domain — all about this process, where the
security screen is about the device.

**Display** reports the panel: product info from EDID where there is one, state
and rotation, the current mode's resolution and density, every mode it can be
driven at, and its HDR and colour capabilities. Driven by a `DisplayListener`
rather than a timer.

**Frame Pacing** measures the vsync callbacks this app is served: the rate
frames actually arrived at against the rate the panel is driven at, frames
missed, the worst gap, and every gap grouped by how many frames it spanned.
Gaps are counted in frame slots, because 16.7 ms is on time at 60 Hz and a
missed frame at 120.

Three readings moved to where they belong rather than being shown twice:
`FDSize` and `RLIMIT_NOFILE` off the memory screen, and the screen state off
the diagnostics screen, which read it as a boolean where the display screen
tells dozing apart from off. `StorageMountsScreen`'s private pill became a
shared `MonitorTag`.

Verified on an emulator: all four screens read real data. 73 unit tests and 18
instrumented tests pass; the native library builds warning-free on all four
ABIs. The home grid now scrolls, so its navigation test scrolls to each tile
instead of asserting only on the ones that happen to fit.