### PR TITLE
refactor(ui): show the structure the app already had

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Nineteen screens, each with one subject. Everything shown is measured on the dev
 
 **What it can reach** — Storage, Network Stats, TCP Connections
 
-**How it is drawn** — Display, Frame Pacing
+**Display and frames** — Display, Frame Pacing
 
 The native screens read what the Java API cannot reach: `dl_iterate_phdr` for the linker's module list, `mallinfo2` for the native heap, `sched_getaffinity` for a thread's CPU mask, `readlink` and `fcntl` for the open descriptors, the capability masks the kernel prints only in `/proc/self/status`. They are served by one shared library, `libsystem_monitor`, built from `app/src/main/cpp`.
 

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/DeviceIdentity.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/DeviceIdentity.kt
@@ -1,0 +1,44 @@
+package com.aoscoremonitor.diagnostics
+
+import android.os.Build
+
+/**
+ * What this device and this build of Android call themselves.
+ *
+ * The one thing the app had nowhere to say. Nineteen screens report what the system is doing and
+ * none of them reported what the system *is*: the model, the release it runs, the patch level it
+ * claims. The system info screen was four live readings and two thirds of a blank screen, and this
+ * is what belongs above them.
+ *
+ * Not the kernel release — that is a different fact about a different layer, and the CPU screen
+ * already reads it from `uname`.
+ */
+data class DeviceIdentity(
+    val manufacturer: String,
+    val model: String,
+    val androidRelease: String,
+    val sdkInt: Int,
+    val securityPatch: String,
+    val buildId: String,
+    val fingerprint: String
+) {
+    /** "Google Pixel 8", without repeating the maker when the model already names it. */
+    val name: String
+        get() = if (model.startsWith(manufacturer, ignoreCase = true)) model else "$manufacturer $model"
+}
+
+/**
+ * Reads the build constants.
+ *
+ * Static for the life of the process — these are baked into the system image — so the screen reads
+ * them once rather than polling for a model number that cannot change.
+ */
+fun readDeviceIdentity(): DeviceIdentity = DeviceIdentity(
+    manufacturer = Build.MANUFACTURER.orEmpty(),
+    model = Build.MODEL.orEmpty(),
+    androidRelease = Build.VERSION.RELEASE.orEmpty(),
+    sdkInt = Build.VERSION.SDK_INT,
+    securityPatch = Build.VERSION.SECURITY_PATCH.orEmpty(),
+    buildId = Build.ID.orEmpty(),
+    fingerprint = Build.FINGERPRINT.orEmpty()
+)

--- a/app/src/main/java/com/aoscoremonitor/ui/components/MonitorScaffold.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/components/MonitorScaffold.kt
@@ -1,7 +1,9 @@
 package com.aoscoremonitor.ui.components
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -12,10 +14,12 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.aoscoremonitor.R
 
 /**
@@ -70,6 +74,27 @@ fun MonitorScaffold(
             )
         },
         floatingActionButton = floatingActionButton,
-        content = content
+        content = { innerPadding ->
+            // A ceiling on how wide a line of a reading gets. Turned sideways, or on a tablet, a
+            // card ran the full width of the display and a mount's options or a log line became a
+            // single line of text a foot long, which is a measure nobody reads comfortably. Centred
+            // rather than left-aligned so the empty space is split evenly.
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.TopCenter
+            ) {
+                Box(modifier = Modifier.widthIn(max = ContentMaxWidth)) {
+                    content(innerPadding)
+                }
+            }
+        }
     )
 }
+
+/**
+ * The widest a column of readings gets.
+ *
+ * Wide enough that a phone in portrait is unaffected — every phone this app runs on is narrower
+ * than this — and narrow enough that a landscape display does not stretch one card across it.
+ */
+private val ContentMaxWidth = 640.dp

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
@@ -211,6 +211,9 @@ sealed interface Destination : NavKey {
     }
 }
 
+/** A named run of the home grid. */
+data class DestinationGroup(@get:StringRes val titleRes: Int, val destinations: List<Destination>)
+
 /**
  * What the home screen offers, in the order it offers it.
  *
@@ -223,28 +226,48 @@ sealed interface Destination : NavKey {
  * threads), what it is holding (memory, libraries, descriptors), who it is (credentials), and what
  * it can reach (storage, network). The display and the frames it is served close the list, being
  * the one layer the app can watch itself being drawn onto.
+ *
+ * Named groups rather than one long list, because that order was the only thing carrying the
+ * structure and nothing on screen showed it: nineteen tiles arrived looking equally related to each
+ * other. The names are what the grid puts above each run.
  */
-val HomeDestinations: List<Destination> = listOf(
-    Destination.SystemInfo,
-    Destination.Log,
-    Destination.SystemDiagnostics,
-    Destination.SecurityInfo,
-    Destination.FrameworkAnalysis,
-    Destination.HalInfo,
-    Destination.Sensors,
-    Destination.KernelCounters,
-    Destination.CpuCores,
-    Destination.Threads,
-    Destination.MemoryMap,
-    Destination.LoadedLibraries,
-    Destination.Descriptors,
-    Destination.ProcessCredentials,
-    Destination.StorageMounts,
-    Destination.NetworkStats,
-    Destination.TcpConnections,
-    Destination.DisplayPanel,
-    Destination.FramePacing
+val HomeGroups: List<DestinationGroup> = listOf(
+    DestinationGroup(
+        R.string.home_group_framework,
+        listOf(
+            Destination.SystemInfo,
+            Destination.Log,
+            Destination.SystemDiagnostics,
+            Destination.SecurityInfo,
+            Destination.FrameworkAnalysis,
+            Destination.HalInfo,
+            Destination.Sensors
+        )
+    ),
+    DestinationGroup(
+        R.string.home_group_native,
+        listOf(
+            Destination.KernelCounters,
+            Destination.CpuCores,
+            Destination.Threads,
+            Destination.MemoryMap,
+            Destination.LoadedLibraries,
+            Destination.Descriptors,
+            Destination.ProcessCredentials
+        )
+    ),
+    DestinationGroup(
+        R.string.home_group_reach,
+        listOf(Destination.StorageMounts, Destination.NetworkStats, Destination.TcpConnections)
+    ),
+    DestinationGroup(
+        R.string.home_group_display,
+        listOf(Destination.DisplayPanel, Destination.FramePacing)
+    )
 )
+
+/** Every destination the grid offers, flattened. What the navigation test walks. */
+val HomeDestinations: List<Destination> = HomeGroups.flatMap { it.destinations }
 
 /** The short label the home grid uses, which is not always the app bar title. */
 @get:StringRes

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/HomeScreen.kt
@@ -1,10 +1,6 @@
 package com.aoscoremonitor.ui.screens
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.core.Spring
-import androidx.compose.animation.core.spring
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.slideInVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,11 +29,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -55,7 +46,6 @@ import com.aoscoremonitor.ui.navigation.shortTitleRes
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
 import com.aoscoremonitor.ui.theme.MonitorPreviews
 import com.aoscoremonitor.ui.theme.Spacing
-import kotlinx.coroutines.delay
 
 /**
  * The entry point: a grid of everything the app can inspect.
@@ -109,7 +99,6 @@ fun HomeScreen(onNavigate: (Destination) -> Unit, modifier: Modifier = Modifier)
             // then what this process is made of, then what it can reach — and this is where that
             // shows. The index carries on across the groups so the entrance still staggers down
             // the screen rather than restarting at every heading.
-            var index = 0
             HomeGroups.forEach { group ->
                 item(key = "group-${group.titleRes}", span = { GridItemSpan(maxLineSpan) }) {
                     Text(
@@ -123,96 +112,85 @@ fun HomeScreen(onNavigate: (Destination) -> Unit, modifier: Modifier = Modifier)
                     )
                 }
                 items(group.destinations, key = { it.toString() }) { destination ->
-                    DestinationTile(
-                        destination = destination,
-                        index = group.destinations.indexOf(destination) + index,
-                        onClick = { onNavigate(destination) }
-                    )
+                    DestinationTile(destination = destination, onClick = { onNavigate(destination) })
                 }
-                index += group.destinations.size
             }
         }
     }
 }
 
+/**
+ * One tile.
+ *
+ * No entrance animation. Each tile used to fade and slide in on a stagger, which meant an
+ * [AnimatedVisibility] per tile — and an invisible AnimatedVisibility measures zero height, so a
+ * tile composed as it scrolled into view left a hole in the grid until its delay elapsed and then
+ * dropped into place. That read as the grid redrawing itself under the user, and it got worse once
+ * the grid grew headings and had more to scroll. A flourish worth one second of the first launch is
+ * not worth that on every scroll.
+ */
 @Composable
-private fun DestinationTile(destination: Destination, index: Int, onClick: () -> Unit, modifier: Modifier = Modifier) {
-    // The tiles were already animating in, but every one of them waited the same 200ms, so they
-    // all arrived together and the stagger the code was reaching for never happened.
-    var visible by rememberSaveable { mutableStateOf(false) }
-    LaunchedEffect(Unit) {
-        delay(STAGGER_STEP_MS * index.coerceAtMost(MAX_STAGGER_STEPS))
-        visible = true
-    }
-
-    AnimatedVisibility(
-        visible = visible,
-        enter = fadeIn() + slideInVertically(
-            initialOffsetY = { it / 4 },
-            animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy, stiffness = Spring.StiffnessLow)
+private fun DestinationTile(destination: Destination, onClick: () -> Unit, modifier: Modifier = Modifier) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.aspectRatio(1f),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
         )
     ) {
-        Card(
-            onClick = onClick,
-            modifier = modifier.aspectRatio(1f),
-            colors = CardDefaults.cardColors(
-                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
-            )
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(Spacing.Medium),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(Spacing.Medium),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
+            // One treatment for every tile. The icons used to be tinted from a rotation of
+            // primary / secondary / tertiary / error / inversePrimary, which read as though
+            // Security and TCP were in a failure state and left Framework's inversePrimary
+            // barely visible against the card.
+            // primaryContainer rather than secondaryContainer: the theme leaves the surface
+            // containers to Material, which derives them from the same near-white surface the
+            // secondary container sits beside, so the well was the same lightness as the card
+            // and read as nothing. The primary one carries enough blue to be seen.
+            Surface(
+                shape = CircleShape,
+                color = MaterialTheme.colorScheme.primaryContainer,
+                contentColor = MaterialTheme.colorScheme.onPrimaryContainer
             ) {
-                // One treatment for every tile. The icons used to be tinted from a rotation of
-                // primary / secondary / tertiary / error / inversePrimary, which read as though
-                // Security and TCP were in a failure state and left Framework's inversePrimary
-                // barely visible against the card.
-                // primaryContainer rather than secondaryContainer: the theme leaves the surface
-                // containers to Material, which derives them from the same near-white surface the
-                // secondary container sits beside, so the well was the same lightness as the card
-                // and read as nothing. The primary one carries enough blue to be seen.
-                Surface(
-                    shape = CircleShape,
-                    color = MaterialTheme.colorScheme.primaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer
-                ) {
-                    Box(modifier = Modifier.size(IconWellSize), contentAlignment = Alignment.Center) {
-                        Icon(
-                            imageVector = destination.icon,
-                            contentDescription = null,
-                            modifier = Modifier.size(IconSize)
-                        )
-                    }
-                }
-                // Two lines of room whether the label needs them or not. The column centres what it
-                // holds, so a label that wrapped made the content taller and pushed the icon up —
-                // "Kernel Counters" and "Native Libraries" sat a line above the tiles beside them.
-                //
-                // The label is centred in that room rather than laid at the top of it, which is
-                // what `minLines = 2` would do: that fixed the icons but left a line-high hole
-                // under every short label. Room measured from the style's line height, so it grows
-                // with the user's font scale instead of being pinned to a dp constant.
-                val labelStyle = MaterialTheme.typography.titleSmall
-                val labelHeight = with(LocalDensity.current) { labelStyle.lineHeight.toDp() * 2 }
-                Box(
-                    modifier = Modifier
-                        .padding(top = Spacing.Small)
-                        .height(labelHeight),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = stringResource(destination.shortTitleRes),
-                        style = labelStyle,
-                        textAlign = TextAlign.Center,
-                        // Shrink to fit so long single words like "Diagnostics" are not broken
-                        // mid-word by the tile's width.
-                        maxLines = 2,
-                        autoSize = TextAutoSize.StepBased(minFontSize = 10.sp, maxFontSize = labelStyle.fontSize)
+                Box(modifier = Modifier.size(IconWellSize), contentAlignment = Alignment.Center) {
+                    Icon(
+                        imageVector = destination.icon,
+                        contentDescription = null,
+                        modifier = Modifier.size(IconSize)
                     )
                 }
+            }
+            // Two lines of room whether the label needs them or not. The column centres what it
+            // holds, so a label that wrapped made the content taller and pushed the icon up —
+            // "Kernel Counters" and "Native Libraries" sat a line above the tiles beside them.
+            //
+            // The label is centred in that room rather than laid at the top of it, which is
+            // what `minLines = 2` would do: that fixed the icons but left a line-high hole
+            // under every short label. Room measured from the style's line height, so it grows
+            // with the user's font scale instead of being pinned to a dp constant.
+            val labelStyle = MaterialTheme.typography.titleSmall
+            val labelHeight = with(LocalDensity.current) { labelStyle.lineHeight.toDp() * 2 }
+            Box(
+                modifier = Modifier
+                    .padding(top = Spacing.Small)
+                    .height(labelHeight),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(destination.shortTitleRes),
+                    style = labelStyle,
+                    textAlign = TextAlign.Center,
+                    // Shrink to fit so long single words like "Diagnostics" are not broken
+                    // mid-word by the tile's width.
+                    maxLines = 2,
+                    autoSize = TextAutoSize.StepBased(minFontSize = 10.sp, maxFontSize = labelStyle.fontSize)
+                )
             }
         }
     }
@@ -222,10 +200,6 @@ private fun DestinationTile(destination: Destination, index: Int, onClick: () ->
 private val TileMinSize = 108.dp
 private val IconWellSize = 48.dp
 private val IconSize = 24.dp
-private const val STAGGER_STEP_MS = 35L
-
-/** One less than the number of tiles, so the last one still arrives after the one before it. */
-private const val MAX_STAGGER_STEPS = 14
 
 @MonitorPreviews
 @Composable

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -42,12 +43,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.aoscoremonitor.R
 import com.aoscoremonitor.ui.navigation.Destination
-import com.aoscoremonitor.ui.navigation.HomeDestinations
+import com.aoscoremonitor.ui.navigation.HomeGroups
 import com.aoscoremonitor.ui.navigation.shortTitleRes
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
 import com.aoscoremonitor.ui.theme.MonitorPreviews
@@ -102,12 +105,31 @@ fun HomeScreen(onNavigate: (Destination) -> Unit, modifier: Modifier = Modifier)
                     modifier = Modifier.padding(bottom = Spacing.Small)
                 )
             }
-            items(HomeDestinations, key = { it.toString() }) { destination ->
-                DestinationTile(
-                    destination = destination,
-                    index = HomeDestinations.indexOf(destination),
-                    onClick = { onNavigate(destination) }
-                )
+            // A heading over each run. The order already meant something — the framework first,
+            // then what this process is made of, then what it can reach — and this is where that
+            // shows. The index carries on across the groups so the entrance still staggers down
+            // the screen rather than restarting at every heading.
+            var index = 0
+            HomeGroups.forEach { group ->
+                item(key = "group-${group.titleRes}", span = { GridItemSpan(maxLineSpan) }) {
+                    Text(
+                        text = stringResource(group.titleRes),
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = Spacing.Medium, bottom = Spacing.Small)
+                            .semantics(mergeDescendants = true) { heading() }
+                    )
+                }
+                items(group.destinations, key = { it.toString() }) { destination ->
+                    DestinationTile(
+                        destination = destination,
+                        index = group.destinations.indexOf(destination) + index,
+                        onClick = { onNavigate(destination) }
+                    )
+                }
+                index += group.destinations.size
             }
         }
     }
@@ -148,10 +170,14 @@ private fun DestinationTile(destination: Destination, index: Int, onClick: () ->
                 // primary / secondary / tertiary / error / inversePrimary, which read as though
                 // Security and TCP were in a failure state and left Framework's inversePrimary
                 // barely visible against the card.
+                // primaryContainer rather than secondaryContainer: the theme leaves the surface
+                // containers to Material, which derives them from the same near-white surface the
+                // secondary container sits beside, so the well was the same lightness as the card
+                // and read as nothing. The primary one carries enough blue to be seen.
                 Surface(
                     shape = CircleShape,
-                    color = MaterialTheme.colorScheme.secondaryContainer,
-                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer
                 ) {
                     Box(modifier = Modifier.size(IconWellSize), contentAlignment = Alignment.Center) {
                         Icon(

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/LogScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/LogScreen.kt
@@ -30,6 +30,9 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -136,13 +139,31 @@ private fun LogContent(lines: List<LogLine>, droppedCount: Int, onNavigateBack: 
     }
 }
 
+/**
+ * One entry.
+ *
+ * The stamp that opens the line is drawn in the muted colour and the message in the ordinary one.
+ * An entry wraps over four or five lines on a phone, and with every character the same weight the
+ * eye has nothing to catch on to find where the next entry starts — the level rule marks severity,
+ * but only down the left edge of an entry that may be a fifth of the screen tall.
+ */
 @Composable
 private fun LogRow(line: LogLine, modifier: Modifier = Modifier) {
     val accent = line.level.accentColor
+    val prefixColor = MaterialTheme.colorScheme.onSurfaceVariant
+    val messageColor = MaterialTheme.colorScheme.onSurface
+    val text = remember(line, prefixColor, messageColor) {
+        buildAnnotatedString {
+            val split = line.prefixLength.coerceIn(0, line.text.length)
+            withStyle(SpanStyle(color = prefixColor)) { append(line.text.substring(0, split)) }
+            withStyle(SpanStyle(color = messageColor)) { append(line.text.substring(split)) }
+        }
+    }
+
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(vertical = 1.dp)
+            .padding(vertical = Spacing.ExtraSmall / 2)
             .clip(MaterialTheme.shapes.extraSmall)
             .background(line.level.backgroundColor)
     ) {
@@ -156,9 +177,8 @@ private fun LogRow(line: LogLine, modifier: Modifier = Modifier) {
                 .background(accent)
         )
         Text(
-            text = line.text,
+            text = text,
             style = MonitorTypography.machineText,
-            color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.padding(horizontal = Spacing.Small, vertical = Spacing.ExtraSmall)
         )
     }

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/SecurityInfoScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/SecurityInfoScreen.kt
@@ -123,13 +123,21 @@ private fun SecurityInfoContent(
  * means the mode could not be read at all. The card used to signal that through
  * primaryContainer / tertiaryContainer / errorContainer, which meant "good" was rendered in the
  * app's brand color and read as decoration.
+ *
+ * A mode that could not be read is [ReadingStatus.Neutral], not [ReadingStatus.Problem]. It used to
+ * be the latter, which painted the card in the error color and said the device was in a bad state
+ * when all that happened was that `getenforce` would not run from the app sandbox. Every other
+ * screen in this app states why a reading is missing rather than colouring it as a fault, and the
+ * note under the row is where that is said.
  */
 @Composable
 private fun SeLinuxCard(status: String, mode: String, modifier: Modifier = Modifier) {
+    val enforcing = mode.contains("Enforcing", ignoreCase = true)
+    val permissive = mode.contains("Permissive", ignoreCase = true)
     val readingStatus = when {
-        mode.contains("Enforcing", ignoreCase = true) -> ReadingStatus.Ok
-        mode.contains("Permissive", ignoreCase = true) -> ReadingStatus.Warning
-        else -> ReadingStatus.Problem
+        enforcing -> ReadingStatus.Ok
+        permissive -> ReadingStatus.Warning
+        else -> ReadingStatus.Neutral
     }
 
     MonitorCard(modifier = modifier, status = readingStatus) {
@@ -146,6 +154,14 @@ private fun SeLinuxCard(status: String, mode: String, modifier: Modifier = Modif
                 label = stringResource(R.string.security_selinux_mode),
                 value = mode,
                 valueStyle = MaterialTheme.typography.titleMedium
+            )
+        }
+        if (!enforcing && !permissive) {
+            Text(
+                text = stringResource(R.string.security_selinux_unreadable),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = Spacing.Small)
             )
         }
     }

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/SystemInfoScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/SystemInfoScreen.kt
@@ -10,18 +10,28 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Battery6Bar
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.NetworkCell
+import androidx.compose.material.icons.filled.PhoneAndroid
 import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.DeviceIdentity
 import com.aoscoremonitor.diagnostics.SystemInfoCollector
+import com.aoscoremonitor.diagnostics.readDeviceIdentity
 import com.aoscoremonitor.ui.components.InfoCard
+import com.aoscoremonitor.ui.components.LabeledValue
+import com.aoscoremonitor.ui.components.MonitorCard
 import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.SectionHeader
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
 import com.aoscoremonitor.ui.theme.MonitorPreviews
+import com.aoscoremonitor.ui.theme.MonitorTypography
 import com.aoscoremonitor.ui.theme.Spacing
 import com.aoscoremonitor.ui.viewmodel.SystemInfoViewModel
 import com.aoscoremonitor.ui.viewmodel.monitorViewModel
@@ -38,13 +48,20 @@ fun SystemInfoScreen(
 
     SystemInfoContent(
         systemInfo = systemInfo,
+        // Read here rather than polled: these are compiled into the system image.
+        device = remember { readDeviceIdentity() },
         onNavigateBack = onNavigateBack,
         modifier = modifier
     )
 }
 
 @Composable
-private fun SystemInfoContent(systemInfo: SystemInfoCollector.SystemInfo, onNavigateBack: () -> Unit, modifier: Modifier = Modifier) {
+private fun SystemInfoContent(
+    systemInfo: SystemInfoCollector.SystemInfo,
+    device: DeviceIdentity,
+    onNavigateBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     MonitorScaffold(
         title = stringResource(R.string.system_info_title),
         onNavigateBack = onNavigateBack,
@@ -58,6 +75,18 @@ private fun SystemInfoContent(systemInfo: SystemInfoCollector.SystemInfo, onNavi
                 .padding(Spacing.Large),
             verticalArrangement = Arrangement.spacedBy(Spacing.Medium)
         ) {
+            SectionHeader(
+                title = stringResource(R.string.system_info_device_section),
+                subtitle = stringResource(R.string.system_info_device_subtitle),
+                icon = Icons.Default.PhoneAndroid
+            )
+            DeviceCard(device)
+
+            SectionHeader(
+                title = stringResource(R.string.system_info_live_section),
+                subtitle = stringResource(R.string.system_info_live_subtitle),
+                icon = Icons.Default.Speed
+            )
             InfoCard(
                 title = stringResource(R.string.system_info_cpu),
                 value = systemInfo.cpuUsage,
@@ -82,6 +111,35 @@ private fun SystemInfoContent(systemInfo: SystemInfoCollector.SystemInfo, onNavi
     }
 }
 
+/**
+ * What the device says it is.
+ *
+ * The fingerprint last and in machine text: it is the one line here that is an identifier rather
+ * than a fact to read, and it is long enough to wrap twice.
+ */
+@Composable
+private fun DeviceCard(device: DeviceIdentity, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier, spacing = Spacing.Medium) {
+        Text(text = device.name, style = MaterialTheme.typography.titleMedium)
+        LabeledValue(
+            label = stringResource(R.string.system_info_android),
+            value = stringResource(R.string.system_info_android_value, device.androidRelease, device.sdkInt)
+        )
+        if (device.securityPatch.isNotEmpty()) {
+            LabeledValue(
+                label = stringResource(R.string.system_info_security_patch),
+                value = device.securityPatch
+            )
+        }
+        LabeledValue(label = stringResource(R.string.system_info_build), value = device.buildId)
+        LabeledValue(
+            label = stringResource(R.string.system_info_fingerprint),
+            value = device.fingerprint,
+            valueStyle = MonitorTypography.machineText
+        )
+    }
+}
+
 @MonitorPreviews
 @Composable
 private fun SystemInfoPreview() {
@@ -92,6 +150,15 @@ private fun SystemInfoPreview() {
                 memoryUsage = "1686 MB available",
                 batteryStatus = "100%",
                 networkStatus = "Wi-Fi"
+            ),
+            device = DeviceIdentity(
+                manufacturer = "Google",
+                model = "Pixel 8",
+                androidRelease = "16",
+                sdkInt = 36,
+                securityPatch = "2026-07-05",
+                buildId = "BP41.250630.005",
+                fingerprint = "google/shiba/shiba:16/BP41.250630.005/13456789:user/release-keys"
             ),
             onNavigateBack = {}
         )

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/LogViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/LogViewModel.kt
@@ -23,7 +23,16 @@ enum class LogLevel {
  * [id] exists so the list can be keyed. Lines are not unique — the same message repeats — so
  * keying on the text would collide and make Compose reuse the wrong row.
  */
-data class LogLine(val id: Long, val text: String, val level: LogLevel)
+/**
+ * One line of logcat.
+ *
+ * [prefixLength] is how much of [text] is the `MM-DD HH:MM:SS.mmm PID TID L` stamp that opens
+ * logcat's threadtime format, or zero for a line in another shape. The screen draws that part in a
+ * quieter colour: on a narrow display one entry wraps over four or five lines, and with every
+ * character the same weight there is nothing to tell the reader where one entry ends and the next
+ * begins.
+ */
+data class LogLine(val id: Long, val text: String, val level: LogLevel, val prefixLength: Int = 0)
 
 /**
  * Collects logcat for the log screen and keeps the most recent [MAX_LINES] of it.
@@ -67,7 +76,7 @@ class LogViewModel : ViewModel() {
     }
 
     private fun append(text: String) {
-        _lines.add(LogLine(id = nextId++, text = text, level = parseLogLevel(text)))
+        _lines.add(LogLine(id = nextId++, text = text, level = parseLogLevel(text), prefixLength = logPrefixLength(text)))
         if (_lines.size > MAX_LINES) {
             val excess = _lines.size - MAX_LINES
             _lines.removeRange(0, excess)
@@ -89,6 +98,12 @@ class LogViewModel : ViewModel() {
  * `MM-DD HH:MM:SS.mmm  PID  TID L TAG: message`.
  */
 private val ThreadTimeLevel = Regex("""^\d{2}-\d{2} [\d:.]+\s+\d+\s+\d+\s+([VDIWEFS])\s""")
+
+/**
+ * How much of the line is the timestamp, pid, tid and level, or zero when the line is not in
+ * logcat's threadtime format.
+ */
+internal fun logPrefixLength(line: String): Int = ThreadTimeLevel.find(line)?.value?.length ?: 0
 
 /**
  * Reads the severity of a logcat line.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,10 @@
 
     <!-- Home -->
     <string name="home_subtitle">Inspect the Android system layers on this device</string>
+    <string name="home_group_framework">Android framework</string>
+    <string name="home_group_native">This process and the kernel</string>
+    <string name="home_group_reach">Storage and network</string>
+    <string name="home_group_display">Display and frames</string>
     <string name="destination_system_info">System Info</string>
     <string name="destination_logs">System Logs</string>
     <string name="destination_diagnostics">Diagnostics</string>
@@ -66,6 +70,7 @@
     <string name="security_selinux_subtitle">Kernel-level mandatory access control</string>
     <string name="security_selinux_status">Status</string>
     <string name="security_selinux_mode">Mode</string>
+    <string name="security_selinux_unreadable">Reading this needs `getenforce`, which the app sandbox may not run. It says nothing about whether SELinux is enforcing — only that this app cannot ask.</string>
     <string name="security_hardware_section">Hardware Security</string>
     <string name="security_hardware_subtitle">Key storage and biometric hardware on this device</string>
     <string name="security_permissions_section">App Permissions</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,15 @@
 
     <!-- System information -->
     <string name="system_info_title">System Information</string>
+    <string name="system_info_device_section">Device</string>
+    <string name="system_info_device_subtitle">What this device and this build of Android call themselves</string>
+    <string name="system_info_android">Android</string>
+    <string name="system_info_android_value">%1$s · API %2$d</string>
+    <string name="system_info_security_patch">Security patch</string>
+    <string name="system_info_build">Build</string>
+    <string name="system_info_fingerprint">Fingerprint</string>
+    <string name="system_info_live_section">Right now</string>
+    <string name="system_info_live_subtitle">Readings that change while you watch</string>
     <string name="system_info_cpu">CPU Usage</string>
     <string name="system_info_memory">Memory</string>
     <string name="system_info_battery">Battery</string>


### PR DESCRIPTION
## Description

Six changes to how the app presents what it already reads. Nothing new is
collected except the device's own name.

**The home grid shows its grouping.** The order of the tiles meant something —
the framework first, then what this process is made of, then what it can reach —
and nothing on screen said so: nineteen tiles arrived looking equally related.
They now sit under four headings taken from the same list that sets the order.

**The per-tile entrance animation is gone.** An invisible `AnimatedVisibility`
measures zero height, so a tile composed as it scrolled into view left a hole in
the grid until its stagger elapsed and then dropped into place. That read as the
grid redrawing itself, and got worse once the grid had more to scroll.

**The icon well is visible.** It was `secondaryContainer`, which the theme
derives from the same near-white surface the tile sits on.

**An unreadable SELinux mode is no longer painted red.** `ReadingStatus.Problem`
said the device was in a bad state when `getenforce` simply would not run from
the app sandbox. It is neutral now, and says which of the two it is — the same
thing every other screen does with a reading it could not take.

**The log has a hierarchy.** An entry wraps over four or five lines on a phone,
and with every character the same weight there was nothing to mark where one
entry ended. The timestamp, pid and level are drawn muted, the message ordinary.

**The system info screen has something to say.** It was four live readings and
two thirds of a blank screen. It now opens with what the device and this build
of Android call themselves — model, release, security patch, build id,
fingerprint — the one thing nineteen screens had nowhere to report. Read once,
since they are compiled into the system image.

`MonitorScaffold` also caps content at 640dp: turned sideways, a card ran the
full width of the display and a mount's options became one very long line.

Checked on a device in both themes, and while scrolling and returning from a
screen — which is where the animation problem showed. 73 unit tests and 18
instrumented tests pass; the navigation test caught a heading that collided with
a tile label, and the heading was renamed.