### PR TITLE
chore(cpp): Align tooling and formatting with android conventions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,20 +1,22 @@
 ---
 Language: Cpp
-# BasedOnStyle: Google
+# CI pins clang-format 18, so keep this file compatible with that release.
+BasedOnStyle: Google
 AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
-AlignOperands: true
-AlignTrailingComments: true
+AlignOperands: Align
+AlignTrailingComments:
+  Kind: Always
+  OverEmptyLines: 0
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
-AllowShortIfStatementsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true
 AlwaysBreakTemplateDeclarations: Yes
@@ -22,11 +24,10 @@ BinPackArguments: true
 BinPackParameters: true
 BraceWrapping:
   AfterClass: false
-  AfterControlStatement: false
+  AfterControlStatement: Never
   AfterEnum: false
   AfterFunction: false
   AfterNamespace: false
-  AfterObjCDeclaration: false
   AfterStruct: false
   AfterUnion: false
   AfterExternBlock: false
@@ -38,21 +39,17 @@ BraceWrapping:
   SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
-BreakBeforeInheritanceComma: false
 BreakInheritanceList: BeforeColon
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
-BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
 ColumnLimit: 100
 CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat: false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
@@ -75,17 +72,12 @@ IndentCaseLabels: true
 IndentPPDirectives: None
 IndentWidth: 2
 IndentWrappedFunctionNames: false
-JavaScriptQuotes: Leave
-JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
 MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-ObjCBinPackProtocolList: Never
-ObjCBlockIndentWidth: 2
-ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: NextLine
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
@@ -134,13 +126,11 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
-SpacesInAngles: false
-SpacesInContainerLiterals: true
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
+SpacesInAngles: Never
+SpacesInParens: Never
 SpacesInSquareBrackets: false
+# clang-format 18 cannot select C++23 explicitly; Auto is the compatible choice until CI upgrades.
 Standard: Auto
 TabWidth: 2
 UseTab: Never

--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@
 Language: Cpp
 # CI pins clang-format 18, so keep this file compatible with that release.
 BasedOnStyle: Google
-AccessModifierOffset: -1
+AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: None
 AlignConsecutiveDeclarations: None
@@ -47,7 +47,7 @@ ColumnLimit: 100
 CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerIndentWidth: 4
-ContinuationIndentWidth: 4
+ContinuationIndentWidth: 8
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 DisableFormat: false
@@ -70,7 +70,7 @@ IncludeCategories:
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
 IndentPPDirectives: None
-IndentWidth: 2
+IndentWidth: 4
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
@@ -132,5 +132,5 @@ SpacesInParens: Never
 SpacesInSquareBrackets: false
 # clang-format 18 cannot select C++23 explicitly; Auto is the compatible choice until CI upgrades.
 Standard: Auto
-TabWidth: 2
+TabWidth: 4
 UseTab: Never

--- a/.editorconfig
+++ b/.editorconfig
@@ -15,7 +15,7 @@ ktlint_code_style = android_studio
 ktlint_function_naming_ignore_when_annotated_with = Composable
 
 [*.{cpp,h,hpp,cc,c}]
-indent_size = 2
+indent_size = 4
 max_line_length = 100
 
 [*.yml]

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,21 +1,28 @@
 {
   "configurations": [
     {
-      "name": "Mac",
-      "includePath": [
-        "${workspaceFolder}/**",
-        "${env:HOME}/Library/Android/sdk/ndk/**",
-        "${env:ANDROID_NDK_HOME}/**"
-      ],
-      "defines": [],
-      "macFrameworkPath": [
-        "/System/Library/Frameworks",
-        "/Library/Frameworks"
-      ],
-      "compilerPath": "/usr/bin/clang",
-      "cStandard": "c11",
-      "cppStandard": "c++17",
-      "intelliSenseMode": "clang-x64"
+      "name": "Android arm64-v8a",
+      "compileCommands": [
+        "${workspaceFolder}/app/.cxx/tools/debug/arm64-v8a/compile_commands.json"
+      ]
+    },
+    {
+      "name": "Android armeabi-v7a",
+      "compileCommands": [
+        "${workspaceFolder}/app/.cxx/tools/debug/armeabi-v7a/compile_commands.json"
+      ]
+    },
+    {
+      "name": "Android x86_64",
+      "compileCommands": [
+        "${workspaceFolder}/app/.cxx/tools/debug/x86_64/compile_commands.json"
+      ]
+    },
+    {
+      "name": "Android x86",
+      "compileCommands": [
+        "${workspaceFolder}/app/.cxx/tools/debug/x86/compile_commands.json"
+      ]
     }
   ],
   "version": 4

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,13 +4,5 @@
   "C_Cpp.formatting": "clangFormat",
   "[cpp]": {
     "editor.defaultFormatter": "ms-vscode.cpptools"
-  },
-  "C_Cpp.default.includePath": [
-    "${workspaceFolder}/**",
-    "${env:HOME}/Library/Android/sdk/ndk/**",
-    "${env:ANDROID_NDK_HOME}/**"
-  ],
-  "C_Cpp.default.cppStandard": "c++17",
-  "C_Cpp.default.cStandard": "c11",
-  "C_Cpp.default.intelliSenseMode": "clang-x64"
+  }
 }

--- a/app/src/main/cpp/cpu_info.cpp
+++ b/app/src/main/cpp/cpu_info.cpp
@@ -25,7 +25,7 @@ using aoscm::ReadUint64;
 constexpr int kMaxCoresPerRange = 1024;
 
 std::string CpuDir(int id) {
-  return "/sys/devices/system/cpu/cpu" + std::to_string(id);
+    return "/sys/devices/system/cpu/cpu" + std::to_string(id);
 }
 
 /**
@@ -36,40 +36,41 @@ std::string CpuDir(int id) {
  * format is a range list such as `0-7` or `0-3,6-7`.
  */
 std::vector<int> PresentCpus() {
-  std::vector<int> ids;
-  const Reading<std::string> present = ReadTrimmedLine("/sys/devices/system/cpu/present");
+    std::vector<int> ids;
+    const Reading<std::string> present = ReadTrimmedLine("/sys/devices/system/cpu/present");
 
-  if (present.has_value()) {
-    std::string_view remaining(*present);
-    while (!remaining.empty()) {
-      const size_t comma = remaining.find(',');
-      const std::string_view range = remaining.substr(0, comma);
-      const size_t dash = range.find('-');
+    if (present.has_value()) {
+        std::string_view remaining(*present);
+        while (!remaining.empty()) {
+            const size_t comma = remaining.find(',');
+            const std::string_view range = remaining.substr(0, comma);
+            const size_t dash = range.find('-');
 
-      const std::optional<int> first = aoscm::ParseNumber<int>(range.substr(0, dash));
-      const std::optional<int> last = (dash == std::string_view::npos)
-                                          ? first
-                                          : aoscm::ParseNumber<int>(range.substr(dash + 1));
-      if (first.has_value() && last.has_value()) {
-        for (int id = *first; id <= *last && id - *first < kMaxCoresPerRange; ++id) {
-          ids.push_back(id);
+            const std::optional<int> first = aoscm::ParseNumber<int>(range.substr(0, dash));
+            const std::optional<int> last =
+                    (dash == std::string_view::npos)
+                            ? first
+                            : aoscm::ParseNumber<int>(range.substr(dash + 1));
+            if (first.has_value() && last.has_value()) {
+                for (int id = *first; id <= *last && id - *first < kMaxCoresPerRange; ++id) {
+                    ids.push_back(id);
+                }
+            }
+
+            if (comma == std::string_view::npos) {
+                break;
+            }
+            remaining.remove_prefix(comma + 1);
         }
-      }
-
-      if (comma == std::string_view::npos) {
-        break;
-      }
-      remaining.remove_prefix(comma + 1);
     }
-  }
 
-  if (ids.empty()) {
-    const long configured = sysconf(_SC_NPROCESSORS_CONF);
-    for (long id = 0; id < configured; ++id) {
-      ids.push_back(static_cast<int>(id));
+    if (ids.empty()) {
+        const long configured = sysconf(_SC_NPROCESSORS_CONF);
+        for (long id = 0; id < configured; ++id) {
+            ids.push_back(static_cast<int>(id));
+        }
     }
-  }
-  return ids;
+    return ids;
 }
 
 /**
@@ -79,8 +80,8 @@ std::vector<int> PresentCpus() {
  * file therefore means online, not unknown.
  */
 bool IsOnline(int id) {
-  const Reading<uint64_t> online = ReadUint64(CpuDir(id) + "/online");
-  return online.value_or(1) != 0;
+    const Reading<uint64_t> online = ReadUint64(CpuDir(id) + "/online");
+    return online.value_or(1) != 0;
 }
 
 /**
@@ -91,86 +92,86 @@ bool IsOnline(int id) {
  * the whole file is filtered for apps on others.
  */
 std::vector<std::string> IsaFeatures() {
-  std::vector<std::string> features;
+    std::vector<std::string> features;
 
 #if defined(__aarch64__) || defined(__arm__)
-  const unsigned long hwcap = getauxval(AT_HWCAP);
-  const unsigned long hwcap2 = getauxval(AT_HWCAP2);
-#define AOSCM_CAP(caps, mask, label) \
-  do {                               \
-    if (((caps) & (mask)) != 0) {    \
-      features.emplace_back(label);  \
-    }                                \
-  } while (0)
+    const unsigned long hwcap = getauxval(AT_HWCAP);
+    const unsigned long hwcap2 = getauxval(AT_HWCAP2);
+#define AOSCM_CAP(caps, mask, label)      \
+    do {                                  \
+        if (((caps) & (mask)) != 0) {     \
+            features.emplace_back(label); \
+        }                                 \
+    } while (0)
 #endif
 
 #if defined(__aarch64__)
-  AOSCM_CAP(hwcap, HWCAP_FP, "fp");
-  AOSCM_CAP(hwcap, HWCAP_ASIMD, "asimd");
-  AOSCM_CAP(hwcap, HWCAP_AES, "aes");
-  AOSCM_CAP(hwcap, HWCAP_PMULL, "pmull");
-  AOSCM_CAP(hwcap, HWCAP_SHA1, "sha1");
-  AOSCM_CAP(hwcap, HWCAP_SHA2, "sha2");
-  AOSCM_CAP(hwcap, HWCAP_SHA3, "sha3");
-  AOSCM_CAP(hwcap, HWCAP_SHA512, "sha512");
-  AOSCM_CAP(hwcap, HWCAP_CRC32, "crc32");
-  AOSCM_CAP(hwcap, HWCAP_ATOMICS, "atomics");
-  AOSCM_CAP(hwcap, HWCAP_FPHP, "fphp");
-  AOSCM_CAP(hwcap, HWCAP_ASIMDHP, "asimdhp");
-  AOSCM_CAP(hwcap, HWCAP_ASIMDRDM, "asimdrdm");
-  AOSCM_CAP(hwcap, HWCAP_ASIMDDP, "asimddp");
-  AOSCM_CAP(hwcap, HWCAP_ASIMDFHM, "asimdfhm");
-  AOSCM_CAP(hwcap, HWCAP_JSCVT, "jscvt");
-  AOSCM_CAP(hwcap, HWCAP_FCMA, "fcma");
-  AOSCM_CAP(hwcap, HWCAP_LRCPC, "lrcpc");
-  AOSCM_CAP(hwcap, HWCAP_DCPOP, "dcpop");
-  AOSCM_CAP(hwcap, HWCAP_SVE, "sve");
-  AOSCM_CAP(hwcap, HWCAP_DIT, "dit");
-  AOSCM_CAP(hwcap, HWCAP_FLAGM, "flagm");
-  AOSCM_CAP(hwcap, HWCAP_SSBS, "ssbs");
-  AOSCM_CAP(hwcap, HWCAP_PACA, "paca");
-  AOSCM_CAP(hwcap2, HWCAP2_SVE2, "sve2");
-  AOSCM_CAP(hwcap2, HWCAP2_I8MM, "i8mm");
-  AOSCM_CAP(hwcap2, HWCAP2_BF16, "bf16");
-  AOSCM_CAP(hwcap2, HWCAP2_RNG, "rng");
-  AOSCM_CAP(hwcap2, HWCAP2_BTI, "bti");
-  AOSCM_CAP(hwcap2, HWCAP2_MTE, "mte");
-  AOSCM_CAP(hwcap2, HWCAP2_ECV, "ecv");
+    AOSCM_CAP(hwcap, HWCAP_FP, "fp");
+    AOSCM_CAP(hwcap, HWCAP_ASIMD, "asimd");
+    AOSCM_CAP(hwcap, HWCAP_AES, "aes");
+    AOSCM_CAP(hwcap, HWCAP_PMULL, "pmull");
+    AOSCM_CAP(hwcap, HWCAP_SHA1, "sha1");
+    AOSCM_CAP(hwcap, HWCAP_SHA2, "sha2");
+    AOSCM_CAP(hwcap, HWCAP_SHA3, "sha3");
+    AOSCM_CAP(hwcap, HWCAP_SHA512, "sha512");
+    AOSCM_CAP(hwcap, HWCAP_CRC32, "crc32");
+    AOSCM_CAP(hwcap, HWCAP_ATOMICS, "atomics");
+    AOSCM_CAP(hwcap, HWCAP_FPHP, "fphp");
+    AOSCM_CAP(hwcap, HWCAP_ASIMDHP, "asimdhp");
+    AOSCM_CAP(hwcap, HWCAP_ASIMDRDM, "asimdrdm");
+    AOSCM_CAP(hwcap, HWCAP_ASIMDDP, "asimddp");
+    AOSCM_CAP(hwcap, HWCAP_ASIMDFHM, "asimdfhm");
+    AOSCM_CAP(hwcap, HWCAP_JSCVT, "jscvt");
+    AOSCM_CAP(hwcap, HWCAP_FCMA, "fcma");
+    AOSCM_CAP(hwcap, HWCAP_LRCPC, "lrcpc");
+    AOSCM_CAP(hwcap, HWCAP_DCPOP, "dcpop");
+    AOSCM_CAP(hwcap, HWCAP_SVE, "sve");
+    AOSCM_CAP(hwcap, HWCAP_DIT, "dit");
+    AOSCM_CAP(hwcap, HWCAP_FLAGM, "flagm");
+    AOSCM_CAP(hwcap, HWCAP_SSBS, "ssbs");
+    AOSCM_CAP(hwcap, HWCAP_PACA, "paca");
+    AOSCM_CAP(hwcap2, HWCAP2_SVE2, "sve2");
+    AOSCM_CAP(hwcap2, HWCAP2_I8MM, "i8mm");
+    AOSCM_CAP(hwcap2, HWCAP2_BF16, "bf16");
+    AOSCM_CAP(hwcap2, HWCAP2_RNG, "rng");
+    AOSCM_CAP(hwcap2, HWCAP2_BTI, "bti");
+    AOSCM_CAP(hwcap2, HWCAP2_MTE, "mte");
+    AOSCM_CAP(hwcap2, HWCAP2_ECV, "ecv");
 #elif defined(__arm__)
-  AOSCM_CAP(hwcap, HWCAP_NEON, "neon");
-  AOSCM_CAP(hwcap, HWCAP_VFP, "vfp");
-  AOSCM_CAP(hwcap, HWCAP_VFPv3, "vfpv3");
-  AOSCM_CAP(hwcap, HWCAP_VFPv4, "vfpv4");
-  AOSCM_CAP(hwcap, HWCAP_IDIVA, "idiva");
-  AOSCM_CAP(hwcap, HWCAP_IDIVT, "idivt");
-  AOSCM_CAP(hwcap, HWCAP_LPAE, "lpae");
-  AOSCM_CAP(hwcap, HWCAP_ASIMDHP, "asimdhp");
-  AOSCM_CAP(hwcap, HWCAP_ASIMDDP, "asimddp");
-  AOSCM_CAP(hwcap2, HWCAP2_AES, "aes");
-  AOSCM_CAP(hwcap2, HWCAP2_PMULL, "pmull");
-  AOSCM_CAP(hwcap2, HWCAP2_SHA1, "sha1");
-  AOSCM_CAP(hwcap2, HWCAP2_SHA2, "sha2");
-  AOSCM_CAP(hwcap2, HWCAP2_CRC32, "crc32");
+    AOSCM_CAP(hwcap, HWCAP_NEON, "neon");
+    AOSCM_CAP(hwcap, HWCAP_VFP, "vfp");
+    AOSCM_CAP(hwcap, HWCAP_VFPv3, "vfpv3");
+    AOSCM_CAP(hwcap, HWCAP_VFPv4, "vfpv4");
+    AOSCM_CAP(hwcap, HWCAP_IDIVA, "idiva");
+    AOSCM_CAP(hwcap, HWCAP_IDIVT, "idivt");
+    AOSCM_CAP(hwcap, HWCAP_LPAE, "lpae");
+    AOSCM_CAP(hwcap, HWCAP_ASIMDHP, "asimdhp");
+    AOSCM_CAP(hwcap, HWCAP_ASIMDDP, "asimddp");
+    AOSCM_CAP(hwcap2, HWCAP2_AES, "aes");
+    AOSCM_CAP(hwcap2, HWCAP2_PMULL, "pmull");
+    AOSCM_CAP(hwcap2, HWCAP2_SHA1, "sha1");
+    AOSCM_CAP(hwcap2, HWCAP2_SHA2, "sha2");
+    AOSCM_CAP(hwcap2, HWCAP2_CRC32, "crc32");
 #elif defined(__i386__) || defined(__x86_64__)
-  // x86 kernels put almost nothing in AT_HWCAP, so the emulator would otherwise show an empty
-  // list. The compiler builtin reads CPUID instead, which is what the auxv stands in for on ARM.
-  // The builtin only takes a literal, so the features are named one by one rather than looped
-  // over a table.
-#define AOSCM_X86(feature)                 \
-  do {                                     \
-    if (__builtin_cpu_supports(feature)) { \
-      features.emplace_back(feature);      \
-    }                                      \
-  } while (0)
-  AOSCM_X86("sse4.2");
-  AOSCM_X86("aes");
-  AOSCM_X86("popcnt");
-  AOSCM_X86("avx");
-  AOSCM_X86("avx2");
-  AOSCM_X86("fma");
-  AOSCM_X86("bmi");
-  AOSCM_X86("bmi2");
-  AOSCM_X86("avx512f");
+    // x86 kernels put almost nothing in AT_HWCAP, so the emulator would otherwise show an empty
+    // list. The compiler builtin reads CPUID instead, which is what the auxv stands in for on ARM.
+    // The builtin only takes a literal, so the features are named one by one rather than looped
+    // over a table.
+#define AOSCM_X86(feature)                     \
+    do {                                       \
+        if (__builtin_cpu_supports(feature)) { \
+            features.emplace_back(feature);    \
+        }                                      \
+    } while (0)
+    AOSCM_X86("sse4.2");
+    AOSCM_X86("aes");
+    AOSCM_X86("popcnt");
+    AOSCM_X86("avx");
+    AOSCM_X86("avx2");
+    AOSCM_X86("fma");
+    AOSCM_X86("bmi");
+    AOSCM_X86("bmi2");
+    AOSCM_X86("avx512f");
 #undef AOSCM_X86
 #endif
 
@@ -178,7 +179,7 @@ std::vector<std::string> IsaFeatures() {
 #undef AOSCM_CAP
 #endif
 
-  return features;
+    return features;
 }
 
 }  // namespace
@@ -187,76 +188,76 @@ std::vector<std::string> IsaFeatures() {
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeCpuInspector_getCpuStaticNative(JNIEnv* env,
                                                                               jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    JsonWriter writer;
-    writer.BeginObject();
+    return aoscm::ReturnJson(env, [] {
+        JsonWriter writer;
+        writer.BeginObject();
 
-    const long configured = sysconf(_SC_NPROCESSORS_CONF);
-    const long online = sysconf(_SC_NPROCESSORS_ONLN);
-    writer.Field("configured", static_cast<uint64_t>(configured > 0 ? configured : 0));
-    writer.Field("online", static_cast<uint64_t>(online > 0 ? online : 0));
-    writer.Field("page_size", static_cast<uint64_t>(sysconf(_SC_PAGESIZE)));
-    writer.Field("clock_ticks", static_cast<uint64_t>(sysconf(_SC_CLK_TCK)));
+        const long configured = sysconf(_SC_NPROCESSORS_CONF);
+        const long online = sysconf(_SC_NPROCESSORS_ONLN);
+        writer.Field("configured", static_cast<uint64_t>(configured > 0 ? configured : 0));
+        writer.Field("online", static_cast<uint64_t>(online > 0 ? online : 0));
+        writer.Field("page_size", static_cast<uint64_t>(sysconf(_SC_PAGESIZE)));
+        writer.Field("clock_ticks", static_cast<uint64_t>(sysconf(_SC_CLK_TCK)));
 
-    utsname system_name = {};
-    if (uname(&system_name) == 0) {
-      writer.Field("machine", system_name.machine);
-      writer.Field("kernel_release", system_name.release);
-    }
+        utsname system_name = {};
+        if (uname(&system_name) == 0) {
+            writer.Field("machine", system_name.machine);
+            writer.Field("kernel_release", system_name.release);
+        }
 
-    writer.Key("cores").BeginArray();
-    for (const int id : PresentCpus()) {
-      const std::string dir = CpuDir(id);
-      writer.BeginObject();
-      writer.Field("id", static_cast<uint64_t>(id));
-      writer.FieldIfSet("core_id", ReadUint64(dir + "/topology/core_id"));
-      writer.FieldIfSet("package_id", ReadUint64(dir + "/topology/physical_package_id"));
-      writer.FieldIfSet("min_khz", ReadUint64(dir + "/cpufreq/cpuinfo_min_freq"));
-      writer.FieldIfSet("max_khz", ReadUint64(dir + "/cpufreq/cpuinfo_max_freq"));
-      writer.EndObject();
-    }
-    writer.EndArray();
+        writer.Key("cores").BeginArray();
+        for (const int id : PresentCpus()) {
+            const std::string dir = CpuDir(id);
+            writer.BeginObject();
+            writer.Field("id", static_cast<uint64_t>(id));
+            writer.FieldIfSet("core_id", ReadUint64(dir + "/topology/core_id"));
+            writer.FieldIfSet("package_id", ReadUint64(dir + "/topology/physical_package_id"));
+            writer.FieldIfSet("min_khz", ReadUint64(dir + "/cpufreq/cpuinfo_min_freq"));
+            writer.FieldIfSet("max_khz", ReadUint64(dir + "/cpufreq/cpuinfo_max_freq"));
+            writer.EndObject();
+        }
+        writer.EndArray();
 
-    writer.Key("features").BeginArray();
-    for (const std::string& feature : IsaFeatures()) {
-      writer.Value(feature);
-    }
-    writer.EndArray();
+        writer.Key("features").BeginArray();
+        for (const std::string& feature : IsaFeatures()) {
+            writer.Value(feature);
+        }
+        writer.EndArray();
 
-    writer.EndObject();
-    return writer.Take();
-  });
+        writer.EndObject();
+        return writer.Take();
+    });
 }
 
 /** The part that moves: which cores are up, how fast they are running, and under which governor. */
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeCpuInspector_getCpuFrequenciesNative(
-    JNIEnv* env, jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    JsonWriter writer;
-    writer.BeginObject();
-    writer.Key("cores").BeginArray();
+        JNIEnv* env, jobject /* this */) {
+    return aoscm::ReturnJson(env, [] {
+        JsonWriter writer;
+        writer.BeginObject();
+        writer.Key("cores").BeginArray();
 
-    for (const int id : PresentCpus()) {
-      const std::string dir = CpuDir(id);
-      writer.BeginObject();
-      writer.Field("id", static_cast<uint64_t>(id));
-      writer.Field("online", IsOnline(id));
+        for (const int id : PresentCpus()) {
+            const std::string dir = CpuDir(id);
+            writer.BeginObject();
+            writer.Field("id", static_cast<uint64_t>(id));
+            writer.Field("online", IsOnline(id));
 
-      // scaling_cur_freq is denied to apps on some devices and missing entirely on others. The
-      // screen says which rather than showing a stale or zero frequency.
-      const Reading<uint64_t> current = ReadUint64(dir + "/cpufreq/scaling_cur_freq");
-      writer.FieldIfSet("cur_khz", current);
-      if (!current.has_value()) {
-        writer.Field("cur_khz_unavailable", aoscm::DescribeFailure(current.error()));
-      }
+            // scaling_cur_freq is denied to apps on some devices and missing entirely on others.
+            // The screen says which rather than showing a stale or zero frequency.
+            const Reading<uint64_t> current = ReadUint64(dir + "/cpufreq/scaling_cur_freq");
+            writer.FieldIfSet("cur_khz", current);
+            if (!current.has_value()) {
+                writer.Field("cur_khz_unavailable", aoscm::DescribeFailure(current.error()));
+            }
 
-      writer.FieldIfSet("governor", ReadTrimmedLine(dir + "/cpufreq/scaling_governor"));
-      writer.EndObject();
-    }
+            writer.FieldIfSet("governor", ReadTrimmedLine(dir + "/cpufreq/scaling_governor"));
+            writer.EndObject();
+        }
 
-    writer.EndArray();
-    writer.EndObject();
-    return writer.Take();
-  });
+        writer.EndArray();
+        writer.EndObject();
+        return writer.Take();
+    });
 }

--- a/app/src/main/cpp/elf_modules.cpp
+++ b/app/src/main/cpp/elf_modules.cpp
@@ -18,20 +18,20 @@ using aoscm::JsonWriter;
 constexpr char kHexDigits[] = "0123456789abcdef";
 
 struct Module {
-  std::string path;
-  uint64_t base = 0;
-  uint64_t mapped_size = 0;
-  std::string build_id;
-  bool has_relro = false;
-  bool has_tls = false;
-  uint64_t segment_count = 0;
+    std::string path;
+    uint64_t base = 0;
+    uint64_t mapped_size = 0;
+    std::string build_id;
+    bool has_relro = false;
+    bool has_tls = false;
+    uint64_t segment_count = 0;
 };
 
 struct Collector {
-  std::vector<Module> modules;
-  unsigned long long adds = 0;
-  unsigned long long subs = 0;
-  bool counts_valid = false;
+    std::vector<Module> modules;
+    unsigned long long adds = 0;
+    unsigned long long subs = 0;
+    bool counts_valid = false;
 };
 
 /**
@@ -44,32 +44,32 @@ struct Collector {
  * Notes are a packed sequence of `Nhdr`, name, and descriptor, each padded to four bytes.
  */
 std::string ReadBuildId(const ElfW(Phdr) & header, ElfW(Addr) base) {
-  const auto* cursor = reinterpret_cast<const unsigned char*>(base + header.p_vaddr);
-  const unsigned char* const end = cursor + header.p_memsz;
+    const auto* cursor = reinterpret_cast<const unsigned char*>(base + header.p_vaddr);
+    const unsigned char* const end = cursor + header.p_memsz;
 
-  while (cursor + sizeof(ElfW(Nhdr)) <= end) {
-    const auto* note = reinterpret_cast<const ElfW(Nhdr)*>(cursor);
-    const size_t name_size = (note->n_namesz + 3) & ~3u;
-    const size_t desc_size = (note->n_descsz + 3) & ~3u;
-    const unsigned char* const name = cursor + sizeof(ElfW(Nhdr));
-    const unsigned char* const descriptor = name + name_size;
+    while (cursor + sizeof(ElfW(Nhdr)) <= end) {
+        const auto* note = reinterpret_cast<const ElfW(Nhdr)*>(cursor);
+        const size_t name_size = (note->n_namesz + 3) & ~3u;
+        const size_t desc_size = (note->n_descsz + 3) & ~3u;
+        const unsigned char* const name = cursor + sizeof(ElfW(Nhdr));
+        const unsigned char* const descriptor = name + name_size;
 
-    if (descriptor + desc_size > end) {
-      break;
+        if (descriptor + desc_size > end) {
+            break;
+        }
+        if (note->n_type == NT_GNU_BUILD_ID && note->n_namesz == 4 &&
+            std::equal(name, name + 4, reinterpret_cast<const unsigned char*>("GNU"))) {
+            std::string hex;
+            hex.reserve(note->n_descsz * 2);
+            for (size_t i = 0; i < note->n_descsz; ++i) {
+                hex.push_back(kHexDigits[descriptor[i] >> 4]);
+                hex.push_back(kHexDigits[descriptor[i] & 0xF]);
+            }
+            return hex;
+        }
+        cursor = descriptor + desc_size;
     }
-    if (note->n_type == NT_GNU_BUILD_ID && note->n_namesz == 4 &&
-        std::equal(name, name + 4, reinterpret_cast<const unsigned char*>("GNU"))) {
-      std::string hex;
-      hex.reserve(note->n_descsz * 2);
-      for (size_t i = 0; i < note->n_descsz; ++i) {
-        hex.push_back(kHexDigits[descriptor[i] >> 4]);
-        hex.push_back(kHexDigits[descriptor[i] & 0xF]);
-      }
-      return hex;
-    }
-    cursor = descriptor + desc_size;
-  }
-  return std::string();
+    return std::string();
 }
 
 /**
@@ -85,53 +85,53 @@ std::string ReadBuildId(const ElfW(Phdr) & header, ElfW(Addr) base) {
  * outcome, but it is a defined one.
  */
 int CollectModule(dl_phdr_info* info, size_t size, void* data) noexcept {
-  auto* collector = static_cast<Collector*>(data);
+    auto* collector = static_cast<Collector*>(data);
 
-  // dlpi_adds and dlpi_subs were added after the original struct, so they are only there when the
-  // linker says the struct is big enough to hold them.
-  if (!collector->counts_valid &&
-      size >= offsetof(dl_phdr_info, dlpi_subs) + sizeof(info->dlpi_subs)) {
-    collector->adds = info->dlpi_adds;
-    collector->subs = info->dlpi_subs;
-    collector->counts_valid = true;
-  }
-
-  Module module;
-  module.path = (info->dlpi_name != nullptr) ? info->dlpi_name : "";
-  module.base = static_cast<uint64_t>(info->dlpi_addr);
-
-  uint64_t lowest = UINT64_MAX;
-  uint64_t highest = 0;
-  // A pointer and a count are what the linker hands over; a span is what the loop should see.
-  const std::span headers(info->dlpi_phdr, info->dlpi_phnum);
-  for (const ElfW(Phdr) & header : headers) {
-    switch (header.p_type) {
-      case PT_LOAD:
-        lowest = std::min<uint64_t>(lowest, header.p_vaddr);
-        highest = std::max<uint64_t>(highest, header.p_vaddr + header.p_memsz);
-        module.segment_count += 1;
-        break;
-      case PT_NOTE:
-        if (module.build_id.empty()) {
-          module.build_id = ReadBuildId(header, info->dlpi_addr);
-        }
-        break;
-      case PT_GNU_RELRO:
-        module.has_relro = true;
-        break;
-      case PT_TLS:
-        module.has_tls = true;
-        break;
-      default:
-        break;
+    // dlpi_adds and dlpi_subs were added after the original struct, so they are only there when the
+    // linker says the struct is big enough to hold them.
+    if (!collector->counts_valid &&
+        size >= offsetof(dl_phdr_info, dlpi_subs) + sizeof(info->dlpi_subs)) {
+        collector->adds = info->dlpi_adds;
+        collector->subs = info->dlpi_subs;
+        collector->counts_valid = true;
     }
-  }
-  if (lowest != UINT64_MAX) {
-    module.mapped_size = highest - lowest;
-  }
 
-  collector->modules.push_back(std::move(module));
-  return 0;
+    Module module;
+    module.path = (info->dlpi_name != nullptr) ? info->dlpi_name : "";
+    module.base = static_cast<uint64_t>(info->dlpi_addr);
+
+    uint64_t lowest = UINT64_MAX;
+    uint64_t highest = 0;
+    // A pointer and a count are what the linker hands over; a span is what the loop should see.
+    const std::span headers(info->dlpi_phdr, info->dlpi_phnum);
+    for (const ElfW(Phdr) & header : headers) {
+        switch (header.p_type) {
+            case PT_LOAD:
+                lowest = std::min<uint64_t>(lowest, header.p_vaddr);
+                highest = std::max<uint64_t>(highest, header.p_vaddr + header.p_memsz);
+                module.segment_count += 1;
+                break;
+            case PT_NOTE:
+                if (module.build_id.empty()) {
+                    module.build_id = ReadBuildId(header, info->dlpi_addr);
+                }
+                break;
+            case PT_GNU_RELRO:
+                module.has_relro = true;
+                break;
+            case PT_TLS:
+                module.has_tls = true;
+                break;
+            default:
+                break;
+        }
+    }
+    if (lowest != UINT64_MAX) {
+        module.mapped_size = highest - lowest;
+    }
+
+    collector->modules.push_back(std::move(module));
+    return 0;
 }
 
 }  // namespace
@@ -145,35 +145,35 @@ int CollectModule(dl_phdr_info* info, size_t size, void* data) noexcept {
  */
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeModuleInspector_getLoadedModulesNative(
-    JNIEnv* env, jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    Collector collector;
-    dl_iterate_phdr(CollectModule, &collector);
+        JNIEnv* env, jobject /* this */) {
+    return aoscm::ReturnJson(env, [] {
+        Collector collector;
+        dl_iterate_phdr(CollectModule, &collector);
 
-    JsonWriter writer;
-    writer.BeginObject();
-    if (collector.counts_valid) {
-      writer.Field("adds", static_cast<uint64_t>(collector.adds));
-      writer.Field("subs", static_cast<uint64_t>(collector.subs));
-    }
+        JsonWriter writer;
+        writer.BeginObject();
+        if (collector.counts_valid) {
+            writer.Field("adds", static_cast<uint64_t>(collector.adds));
+            writer.Field("subs", static_cast<uint64_t>(collector.subs));
+        }
 
-    writer.Key("modules").BeginArray();
-    for (const Module& module : collector.modules) {
-      writer.BeginObject();
-      writer.Field("path", module.path);
-      writer.FieldHex("base", module.base);
-      writer.Field("mapped_size", module.mapped_size);
-      writer.Field("segment_count", module.segment_count);
-      writer.Field("relro", module.has_relro);
-      writer.Field("tls", module.has_tls);
-      if (!module.build_id.empty()) {
-        writer.Field("build_id", module.build_id);
-      }
-      writer.EndObject();
-    }
-    writer.EndArray();
+        writer.Key("modules").BeginArray();
+        for (const Module& module : collector.modules) {
+            writer.BeginObject();
+            writer.Field("path", module.path);
+            writer.FieldHex("base", module.base);
+            writer.Field("mapped_size", module.mapped_size);
+            writer.Field("segment_count", module.segment_count);
+            writer.Field("relro", module.has_relro);
+            writer.Field("tls", module.has_tls);
+            if (!module.build_id.empty()) {
+                writer.Field("build_id", module.build_id);
+            }
+            writer.EndObject();
+        }
+        writer.EndArray();
 
-    writer.EndObject();
-    return writer.Take();
-  });
+        writer.EndObject();
+        return writer.Take();
+    });
 }

--- a/app/src/main/cpp/fd_info.cpp
+++ b/app/src/main/cpp/fd_info.cpp
@@ -33,12 +33,12 @@ using FdDir = std::unique_ptr<DIR, decltype([](DIR* dir) { closedir(dir); })>;
  * data synchronisation.
  */
 constexpr std::array<std::pair<int, const char*>, 6> kStatusFlags = {{
-    {O_APPEND, "append"},
-    {O_NONBLOCK, "nonblock"},
-    {O_DIRECT, "direct"},
-    {O_SYNC, "sync"},
-    {O_NOATIME, "noatime"},
-    {O_PATH, "path"},
+        {O_APPEND, "append"},
+        {O_NONBLOCK, "nonblock"},
+        {O_DIRECT, "direct"},
+        {O_SYNC, "sync"},
+        {O_NOATIME, "noatime"},
+        {O_PATH, "path"},
 }};
 
 /**
@@ -49,37 +49,37 @@ constexpr std::array<std::pair<int, const char*>, 6> kStatusFlags = {{
  * so a `mode_t` parameter narrows the very field it exists to read.
  */
 const char* TypeName(uint32_t mode) {
-  switch (mode & S_IFMT) {
-    case S_IFREG:
-      return "regular";
-    case S_IFDIR:
-      return "directory";
-    case S_IFCHR:
-      return "character";
-    case S_IFBLK:
-      return "block";
-    case S_IFIFO:
-      return "fifo";
-    case S_IFSOCK:
-      return "socket";
-    case S_IFLNK:
-      return "symlink";
-    default:
-      return "unknown";
-  }
+    switch (mode & S_IFMT) {
+        case S_IFREG:
+            return "regular";
+        case S_IFDIR:
+            return "directory";
+        case S_IFCHR:
+            return "character";
+        case S_IFBLK:
+            return "block";
+        case S_IFIFO:
+            return "fifo";
+        case S_IFSOCK:
+            return "socket";
+        case S_IFLNK:
+            return "symlink";
+        default:
+            return "unknown";
+    }
 }
 
 const char* AccessName(int status_flags) {
-  switch (status_flags & O_ACCMODE) {
-    case O_RDONLY:
-      return "read";
-    case O_WRONLY:
-      return "write";
-    case O_RDWR:
-      return "readwrite";
-    default:
-      return "unknown";
-  }
+    switch (status_flags & O_ACCMODE) {
+        case O_RDONLY:
+            return "read";
+        case O_WRONLY:
+            return "write";
+        case O_RDWR:
+            return "readwrite";
+        default:
+            return "unknown";
+    }
 }
 
 /**
@@ -95,18 +95,18 @@ const char* AccessName(int status_flags) {
  * back as though the process had been holding it all along.
  */
 std::vector<int> ListDescriptorNumbers() {
-  std::vector<int> numbers;
-  const FdDir descriptors{opendir("/proc/self/fd")};
-  if (!descriptors) {
-    return numbers;
-  }
-  while (const dirent* entry = readdir(descriptors.get())) {
-    if (const std::optional<int> fd = aoscm::ParseNumber<int>(entry->d_name)) {
-      numbers.push_back(*fd);
+    std::vector<int> numbers;
+    const FdDir descriptors{opendir("/proc/self/fd")};
+    if (!descriptors) {
+        return numbers;
     }
-    // Anything else is "." or "..", which readdir reports alongside the numbers.
-  }
-  return numbers;
+    while (const dirent* entry = readdir(descriptors.get())) {
+        if (const std::optional<int> fd = aoscm::ParseNumber<int>(entry->d_name)) {
+            numbers.push_back(*fd);
+        }
+        // Anything else is "." or "..", which readdir reports alongside the numbers.
+    }
+    return numbers;
 }
 
 /**
@@ -117,67 +117,68 @@ std::vector<int> ListDescriptorNumbers() {
  * that race is inherent to reading a live process and costs a field, not a wrong reading.
  */
 void WriteDescriptor(JsonWriter* writer, int fd) {
-  char link[PATH_MAX];
-  const std::string path = "/proc/self/fd/" + std::to_string(fd);
-  const ssize_t length = readlink(path.c_str(), link, sizeof(link));
-  const int link_error = length < 0 ? errno : 0;
-  if (link_error == ENOENT || link_error == EBADF) {
-    return;
-  }
-
-  writer->BeginObject();
-  writer->Field("fd", static_cast<uint64_t>(fd));
-
-  if (length >= 0) {
-    // readlink neither terminates what it writes nor fails when the buffer is short — it truncates
-    // — so the length it returns is the only thing that says where the target ends. PATH_MAX is
-    // what the kernel caps these links at, so the truncating case is unreachable here.
-    writer->Field("target", std::string_view(link, static_cast<size_t>(length)));
-  } else {
-    writer->Field("target_unavailable", aoscm::DescribeFailure(link_error));
-  }
-
-  struct stat64 info = {};
-  if (fstat64(fd, &info) != 0) {
-    writer->Field("stat_unavailable", aoscm::DescribeFailure(errno));
-  } else {
-    writer->Field("type", TypeName(info.st_mode));
-    writer->Field("inode", static_cast<uint64_t>(info.st_ino));
-    if (S_ISREG(info.st_mode)) {
-      // Only a regular file has a length worth reporting: a socket answers with zero and a device
-      // with whatever its driver felt like, neither of which is a size.
-      writer->Field("size_bytes", static_cast<uint64_t>(info.st_size));
+    char link[PATH_MAX];
+    const std::string path = "/proc/self/fd/" + std::to_string(fd);
+    const ssize_t length = readlink(path.c_str(), link, sizeof(link));
+    const int link_error = length < 0 ? errno : 0;
+    if (link_error == ENOENT || link_error == EBADF) {
+        return;
     }
-  }
 
-  const int status_flags = fcntl(fd, F_GETFL);
-  if (status_flags >= 0) {
-    writer->Field("access", AccessName(status_flags));
-    writer->Key("flags").BeginArray();
-    for (const auto& [bit, name] : kStatusFlags) {
-      if ((status_flags & bit) == bit) {
-        writer->Value(name);
-      }
+    writer->BeginObject();
+    writer->Field("fd", static_cast<uint64_t>(fd));
+
+    if (length >= 0) {
+        // readlink neither terminates what it writes nor fails when the buffer is short — it
+        // truncates — so the length it returns is the only thing that says where the target ends.
+        // PATH_MAX is what the kernel caps these links at, so the truncating case is unreachable
+        // here.
+        writer->Field("target", std::string_view(link, static_cast<size_t>(length)));
+    } else {
+        writer->Field("target_unavailable", aoscm::DescribeFailure(link_error));
     }
-    writer->EndArray();
-  }
 
-  // The descriptor flag, which is not among the status flags above: close-on-exec belongs to the
-  // descriptor rather than to the open file it names, and F_GETFD is what reports it.
-  const int descriptor_flags = fcntl(fd, F_GETFD);
-  if (descriptor_flags >= 0) {
-    writer->Field("close_on_exec", (descriptor_flags & FD_CLOEXEC) != 0);
-  }
+    struct stat64 info = {};
+    if (fstat64(fd, &info) != 0) {
+        writer->Field("stat_unavailable", aoscm::DescribeFailure(errno));
+    } else {
+        writer->Field("type", TypeName(info.st_mode));
+        writer->Field("inode", static_cast<uint64_t>(info.st_ino));
+        if (S_ISREG(info.st_mode)) {
+            // Only a regular file has a length worth reporting: a socket answers with zero and a
+            // device with whatever its driver felt like, neither of which is a size.
+            writer->Field("size_bytes", static_cast<uint64_t>(info.st_size));
+        }
+    }
 
-  // Where the next read would start. Asking for the current offset moves nothing. A pipe or a
-  // socket has no offset at all, which lseek reports as ESPIPE; the key is then left out rather
-  // than sent as a zero, which would read as "at the beginning".
-  const off64_t offset = lseek64(fd, 0, SEEK_CUR);
-  if (offset >= 0) {
-    writer->Field("offset", static_cast<uint64_t>(offset));
-  }
+    const int status_flags = fcntl(fd, F_GETFL);
+    if (status_flags >= 0) {
+        writer->Field("access", AccessName(status_flags));
+        writer->Key("flags").BeginArray();
+        for (const auto& [bit, name] : kStatusFlags) {
+            if ((status_flags & bit) == bit) {
+                writer->Value(name);
+            }
+        }
+        writer->EndArray();
+    }
 
-  writer->EndObject();
+    // The descriptor flag, which is not among the status flags above: close-on-exec belongs to the
+    // descriptor rather than to the open file it names, and F_GETFD is what reports it.
+    const int descriptor_flags = fcntl(fd, F_GETFD);
+    if (descriptor_flags >= 0) {
+        writer->Field("close_on_exec", (descriptor_flags & FD_CLOEXEC) != 0);
+    }
+
+    // Where the next read would start. Asking for the current offset moves nothing. A pipe or a
+    // socket has no offset at all, which lseek reports as ESPIPE; the key is then left out rather
+    // than sent as a zero, which would read as "at the beginning".
+    const off64_t offset = lseek64(fd, 0, SEEK_CUR);
+    if (offset >= 0) {
+        writer->Field("offset", static_cast<uint64_t>(offset));
+    }
+
+    writer->EndObject();
 }
 
 }  // namespace
@@ -194,30 +195,30 @@ void WriteDescriptor(JsonWriter* writer, int fd) {
  */
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeDescriptorInspector_getDescriptorsNative(
-    JNIEnv* env, jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    JsonWriter writer;
-    writer.BeginObject();
+        JNIEnv* env, jobject /* this */) {
+    return aoscm::ReturnJson(env, [] {
+        JsonWriter writer;
+        writer.BeginObject();
 
-    rlimit limit = {};
-    if (getrlimit(RLIMIT_NOFILE, &limit) == 0) {
-      // An unlimited ceiling is left out rather than published as a sentinel, so the screen has
-      // nothing to draw a headroom bar against.
-      if (limit.rlim_cur != RLIM_INFINITY) {
-        writer.Field("limit_soft", static_cast<uint64_t>(limit.rlim_cur));
-      }
-      if (limit.rlim_max != RLIM_INFINITY) {
-        writer.Field("limit_hard", static_cast<uint64_t>(limit.rlim_max));
-      }
-    }
+        rlimit limit = {};
+        if (getrlimit(RLIMIT_NOFILE, &limit) == 0) {
+            // An unlimited ceiling is left out rather than published as a sentinel, so the screen
+            // has nothing to draw a headroom bar against.
+            if (limit.rlim_cur != RLIM_INFINITY) {
+                writer.Field("limit_soft", static_cast<uint64_t>(limit.rlim_cur));
+            }
+            if (limit.rlim_max != RLIM_INFINITY) {
+                writer.Field("limit_hard", static_cast<uint64_t>(limit.rlim_max));
+            }
+        }
 
-    writer.Key("descriptors").BeginArray();
-    for (const int fd : ListDescriptorNumbers()) {
-      WriteDescriptor(&writer, fd);
-    }
-    writer.EndArray();
+        writer.Key("descriptors").BeginArray();
+        for (const int fd : ListDescriptorNumbers()) {
+            WriteDescriptor(&writer, fd);
+        }
+        writer.EndArray();
 
-    writer.EndObject();
-    return writer.Take();
-  });
+        writer.EndObject();
+        return writer.Take();
+    });
 }

--- a/app/src/main/cpp/memory_map.cpp
+++ b/app/src/main/cpp/memory_map.cpp
@@ -26,60 +26,60 @@ using aoscm::JsonWriter;
  * signedness conversion at each one.
  */
 enum class Category : size_t {
-  kNativeLib,
-  kArt,
-  kDalvik,
-  kNativeHeap,
-  kStack,
-  kAnon,
-  kOther,
-  kCount,
+    kNativeLib,
+    kArt,
+    kDalvik,
+    kNativeHeap,
+    kStack,
+    kAnon,
+    kOther,
+    kCount,
 };
 
 constexpr std::array<const char*, std::to_underlying(Category::kCount)> kCategoryKeys = {
-    "native_lib", "art", "dalvik", "native_heap", "stack", "anon", "other",
+        "native_lib", "art", "dalvik", "native_heap", "stack", "anon", "other",
 };
 
 Category Classify(std::string_view path) {
-  if (path.empty()) {
-    return Category::kAnon;
-  }
-  if (path.starts_with("[stack") || path.starts_with("[anon:stack_and_tls")) {
-    return Category::kStack;
-  }
-  if (path == "[heap]" || path.starts_with("[anon:libc_malloc") ||
-      path.starts_with("[anon:scudo") || path.starts_with("[anon:GWP-ASan")) {
-    return Category::kNativeHeap;
-  }
-  if (path.contains("dalvik")) {
-    return Category::kDalvik;
-  }
-  // A deleted file keeps its name and gains a " (deleted)" suffix, so a library is matched at
-  // either the end of the path or before that marker.
-  if (path.ends_with(".so") || path.contains(".so ")) {
-    return Category::kNativeLib;
-  }
-  if (path.ends_with(".art") || path.ends_with(".oat") || path.ends_with(".odex") ||
-      path.ends_with(".vdex") || path.ends_with(".dex") || path.ends_with(".jar") ||
-      path.ends_with(".apk")) {
-    return Category::kArt;
-  }
-  if (path.starts_with("[")) {
-    return Category::kAnon;
-  }
-  return Category::kOther;
+    if (path.empty()) {
+        return Category::kAnon;
+    }
+    if (path.starts_with("[stack") || path.starts_with("[anon:stack_and_tls")) {
+        return Category::kStack;
+    }
+    if (path == "[heap]" || path.starts_with("[anon:libc_malloc") ||
+        path.starts_with("[anon:scudo") || path.starts_with("[anon:GWP-ASan")) {
+        return Category::kNativeHeap;
+    }
+    if (path.contains("dalvik")) {
+        return Category::kDalvik;
+    }
+    // A deleted file keeps its name and gains a " (deleted)" suffix, so a library is matched at
+    // either the end of the path or before that marker.
+    if (path.ends_with(".so") || path.contains(".so ")) {
+        return Category::kNativeLib;
+    }
+    if (path.ends_with(".art") || path.ends_with(".oat") || path.ends_with(".odex") ||
+        path.ends_with(".vdex") || path.ends_with(".dex") || path.ends_with(".jar") ||
+        path.ends_with(".apk")) {
+        return Category::kArt;
+    }
+    if (path.starts_with("[")) {
+        return Category::kAnon;
+    }
+    return Category::kOther;
 }
 
 struct CategoryTotals {
-  uint64_t count = 0;
-  uint64_t size_kb = 0;
+    uint64_t count = 0;
+    uint64_t size_kb = 0;
 };
 
 struct MapsSummary {
-  uint64_t total_regions = 0;
-  uint64_t reserved_regions = 0;
-  uint64_t reserved_kb = 0;
-  std::array<CategoryTotals, std::to_underlying(Category::kCount)> categories = {};
+    uint64_t total_regions = 0;
+    uint64_t reserved_regions = 0;
+    uint64_t reserved_kb = 0;
+    std::array<CategoryTotals, std::to_underlying(Category::kCount)> categories = {};
 };
 
 /**
@@ -95,83 +95,84 @@ struct MapsSummary {
  * process holding 100 MB, which is true of the address space and says nothing about the memory.
  */
 MapsSummary SummarizeMaps() {
-  MapsSummary summary;
-  std::ifstream maps("/proc/self/maps");
-  if (!maps.is_open()) {
+    MapsSummary summary;
+    std::ifstream maps("/proc/self/maps");
+    if (!maps.is_open()) {
+        return summary;
+    }
+
+    std::string line;
+    while (std::getline(maps, line)) {
+        const size_t dash = line.find('-');
+        const size_t space = line.find(' ');
+        if (dash == std::string::npos || space == std::string::npos || dash > space) {
+            continue;
+        }
+
+        const std::string_view entry(line);
+        const std::optional<uint64_t> first =
+                aoscm::ParseNumber<uint64_t, 16>(entry.substr(0, dash));
+        const std::optional<uint64_t> last =
+                aoscm::ParseNumber<uint64_t, 16>(entry.substr(dash + 1, space - dash - 1));
+        if (!first.has_value() || !last.has_value() || *last <= *first) {
+            continue;
+        }
+        const uint64_t start = *first;
+        const uint64_t end = *last;
+
+        summary.total_regions += 1;
+
+        // The permissions are the fixed-width field straight after the address range.
+        const std::string_view permissions = entry.substr(space + 1, 4);
+        const bool accessible =
+                permissions.size() == 4 &&
+                (permissions[0] == 'r' || permissions[1] == 'w' || permissions[2] == 'x');
+        if (!accessible) {
+            summary.reserved_regions += 1;
+            summary.reserved_kb += (end - start) / 1024;
+            continue;
+        }
+
+        // Five whitespace-separated fields precede the path; whatever follows them is the path,
+        // spaces included.
+        size_t position = 0;
+        int fields = 0;
+        while (fields < 5 && position < line.size()) {
+            position = line.find(' ', position);
+            if (position == std::string::npos) {
+                break;
+            }
+            position = line.find_first_not_of(' ', position);
+            ++fields;
+        }
+        const std::string_view path =
+                (fields == 5 && position != std::string::npos && position < line.size())
+                        ? entry.substr(position)
+                        : std::string_view();
+
+        auto& totals = summary.categories[std::to_underlying(Classify(path))];
+        totals.count += 1;
+        totals.size_kb += (end - start) / 1024;
+    }
     return summary;
-  }
-
-  std::string line;
-  while (std::getline(maps, line)) {
-    const size_t dash = line.find('-');
-    const size_t space = line.find(' ');
-    if (dash == std::string::npos || space == std::string::npos || dash > space) {
-      continue;
-    }
-
-    const std::string_view entry(line);
-    const std::optional<uint64_t> first = aoscm::ParseNumber<uint64_t, 16>(entry.substr(0, dash));
-    const std::optional<uint64_t> last =
-        aoscm::ParseNumber<uint64_t, 16>(entry.substr(dash + 1, space - dash - 1));
-    if (!first.has_value() || !last.has_value() || *last <= *first) {
-      continue;
-    }
-    const uint64_t start = *first;
-    const uint64_t end = *last;
-
-    summary.total_regions += 1;
-
-    // The permissions are the fixed-width field straight after the address range.
-    const std::string_view permissions = entry.substr(space + 1, 4);
-    const bool accessible =
-        permissions.size() == 4 &&
-        (permissions[0] == 'r' || permissions[1] == 'w' || permissions[2] == 'x');
-    if (!accessible) {
-      summary.reserved_regions += 1;
-      summary.reserved_kb += (end - start) / 1024;
-      continue;
-    }
-
-    // Five whitespace-separated fields precede the path; whatever follows them is the path,
-    // spaces included.
-    size_t position = 0;
-    int fields = 0;
-    while (fields < 5 && position < line.size()) {
-      position = line.find(' ', position);
-      if (position == std::string::npos) {
-        break;
-      }
-      position = line.find_first_not_of(' ', position);
-      ++fields;
-    }
-    const std::string_view path =
-        (fields == 5 && position != std::string::npos && position < line.size())
-            ? entry.substr(position)
-            : std::string_view();
-
-    auto& totals = summary.categories[std::to_underlying(Classify(path))];
-    totals.count += 1;
-    totals.size_kb += (end - start) / 1024;
-  }
-  return summary;
 }
 
 /** The smaps counters worth showing, in the order the screen shows them. */
 constexpr std::array<const char*, 8> kRollupKeys = {
-    "Rss",          "Pss",          "Private_Clean", "Private_Dirty",
-    "Shared_Clean", "Shared_Dirty", "Swap",          "SwapPss",
+        "Rss",          "Pss",          "Private_Clean", "Private_Dirty",
+        "Shared_Clean", "Shared_Dirty", "Swap",          "SwapPss",
 };
 
 /** The JSON key each smaps counter is published under. */
 constexpr std::array<const char*, 8> kRollupJsonKeys = {
-    "rss_kb",          "pss_kb",          "private_clean_kb", "private_dirty_kb",
-    "shared_clean_kb", "shared_dirty_kb", "swap_kb",          "swap_pss_kb",
+        "rss_kb",          "pss_kb",          "private_clean_kb", "private_dirty_kb",
+        "shared_clean_kb", "shared_dirty_kb", "swap_kb",          "swap_pss_kb",
 };
 
 struct Rollup {
-  bool present = false;
-  bool from_rollup_file = false;
-  std::array<uint64_t, kRollupKeys.size()> values = {};
+    bool present = false;
+    bool from_rollup_file = false;
+    std::array<uint64_t, kRollupKeys.size()> values = {};
 };
 
 /**
@@ -183,31 +184,31 @@ struct Rollup {
  * them and only the cost differs.
  */
 Rollup ReadSmaps(const char* path, bool is_rollup_file) {
-  Rollup rollup;
-  std::ifstream file(path);
-  if (!file.is_open()) {
-    return rollup;
-  }
+    Rollup rollup;
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return rollup;
+    }
 
-  std::string line;
-  while (std::getline(file, line)) {
-    const size_t colon = line.find(':');
-    if (colon == std::string::npos) {
-      continue;
+    std::string line;
+    while (std::getline(file, line)) {
+        const size_t colon = line.find(':');
+        if (colon == std::string::npos) {
+            continue;
+        }
+        const std::string_view key = std::string_view(line).substr(0, colon);
+        for (size_t i = 0; i < kRollupKeys.size(); ++i) {
+            if (key == kRollupKeys[i]) {
+                const std::optional<uint64_t> value = aoscm::ParseLeadingNumber<uint64_t>(
+                        std::string_view(line).substr(colon + 1));
+                rollup.values[i] += value.value_or(0);
+                rollup.present = true;
+                break;
+            }
+        }
     }
-    const std::string_view key = std::string_view(line).substr(0, colon);
-    for (size_t i = 0; i < kRollupKeys.size(); ++i) {
-      if (key == kRollupKeys[i]) {
-        const std::optional<uint64_t> value =
-            aoscm::ParseLeadingNumber<uint64_t>(std::string_view(line).substr(colon + 1));
-        rollup.values[i] += value.value_or(0);
-        rollup.present = true;
-        break;
-      }
-    }
-  }
-  rollup.from_rollup_file = is_rollup_file && rollup.present;
-  return rollup;
+    rollup.from_rollup_file = is_rollup_file && rollup.present;
+    return rollup;
 }
 
 /**
@@ -218,29 +219,29 @@ Rollup ReadSmaps(const char* path, bool is_rollup_file) {
  * the same figure is what that screen was added to stop, not to continue.
  */
 constexpr std::array<const char*, 5> kStatusKeys = {
-    "VmSize", "VmRSS", "VmHWM", "VmSwap", "Threads",
+        "VmSize", "VmRSS", "VmHWM", "VmSwap", "Threads",
 };
 
 void WriteStatus(JsonWriter* writer, const aoscm::StatusLines& status) {
-  // Driven by the key list rather than by the file, so the screen gets them in the order named
-  // above. Walking the file put them in the kernel's order, which is not the same one.
-  writer->Key("status").BeginObject();
-  for (const char* key : kStatusKeys) {
-    if (const std::string* value = aoscm::FindStatus(status, key)) {
-      writer->Field(key, *value);
+    // Driven by the key list rather than by the file, so the screen gets them in the order named
+    // above. Walking the file put them in the kernel's order, which is not the same one.
+    writer->Key("status").BeginObject();
+    for (const char* key : kStatusKeys) {
+        if (const std::string* value = aoscm::FindStatus(status, key)) {
+            writer->Field(key, *value);
+        }
     }
-  }
-  writer->EndObject();
+    writer->EndObject();
 }
 
 void WriteLimit(JsonWriter* writer, const char* key, int resource) {
-  rlimit limit = {};
-  if (getrlimit(resource, &limit) != 0 || limit.rlim_cur == RLIM_INFINITY) {
-    // An unlimited resource is left out rather than published as a sentinel, so the screen has
-    // nothing to misreport as a very large number.
-    return;
-  }
-  writer->Field(key, static_cast<uint64_t>(limit.rlim_cur));
+    rlimit limit = {};
+    if (getrlimit(resource, &limit) != 0 || limit.rlim_cur == RLIM_INFINITY) {
+        // An unlimited resource is left out rather than published as a sentinel, so the screen has
+        // nothing to misreport as a very large number.
+        return;
+    }
+    writer->Field(key, static_cast<uint64_t>(limit.rlim_cur));
 }
 
 }  // namespace
@@ -254,65 +255,65 @@ void WriteLimit(JsonWriter* writer, const char* key, int resource) {
  */
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeMemoryInspector_getMemoryMapNative(
-    JNIEnv* env, jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    JsonWriter writer;
-    writer.BeginObject();
+        JNIEnv* env, jobject /* this */) {
+    return aoscm::ReturnJson(env, [] {
+        JsonWriter writer;
+        writer.BeginObject();
 
-    Rollup rollup = ReadSmaps("/proc/self/smaps_rollup", true);
-    if (!rollup.present) {
-      rollup = ReadSmaps("/proc/self/smaps", false);
-    }
-    if (rollup.present) {
-      writer.Key("rollup").BeginObject();
-      for (size_t i = 0; i < kRollupJsonKeys.size(); ++i) {
-        writer.Field(kRollupJsonKeys[i], rollup.values[i]);
-      }
-      writer.Field("from_rollup_file", rollup.from_rollup_file);
-      writer.EndObject();
-    }
+        Rollup rollup = ReadSmaps("/proc/self/smaps_rollup", true);
+        if (!rollup.present) {
+            rollup = ReadSmaps("/proc/self/smaps", false);
+        }
+        if (rollup.present) {
+            writer.Key("rollup").BeginObject();
+            for (size_t i = 0; i < kRollupJsonKeys.size(); ++i) {
+                writer.Field(kRollupJsonKeys[i], rollup.values[i]);
+            }
+            writer.Field("from_rollup_file", rollup.from_rollup_file);
+            writer.EndObject();
+        }
 
-    WriteStatus(&writer, aoscm::ReadProcStatus());
+        WriteStatus(&writer, aoscm::ReadProcStatus());
 
-    const MapsSummary maps = SummarizeMaps();
-    writer.Key("regions").BeginObject();
-    writer.Field("total", maps.total_regions);
-    writer.Field("reserved_count", maps.reserved_regions);
-    writer.Field("reserved_kb", maps.reserved_kb);
-    writer.Key("categories").BeginArray();
-    for (size_t i = 0; i < kCategoryKeys.size(); ++i) {
-      if (maps.categories[i].count == 0) {
-        continue;
-      }
-      writer.BeginObject();
-      writer.Field("key", kCategoryKeys[i]);
-      writer.Field("count", maps.categories[i].count);
-      writer.Field("size_kb", maps.categories[i].size_kb);
-      writer.EndObject();
-    }
-    writer.EndArray();
-    writer.EndObject();
+        const MapsSummary maps = SummarizeMaps();
+        writer.Key("regions").BeginObject();
+        writer.Field("total", maps.total_regions);
+        writer.Field("reserved_count", maps.reserved_regions);
+        writer.Field("reserved_kb", maps.reserved_kb);
+        writer.Key("categories").BeginArray();
+        for (size_t i = 0; i < kCategoryKeys.size(); ++i) {
+            if (maps.categories[i].count == 0) {
+                continue;
+            }
+            writer.BeginObject();
+            writer.Field("key", kCategoryKeys[i]);
+            writer.Field("count", maps.categories[i].count);
+            writer.Field("size_kb", maps.categories[i].size_kb);
+            writer.EndObject();
+        }
+        writer.EndArray();
+        writer.EndObject();
 
-    const struct mallinfo2 heap = mallinfo2();
-    writer.Key("malloc").BeginObject();
-    writer.Field("arena", static_cast<uint64_t>(heap.arena));
-    writer.Field("in_use", static_cast<uint64_t>(heap.uordblks));
-    writer.Field("free", static_cast<uint64_t>(heap.fordblks));
-    writer.Field("free_chunks", static_cast<uint64_t>(heap.ordblks));
-    writer.Field("mmapped", static_cast<uint64_t>(heap.hblkhd));
-    writer.Field("peak", static_cast<uint64_t>(heap.usmblks));
-    writer.Field("releasable", static_cast<uint64_t>(heap.keepcost));
-    writer.EndObject();
+        const struct mallinfo2 heap = mallinfo2();
+        writer.Key("malloc").BeginObject();
+        writer.Field("arena", static_cast<uint64_t>(heap.arena));
+        writer.Field("in_use", static_cast<uint64_t>(heap.uordblks));
+        writer.Field("free", static_cast<uint64_t>(heap.fordblks));
+        writer.Field("free_chunks", static_cast<uint64_t>(heap.ordblks));
+        writer.Field("mmapped", static_cast<uint64_t>(heap.hblkhd));
+        writer.Field("peak", static_cast<uint64_t>(heap.usmblks));
+        writer.Field("releasable", static_cast<uint64_t>(heap.keepcost));
+        writer.EndObject();
 
-    writer.Key("limits").BeginObject();
-    WriteLimit(&writer, "address_space", RLIMIT_AS);
-    WriteLimit(&writer, "data", RLIMIT_DATA);
-    WriteLimit(&writer, "stack", RLIMIT_STACK);
-    // RLIMIT_NOFILE was here. It bounds the descriptor table rather than the address space, and the
-    // descriptor screen shows it where the count it bounds is.
-    writer.EndObject();
+        writer.Key("limits").BeginObject();
+        WriteLimit(&writer, "address_space", RLIMIT_AS);
+        WriteLimit(&writer, "data", RLIMIT_DATA);
+        WriteLimit(&writer, "stack", RLIMIT_STACK);
+        // RLIMIT_NOFILE was here. It bounds the descriptor table rather than the address space, and
+        // the descriptor screen shows it where the count it bounds is.
+        writer.EndObject();
 
-    writer.EndObject();
-    return writer.Take();
-  });
+        writer.EndObject();
+        return writer.Take();
+    });
 }

--- a/app/src/main/cpp/native_util.cpp
+++ b/app/src/main/cpp/native_util.cpp
@@ -16,12 +16,12 @@ namespace {
 constexpr char kHexDigits[] = "0123456789abcdef";
 
 std::string Trim(const std::string& text) {
-  const size_t first = text.find_first_not_of(" \t\n\r");
-  if (first == std::string::npos) {
-    return std::string();
-  }
-  const size_t last = text.find_last_not_of(" \t\n\r");
-  return text.substr(first, last - first + 1);
+    const size_t first = text.find_first_not_of(" \t\n\r");
+    if (first == std::string::npos) {
+        return std::string();
+    }
+    const size_t last = text.find_last_not_of(" \t\n\r");
+    return text.substr(first, last - first + 1);
 }
 
 /**
@@ -31,65 +31,65 @@ std::string Trim(const std::string& text) {
  * than passed through to the JVM.
  */
 size_t Utf8SequenceLength(const unsigned char* bytes, size_t available) {
-  const unsigned char lead = bytes[0];
-  size_t length;
-  unsigned char min_second;
-  unsigned char max_second;
+    const unsigned char lead = bytes[0];
+    size_t length;
+    unsigned char min_second;
+    unsigned char max_second;
 
-  if (lead >= 0xC2 && lead <= 0xDF) {
-    length = 2;
-    min_second = 0x80;
-    max_second = 0xBF;
-  } else if (lead >= 0xE0 && lead <= 0xEF) {
-    length = 3;
-    min_second = (lead == 0xE0) ? 0xA0 : 0x80;
-    max_second = (lead == 0xED) ? 0x9F : 0xBF;
-  } else if (lead >= 0xF0 && lead <= 0xF4) {
-    length = 4;
-    min_second = (lead == 0xF0) ? 0x90 : 0x80;
-    max_second = (lead == 0xF4) ? 0x8F : 0xBF;
-  } else {
-    return 0;
-  }
-
-  if (available < length) {
-    return 0;
-  }
-  if (bytes[1] < min_second || bytes[1] > max_second) {
-    return 0;
-  }
-  for (size_t i = 2; i < length; ++i) {
-    if (bytes[i] < 0x80 || bytes[i] > 0xBF) {
-      return 0;
+    if (lead >= 0xC2 && lead <= 0xDF) {
+        length = 2;
+        min_second = 0x80;
+        max_second = 0xBF;
+    } else if (lead >= 0xE0 && lead <= 0xEF) {
+        length = 3;
+        min_second = (lead == 0xE0) ? 0xA0 : 0x80;
+        max_second = (lead == 0xED) ? 0x9F : 0xBF;
+    } else if (lead >= 0xF0 && lead <= 0xF4) {
+        length = 4;
+        min_second = (lead == 0xF0) ? 0x90 : 0x80;
+        max_second = (lead == 0xF4) ? 0x8F : 0xBF;
+    } else {
+        return 0;
     }
-  }
-  return length;
+
+    if (available < length) {
+        return 0;
+    }
+    if (bytes[1] < min_second || bytes[1] > max_second) {
+        return 0;
+    }
+    for (size_t i = 2; i < length; ++i) {
+        if (bytes[i] < 0x80 || bytes[i] > 0xBF) {
+            return 0;
+        }
+    }
+    return length;
 }
 
 void AppendUtf16Escape(std::string* out, uint32_t unit) {
-  out->append("\\u");
-  for (int shift = 12; shift >= 0; shift -= 4) {
-    out->push_back(kHexDigits[(unit >> shift) & 0xF]);
-  }
+    out->append("\\u");
+    for (int shift = 12; shift >= 0; shift -= 4) {
+        out->push_back(kHexDigits[(unit >> shift) & 0xF]);
+    }
 }
 
 /** Closes the descriptor however the scope is left. */
 class ScopedFd {
- public:
-  explicit ScopedFd(int fd) : fd_(fd) {}
-  ~ScopedFd() {
-    if (fd_ >= 0) {
-      ::close(fd_);
+public:
+    explicit ScopedFd(int fd) : fd_(fd) {}
+    ~ScopedFd() {
+        if (fd_ >= 0) {
+            ::close(fd_);
+        }
     }
-  }
-  ScopedFd(const ScopedFd&) = delete;
-  ScopedFd& operator=(const ScopedFd&) = delete;
+    ScopedFd(const ScopedFd&) = delete;
+    ScopedFd& operator=(const ScopedFd&) = delete;
 
-  [[nodiscard]] int get() const { return fd_; }
-  [[nodiscard]] bool valid() const { return fd_ >= 0; }
+    [[nodiscard]] int get() const { return fd_; }
+    [[nodiscard]] bool valid() const { return fd_ >= 0; }
 
- private:
-  int fd_;
+private:
+    int fd_;
 };
 
 /**
@@ -100,288 +100,288 @@ class ScopedFd {
  * does not have, so the length has to come from reading to the end.
  */
 Reading<std::string> ReadFile(const std::string& path) {
-  const ScopedFd file(::open(path.c_str(), O_RDONLY | O_CLOEXEC));
-  if (!file.valid()) {
-    return std::unexpected(errno);
-  }
+    const ScopedFd file(::open(path.c_str(), O_RDONLY | O_CLOEXEC));
+    if (!file.valid()) {
+        return std::unexpected(errno);
+    }
 
-  std::string contents;
-  char buffer[4096];
-  while (true) {
-    const ssize_t count = ::read(file.get(), buffer, sizeof(buffer));
-    if (count < 0) {
-      if (errno == EINTR) {
-        continue;
-      }
-      return std::unexpected(errno);
+    std::string contents;
+    char buffer[4096];
+    while (true) {
+        const ssize_t count = ::read(file.get(), buffer, sizeof(buffer));
+        if (count < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            return std::unexpected(errno);
+        }
+        if (count == 0) {
+            return contents;
+        }
+        contents.append(buffer, static_cast<size_t>(count));
     }
-    if (count == 0) {
-      return contents;
-    }
-    contents.append(buffer, static_cast<size_t>(count));
-  }
 }
 
 }  // namespace
 
 void LogCollectorFailure(const char* what) {
-  __android_log_print(ANDROID_LOG_ERROR, "NativeCollector", "Collector failed: %s", what);
+    __android_log_print(ANDROID_LOG_ERROR, "NativeCollector", "Collector failed: %s", what);
 }
 
 std::string_view DescribeFailure(int error) {
-  switch (error) {
-    case EACCES:
-    case EPERM:
-      return "denied";
-    case ENOENT:
-    case ENODEV:
-    case ENXIO:
-      return "absent";
-    default:
-      return "error";
-  }
+    switch (error) {
+        case EACCES:
+        case EPERM:
+            return "denied";
+        case ENOENT:
+        case ENODEV:
+        case ENXIO:
+            return "absent";
+        default:
+            return "error";
+    }
 }
 
 Reading<std::string> ReadTrimmedLine(const std::string& path) {
-  const Reading<std::string> contents = ReadFile(path);
-  if (!contents.has_value()) {
-    return std::unexpected(contents.error());
-  }
-  std::string trimmed = Trim(*contents);
-  if (trimmed.empty()) {
-    // The file opened and held nothing, which is not the same as being refused.
-    return std::unexpected(ENODATA);
-  }
-  return trimmed;
+    const Reading<std::string> contents = ReadFile(path);
+    if (!contents.has_value()) {
+        return std::unexpected(contents.error());
+    }
+    std::string trimmed = Trim(*contents);
+    if (trimmed.empty()) {
+        // The file opened and held nothing, which is not the same as being refused.
+        return std::unexpected(ENODATA);
+    }
+    return trimmed;
 }
 
 Reading<uint64_t> ReadUint64(const std::string& path) {
-  const Reading<std::string> line = ReadTrimmedLine(path);
-  if (!line.has_value()) {
-    return std::unexpected(line.error());
-  }
-  const std::optional<uint64_t> value = ParseNumber<uint64_t>(*line);
-  if (!value.has_value()) {
-    return std::unexpected(EINVAL);
-  }
-  return *value;
+    const Reading<std::string> line = ReadTrimmedLine(path);
+    if (!line.has_value()) {
+        return std::unexpected(line.error());
+    }
+    const std::optional<uint64_t> value = ParseNumber<uint64_t>(*line);
+    if (!value.has_value()) {
+        return std::unexpected(EINVAL);
+    }
+    return *value;
 }
 
 StatusLines ReadProcStatus() {
-  StatusLines lines;
-  std::ifstream status("/proc/self/status");
-  std::string line;
-  while (std::getline(status, line)) {
-    const size_t colon = line.find(':');
-    if (colon == std::string::npos) {
-      continue;
+    StatusLines lines;
+    std::ifstream status("/proc/self/status");
+    std::string line;
+    while (std::getline(status, line)) {
+        const size_t colon = line.find(':');
+        if (colon == std::string::npos) {
+            continue;
+        }
+        const size_t value_start = line.find_first_not_of(" \t", colon + 1);
+        if (value_start == std::string::npos) {
+            continue;
+        }
+        lines.emplace_back(line.substr(0, colon), line.substr(value_start));
     }
-    const size_t value_start = line.find_first_not_of(" \t", colon + 1);
-    if (value_start == std::string::npos) {
-      continue;
-    }
-    lines.emplace_back(line.substr(0, colon), line.substr(value_start));
-  }
-  return lines;
+    return lines;
 }
 
 const std::string* FindStatus(const StatusLines& status, std::string_view key) {
-  for (const auto& [name, value] : status) {
-    if (name == key) {
-      return &value;
+    for (const auto& [name, value] : status) {
+        if (name == key) {
+            return &value;
+        }
     }
-  }
-  return nullptr;
+    return nullptr;
 }
 
 void JsonWriter::Separate() {
-  if (needs_comma_) {
-    out_.push_back(',');
-  }
-  needs_comma_ = false;
+    if (needs_comma_) {
+        out_.push_back(',');
+    }
+    needs_comma_ = false;
 }
 
 void JsonWriter::AppendEscaped(std::string_view value) {
-  const auto* bytes = reinterpret_cast<const unsigned char*>(value.data());
-  const size_t size = value.size();
+    const auto* bytes = reinterpret_cast<const unsigned char*>(value.data());
+    const size_t size = value.size();
 
-  for (size_t i = 0; i < size;) {
-    const unsigned char byte = bytes[i];
-    if (byte < 0x80) {
-      switch (byte) {
-        case '"':
-          out_.append("\\\"");
-          break;
-        case '\\':
-          out_.append("\\\\");
-          break;
-        case '\n':
-          out_.append("\\n");
-          break;
-        case '\r':
-          out_.append("\\r");
-          break;
-        case '\t':
-          out_.append("\\t");
-          break;
-        default:
-          if (byte < 0x20) {
-            AppendUtf16Escape(&out_, byte);
-          } else {
-            out_.push_back(static_cast<char>(byte));
-          }
-          break;
-      }
-      ++i;
-      continue;
-    }
+    for (size_t i = 0; i < size;) {
+        const unsigned char byte = bytes[i];
+        if (byte < 0x80) {
+            switch (byte) {
+                case '"':
+                    out_.append("\\\"");
+                    break;
+                case '\\':
+                    out_.append("\\\\");
+                    break;
+                case '\n':
+                    out_.append("\\n");
+                    break;
+                case '\r':
+                    out_.append("\\r");
+                    break;
+                case '\t':
+                    out_.append("\\t");
+                    break;
+                default:
+                    if (byte < 0x20) {
+                        AppendUtf16Escape(&out_, byte);
+                    } else {
+                        out_.push_back(static_cast<char>(byte));
+                    }
+                    break;
+            }
+            ++i;
+            continue;
+        }
 
-    const size_t length = Utf8SequenceLength(bytes + i, size - i);
-    if (length == 0) {
-      // A path is a byte string, so it need not be text at all. Replacing the byte keeps the
-      // document decodable instead of handing the JVM something it cannot represent.
-      out_.push_back('?');
-      ++i;
-      continue;
+        const size_t length = Utf8SequenceLength(bytes + i, size - i);
+        if (length == 0) {
+            // A path is a byte string, so it need not be text at all. Replacing the byte keeps the
+            // document decodable instead of handing the JVM something it cannot represent.
+            out_.push_back('?');
+            ++i;
+            continue;
+        }
+        if (length == 4) {
+            // Escaped as a surrogate pair: the JVM's modified UTF-8 has no four-byte form, and
+            // passing one to NewStringUTF is undefined.
+            const uint32_t code_point = (static_cast<uint32_t>(bytes[i] & 0x07) << 18) |
+                                        (static_cast<uint32_t>(bytes[i + 1] & 0x3F) << 12) |
+                                        (static_cast<uint32_t>(bytes[i + 2] & 0x3F) << 6) |
+                                        static_cast<uint32_t>(bytes[i + 3] & 0x3F);
+            const uint32_t offset = code_point - 0x10000;
+            AppendUtf16Escape(&out_, 0xD800 + (offset >> 10));
+            AppendUtf16Escape(&out_, 0xDC00 + (offset & 0x3FF));
+        } else {
+            out_.append(value.substr(i, length));
+        }
+        i += length;
     }
-    if (length == 4) {
-      // Escaped as a surrogate pair: the JVM's modified UTF-8 has no four-byte form, and passing
-      // one to NewStringUTF is undefined.
-      const uint32_t code_point = (static_cast<uint32_t>(bytes[i] & 0x07) << 18) |
-                                  (static_cast<uint32_t>(bytes[i + 1] & 0x3F) << 12) |
-                                  (static_cast<uint32_t>(bytes[i + 2] & 0x3F) << 6) |
-                                  static_cast<uint32_t>(bytes[i + 3] & 0x3F);
-      const uint32_t offset = code_point - 0x10000;
-      AppendUtf16Escape(&out_, 0xD800 + (offset >> 10));
-      AppendUtf16Escape(&out_, 0xDC00 + (offset & 0x3FF));
-    } else {
-      out_.append(value.substr(i, length));
-    }
-    i += length;
-  }
 }
 
 JsonWriter& JsonWriter::BeginObject() {
-  Separate();
-  out_.push_back('{');
-  return *this;
+    Separate();
+    out_.push_back('{');
+    return *this;
 }
 
 JsonWriter& JsonWriter::EndObject() {
-  out_.push_back('}');
-  needs_comma_ = true;
-  return *this;
+    out_.push_back('}');
+    needs_comma_ = true;
+    return *this;
 }
 
 JsonWriter& JsonWriter::BeginArray() {
-  Separate();
-  out_.push_back('[');
-  return *this;
+    Separate();
+    out_.push_back('[');
+    return *this;
 }
 
 JsonWriter& JsonWriter::EndArray() {
-  out_.push_back(']');
-  needs_comma_ = true;
-  return *this;
+    out_.push_back(']');
+    needs_comma_ = true;
+    return *this;
 }
 
 JsonWriter& JsonWriter::Key(std::string_view key) {
-  Separate();
-  out_.push_back('"');
-  AppendEscaped(key);
-  out_.append("\":");
-  return *this;
+    Separate();
+    out_.push_back('"');
+    AppendEscaped(key);
+    out_.append("\":");
+    return *this;
 }
 
 JsonWriter& JsonWriter::Value(std::string_view value) {
-  Separate();
-  out_.push_back('"');
-  AppendEscaped(value);
-  out_.push_back('"');
-  needs_comma_ = true;
-  return *this;
+    Separate();
+    out_.push_back('"');
+    AppendEscaped(value);
+    out_.push_back('"');
+    needs_comma_ = true;
+    return *this;
 }
 
 JsonWriter& JsonWriter::Value(uint64_t value) {
-  Separate();
-  out_.append(std::to_string(value));
-  needs_comma_ = true;
-  return *this;
+    Separate();
+    out_.append(std::to_string(value));
+    needs_comma_ = true;
+    return *this;
 }
 
 JsonWriter& JsonWriter::Value(int64_t value) {
-  Separate();
-  out_.append(std::to_string(value));
-  needs_comma_ = true;
-  return *this;
+    Separate();
+    out_.append(std::to_string(value));
+    needs_comma_ = true;
+    return *this;
 }
 
 JsonWriter& JsonWriter::Value(bool value) {
-  Separate();
-  out_.append(value ? "true" : "false");
-  needs_comma_ = true;
-  return *this;
+    Separate();
+    out_.append(value ? "true" : "false");
+    needs_comma_ = true;
+    return *this;
 }
 
 JsonWriter& JsonWriter::Value(const char* value) {
-  return Value(value == nullptr ? std::string_view() : std::string_view(value));
+    return Value(value == nullptr ? std::string_view() : std::string_view(value));
 }
 
 // to_chars rather than std::format: libc++ is linked statically here, so one format call pulls
 // the whole formatting machinery into the library — measured at 210 KB per ABI.
 JsonWriter& JsonWriter::ValueHex(uint64_t value) {
-  // 16 digits is the widest a uint64_t reaches in base 16, so to_chars cannot run out of room.
-  char digits[16];
-  const auto [end, error] = std::to_chars(digits, digits + sizeof(digits), value, 16);
-  if (error != std::errc()) {
-    return Value("0x0");
-  }
-  return Value("0x" + std::string(digits, end));
+    // 16 digits is the widest a uint64_t reaches in base 16, so to_chars cannot run out of room.
+    char digits[16];
+    const auto [end, error] = std::to_chars(digits, digits + sizeof(digits), value, 16);
+    if (error != std::errc()) {
+        return Value("0x0");
+    }
+    return Value("0x" + std::string(digits, end));
 }
 
 JsonWriter& JsonWriter::Field(std::string_view key, std::string_view value) {
-  return Key(key).Value(value);
+    return Key(key).Value(value);
 }
 
 JsonWriter& JsonWriter::Field(std::string_view key, uint64_t value) {
-  return Key(key).Value(value);
+    return Key(key).Value(value);
 }
 
 JsonWriter& JsonWriter::Field(std::string_view key, int64_t value) {
-  return Key(key).Value(value);
+    return Key(key).Value(value);
 }
 
 JsonWriter& JsonWriter::Field(std::string_view key, bool value) {
-  return Key(key).Value(value);
+    return Key(key).Value(value);
 }
 
 JsonWriter& JsonWriter::Field(std::string_view key, const char* value) {
-  return Key(key).Value(value);
+    return Key(key).Value(value);
 }
 
 JsonWriter& JsonWriter::FieldHex(std::string_view key, uint64_t value) {
-  return Key(key).ValueHex(value);
+    return Key(key).ValueHex(value);
 }
 
 JsonWriter& JsonWriter::FieldIfSet(std::string_view key, const Reading<uint64_t>& value) {
-  if (value.has_value()) {
-    Field(key, *value);
-  }
-  return *this;
+    if (value.has_value()) {
+        Field(key, *value);
+    }
+    return *this;
 }
 
 JsonWriter& JsonWriter::FieldIfSet(std::string_view key, const Reading<std::string>& value) {
-  if (value.has_value()) {
-    Field(key, *value);
-  }
-  return *this;
+    if (value.has_value()) {
+        Field(key, *value);
+    }
+    return *this;
 }
 
 std::string JsonWriter::Take() {
-  std::string result;
-  result.swap(out_);
-  needs_comma_ = false;
-  return result;
+    std::string result;
+    result.swap(out_);
+    needs_comma_ = false;
+    return result;
 }
 
 }  // namespace aoscm

--- a/app/src/main/cpp/native_util.h
+++ b/app/src/main/cpp/native_util.h
@@ -30,14 +30,14 @@ void LogCollectorFailure(const char* what);
  */
 template <typename Collect>
 jstring ReturnJson(JNIEnv* env, Collect collect) noexcept {
-  try {
-    return env->NewStringUTF(collect().c_str());
-  } catch (const std::exception& failure) {
-    LogCollectorFailure(failure.what());
-  } catch (...) {
-    LogCollectorFailure("unknown exception");
-  }
-  return env->NewStringUTF("{}");
+    try {
+        return env->NewStringUTF(collect().c_str());
+    } catch (const std::exception& failure) {
+        LogCollectorFailure(failure.what());
+    } catch (...) {
+        LogCollectorFailure("unknown exception");
+    }
+    return env->NewStringUTF("{}");
 }
 
 /**
@@ -68,14 +68,14 @@ using Reading = std::expected<T, int>;
  */
 template <typename T, int Base = 10>
 [[nodiscard]] std::optional<T> ParseNumber(std::string_view text) {
-  T value{};
-  const char* const first = text.data();
-  const char* const last = first + text.size();
-  const auto [end, error] = std::from_chars(first, last, value, Base);
-  if (error != std::errc() || end != last) {
-    return std::nullopt;
-  }
-  return value;
+    T value{};
+    const char* const first = text.data();
+    const char* const last = first + text.size();
+    const auto [end, error] = std::from_chars(first, last, value, Base);
+    if (error != std::errc() || end != last) {
+        return std::nullopt;
+    }
+    return value;
 }
 
 /**
@@ -86,18 +86,18 @@ template <typename T, int Base = 10>
  */
 template <typename T, int Base = 10>
 [[nodiscard]] std::optional<T> ParseLeadingNumber(std::string_view text) {
-  const size_t start = text.find_first_not_of(" \t");
-  if (start == std::string_view::npos) {
-    return std::nullopt;
-  }
-  T value{};
-  const char* const first = text.data() + start;
-  const char* const last = text.data() + text.size();
-  const auto [end, error] = std::from_chars(first, last, value, Base);
-  if (error != std::errc() || end == first) {
-    return std::nullopt;
-  }
-  return value;
+    const size_t start = text.find_first_not_of(" \t");
+    if (start == std::string_view::npos) {
+        return std::nullopt;
+    }
+    T value{};
+    const char* const first = text.data() + start;
+    const char* const last = text.data() + text.size();
+    const auto [end, error] = std::from_chars(first, last, value, Base);
+    if (error != std::errc() || end == first) {
+        return std::nullopt;
+    }
+    return value;
 }
 
 /**
@@ -142,55 +142,55 @@ using StatusLines = std::vector<std::pair<std::string, std::string>>;
  * Structure is the caller's responsibility; the writer only tracks where a comma belongs.
  */
 class JsonWriter {
- public:
-  JsonWriter& BeginObject();
-  JsonWriter& EndObject();
-  JsonWriter& BeginArray();
-  JsonWriter& EndArray();
+public:
+    JsonWriter& BeginObject();
+    JsonWriter& EndObject();
+    JsonWriter& BeginArray();
+    JsonWriter& EndArray();
 
-  JsonWriter& Key(std::string_view key);
+    JsonWriter& Key(std::string_view key);
 
-  JsonWriter& Value(std::string_view value);
-  JsonWriter& Value(uint64_t value);
-  /** For counters the kernel reports signed — a thread's nice value runs from -20. */
-  JsonWriter& Value(int64_t value);
-  JsonWriter& Value(bool value);
-  /**
-   * Keeps a C string a string.
-   *
-   * Without it, `const char*` converts to `bool` by a standard conversion and to `string_view`
-   * only by a user-defined one, so overload resolution silently picks the boolean overload and
-   * `uname().machine` is written as `true`.
-   */
-  JsonWriter& Value(const char* value);
-  JsonWriter& Field(std::string_view key, std::string_view value);
-  JsonWriter& Field(std::string_view key, uint64_t value);
-  /** See [Value(int64_t)]. */
-  JsonWriter& Field(std::string_view key, int64_t value);
-  JsonWriter& Field(std::string_view key, bool value);
-  /** See [Value(const char*)] — the same overload trap applies here. */
-  JsonWriter& Field(std::string_view key, const char* value);
-  /** Writes an address as a `"0x…"` string: JSON numbers cannot hold a 64-bit pointer exactly. */
-  JsonWriter& FieldHex(std::string_view key, uint64_t value);
+    JsonWriter& Value(std::string_view value);
+    JsonWriter& Value(uint64_t value);
+    /** For counters the kernel reports signed — a thread's nice value runs from -20. */
+    JsonWriter& Value(int64_t value);
+    JsonWriter& Value(bool value);
+    /**
+     * Keeps a C string a string.
+     *
+     * Without it, `const char*` converts to `bool` by a standard conversion and to `string_view`
+     * only by a user-defined one, so overload resolution silently picks the boolean overload and
+     * `uname().machine` is written as `true`.
+     */
+    JsonWriter& Value(const char* value);
+    JsonWriter& Field(std::string_view key, std::string_view value);
+    JsonWriter& Field(std::string_view key, uint64_t value);
+    /** See [Value(int64_t)]. */
+    JsonWriter& Field(std::string_view key, int64_t value);
+    JsonWriter& Field(std::string_view key, bool value);
+    /** See [Value(const char*)] — the same overload trap applies here. */
+    JsonWriter& Field(std::string_view key, const char* value);
+    /** Writes an address as a `"0x…"` string: JSON numbers cannot hold a 64-bit pointer exactly. */
+    JsonWriter& FieldHex(std::string_view key, uint64_t value);
 
-  /**
-   * Writes the field only when the reading was taken.
-   *
-   * Absent keys, rather than nulls or zeros, are how an unavailable reading crosses to Kotlin.
-   */
-  JsonWriter& FieldIfSet(std::string_view key, const Reading<uint64_t>& value);
-  JsonWriter& FieldIfSet(std::string_view key, const Reading<std::string>& value);
+    /**
+     * Writes the field only when the reading was taken.
+     *
+     * Absent keys, rather than nulls or zeros, are how an unavailable reading crosses to Kotlin.
+     */
+    JsonWriter& FieldIfSet(std::string_view key, const Reading<uint64_t>& value);
+    JsonWriter& FieldIfSet(std::string_view key, const Reading<std::string>& value);
 
-  /** Hands over the finished document. The writer is empty afterwards. */
-  [[nodiscard]] std::string Take();
+    /** Hands over the finished document. The writer is empty afterwards. */
+    [[nodiscard]] std::string Take();
 
- private:
-  JsonWriter& ValueHex(uint64_t value);
-  void Separate();
-  void AppendEscaped(std::string_view value);
+private:
+    JsonWriter& ValueHex(uint64_t value);
+    void Separate();
+    void AppendEscaped(std::string_view value);
 
-  std::string out_;
-  bool needs_comma_ = false;
+    std::string out_;
+    bool needs_comma_ = false;
 };
 
 }  // namespace aoscm

--- a/app/src/main/cpp/process_creds.cpp
+++ b/app/src/main/cpp/process_creds.cpp
@@ -29,57 +29,57 @@ using aoscm::StatusLines;
  * to translate CAP_SYS_ADMIN.
  */
 constexpr std::array<const char*, 41> kCapabilityNames = {
-    "CAP_CHOWN",
-    "CAP_DAC_OVERRIDE",
-    "CAP_DAC_READ_SEARCH",
-    "CAP_FOWNER",
-    "CAP_FSETID",
-    "CAP_KILL",
-    "CAP_SETGID",
-    "CAP_SETUID",
-    "CAP_SETPCAP",
-    "CAP_LINUX_IMMUTABLE",
-    "CAP_NET_BIND_SERVICE",
-    "CAP_NET_BROADCAST",
-    "CAP_NET_ADMIN",
-    "CAP_NET_RAW",
-    "CAP_IPC_LOCK",
-    "CAP_IPC_OWNER",
-    "CAP_SYS_MODULE",
-    "CAP_SYS_RAWIO",
-    "CAP_SYS_CHROOT",
-    "CAP_SYS_PTRACE",
-    "CAP_SYS_PACCT",
-    "CAP_SYS_ADMIN",
-    "CAP_SYS_BOOT",
-    "CAP_SYS_NICE",
-    "CAP_SYS_RESOURCE",
-    "CAP_SYS_TIME",
-    "CAP_SYS_TTY_CONFIG",
-    "CAP_MKNOD",
-    "CAP_LEASE",
-    "CAP_AUDIT_WRITE",
-    "CAP_AUDIT_CONTROL",
-    "CAP_SETFCAP",
-    "CAP_MAC_OVERRIDE",
-    "CAP_MAC_ADMIN",
-    "CAP_SYSLOG",
-    "CAP_WAKE_ALARM",
-    "CAP_BLOCK_SUSPEND",
-    "CAP_AUDIT_READ",
-    "CAP_PERFMON",
-    "CAP_BPF",
-    "CAP_CHECKPOINT_RESTORE",
+        "CAP_CHOWN",
+        "CAP_DAC_OVERRIDE",
+        "CAP_DAC_READ_SEARCH",
+        "CAP_FOWNER",
+        "CAP_FSETID",
+        "CAP_KILL",
+        "CAP_SETGID",
+        "CAP_SETUID",
+        "CAP_SETPCAP",
+        "CAP_LINUX_IMMUTABLE",
+        "CAP_NET_BIND_SERVICE",
+        "CAP_NET_BROADCAST",
+        "CAP_NET_ADMIN",
+        "CAP_NET_RAW",
+        "CAP_IPC_LOCK",
+        "CAP_IPC_OWNER",
+        "CAP_SYS_MODULE",
+        "CAP_SYS_RAWIO",
+        "CAP_SYS_CHROOT",
+        "CAP_SYS_PTRACE",
+        "CAP_SYS_PACCT",
+        "CAP_SYS_ADMIN",
+        "CAP_SYS_BOOT",
+        "CAP_SYS_NICE",
+        "CAP_SYS_RESOURCE",
+        "CAP_SYS_TIME",
+        "CAP_SYS_TTY_CONFIG",
+        "CAP_MKNOD",
+        "CAP_LEASE",
+        "CAP_AUDIT_WRITE",
+        "CAP_AUDIT_CONTROL",
+        "CAP_SETFCAP",
+        "CAP_MAC_OVERRIDE",
+        "CAP_MAC_ADMIN",
+        "CAP_SYSLOG",
+        "CAP_WAKE_ALARM",
+        "CAP_BLOCK_SUSPEND",
+        "CAP_AUDIT_READ",
+        "CAP_PERFMON",
+        "CAP_BPF",
+        "CAP_CHECKPOINT_RESTORE",
 };
 
 /** The five capability sets, as the JSON key each goes out under and the status line it comes from.
  */
 constexpr std::array<std::pair<const char*, const char*>, 5> kCapabilitySets = {{
-    {"effective", "CapEff"},
-    {"permitted", "CapPrm"},
-    {"inheritable", "CapInh"},
-    {"bounding", "CapBnd"},
-    {"ambient", "CapAmb"},
+        {"effective", "CapEff"},
+        {"permitted", "CapPrm"},
+        {"inheritable", "CapInh"},
+        {"bounding", "CapBnd"},
+        {"ambient", "CapAmb"},
 }};
 
 /**
@@ -90,42 +90,43 @@ constexpr std::array<std::pair<const char*, const char*>, 5> kCapabilitySets = {
  */
 void WriteCapabilitySet(JsonWriter* writer, const StatusLines& status, const char* key,
                         const char* status_key) {
-  const std::string* text = aoscm::FindStatus(status, status_key);
-  if (text == nullptr) {
-    return;
-  }
-
-  writer->Key(key).BeginObject();
-  writer->Field("hex", *text);
-  if (const std::optional<uint64_t> mask = aoscm::ParseNumber<uint64_t, 16>(*text)) {
-    writer->Key("names").BeginArray();
-    for (unsigned bit = 0; bit < 64; ++bit) {
-      if ((*mask & (uint64_t{1} << bit)) == 0) {
-        continue;
-      }
-      if (bit < kCapabilityNames.size()) {
-        writer->Value(kCapabilityNames[bit]);
-      } else {
-        // A capability this build predates. Named by its bit so the set still adds up, rather than
-        // dropped, which would show a non-empty mask alongside a shorter list than it holds.
-        writer->Value("CAP_" + std::to_string(bit));
-      }
+    const std::string* text = aoscm::FindStatus(status, status_key);
+    if (text == nullptr) {
+        return;
     }
-    writer->EndArray();
-  }
-  writer->EndObject();
+
+    writer->Key(key).BeginObject();
+    writer->Field("hex", *text);
+    if (const std::optional<uint64_t> mask = aoscm::ParseNumber<uint64_t, 16>(*text)) {
+        writer->Key("names").BeginArray();
+        for (unsigned bit = 0; bit < 64; ++bit) {
+            if ((*mask & (uint64_t{1} << bit)) == 0) {
+                continue;
+            }
+            if (bit < kCapabilityNames.size()) {
+                writer->Value(kCapabilityNames[bit]);
+            } else {
+                // A capability this build predates. Named by its bit so the set still adds up,
+                // rather than dropped, which would show a non-empty mask alongside a shorter list
+                // than it holds.
+                writer->Value("CAP_" + std::to_string(bit));
+            }
+        }
+        writer->EndArray();
+    }
+    writer->EndObject();
 }
 
 /** Writes a `/proc/self/status` line that holds a plain decimal count. */
 void WriteStatusNumber(JsonWriter* writer, const StatusLines& status, const char* key,
                        const char* status_key) {
-  const std::string* text = aoscm::FindStatus(status, status_key);
-  if (text == nullptr) {
-    return;
-  }
-  if (const std::optional<uint64_t> value = aoscm::ParseNumber<uint64_t>(*text)) {
-    writer->Field(key, *value);
-  }
+    const std::string* text = aoscm::FindStatus(status, status_key);
+    if (text == nullptr) {
+        return;
+    }
+    if (const std::optional<uint64_t> value = aoscm::ParseNumber<uint64_t>(*text)) {
+        writer->Field(key, *value);
+    }
 }
 
 /**
@@ -136,29 +137,29 @@ void WriteStatusNumber(JsonWriter* writer, const StatusLines& status, const char
  */
 void WriteIdTriple(JsonWriter* writer, const char* key, unsigned int real, unsigned int effective,
                    unsigned int saved) {
-  writer->Key(key).BeginObject();
-  writer->Field("real", static_cast<uint64_t>(real));
-  writer->Field("effective", static_cast<uint64_t>(effective));
-  writer->Field("saved", static_cast<uint64_t>(saved));
-  writer->EndObject();
+    writer->Key(key).BeginObject();
+    writer->Field("real", static_cast<uint64_t>(real));
+    writer->Field("effective", static_cast<uint64_t>(effective));
+    writer->Field("saved", static_cast<uint64_t>(saved));
+    writer->EndObject();
 }
 
 void WriteUserIds(JsonWriter* writer) {
-  uid_t real = 0;
-  uid_t effective = 0;
-  uid_t saved = 0;
-  if (getresuid(&real, &effective, &saved) == 0) {
-    WriteIdTriple(writer, "uid", real, effective, saved);
-  }
+    uid_t real = 0;
+    uid_t effective = 0;
+    uid_t saved = 0;
+    if (getresuid(&real, &effective, &saved) == 0) {
+        WriteIdTriple(writer, "uid", real, effective, saved);
+    }
 }
 
 void WriteGroupIds(JsonWriter* writer) {
-  gid_t real = 0;
-  gid_t effective = 0;
-  gid_t saved = 0;
-  if (getresgid(&real, &effective, &saved) == 0) {
-    WriteIdTriple(writer, "gid", real, effective, saved);
-  }
+    gid_t real = 0;
+    gid_t effective = 0;
+    gid_t saved = 0;
+    if (getresgid(&real, &effective, &saved) == 0) {
+        WriteIdTriple(writer, "gid", real, effective, saved);
+    }
 }
 
 /**
@@ -166,48 +167,48 @@ void WriteGroupIds(JsonWriter* writer) {
  * platform — AID_INET for a socket, AID_EXT_STORAGE for the shared volume.
  */
 void WriteSupplementaryGroups(JsonWriter* writer) {
-  const int count = getgroups(0, nullptr);
-  if (count < 0) {
-    writer->Field("groups_unavailable", aoscm::DescribeFailure(errno));
-    return;
-  }
+    const int count = getgroups(0, nullptr);
+    if (count < 0) {
+        writer->Field("groups_unavailable", aoscm::DescribeFailure(errno));
+        return;
+    }
 
-  std::vector<gid_t> groups(static_cast<size_t>(count));
-  // Asked for twice on purpose: setgroups can run between the two calls, and getgroups reports
-  // that as EINVAL rather than filling a short buffer.
-  const int filled = getgroups(count, groups.data());
-  if (filled < 0) {
-    writer->Field("groups_unavailable", aoscm::DescribeFailure(errno));
-    return;
-  }
+    std::vector<gid_t> groups(static_cast<size_t>(count));
+    // Asked for twice on purpose: setgroups can run between the two calls, and getgroups reports
+    // that as EINVAL rather than filling a short buffer.
+    const int filled = getgroups(count, groups.data());
+    if (filled < 0) {
+        writer->Field("groups_unavailable", aoscm::DescribeFailure(errno));
+        return;
+    }
 
-  writer->Key("groups").BeginArray();
-  for (int i = 0; i < filled; ++i) {
-    writer->Value(static_cast<uint64_t>(groups[static_cast<size_t>(i)]));
-  }
-  writer->EndArray();
+    writer->Key("groups").BeginArray();
+    for (int i = 0; i < filled; ++i) {
+        writer->Value(static_cast<uint64_t>(groups[static_cast<size_t>(i)]));
+    }
+    writer->EndArray();
 }
 
 /** A switch `prctl` answers with 0 or 1, or the reason it would not answer. */
 void WritePrctlFlag(JsonWriter* writer, const char* key, const char* unavailable_key, int option) {
-  const int value = prctl(option, 0, 0, 0, 0);
-  if (value < 0) {
-    writer->Field(unavailable_key, aoscm::DescribeFailure(errno));
-    return;
-  }
-  writer->Field(key, value != 0);
+    const int value = prctl(option, 0, 0, 0, 0);
+    if (value < 0) {
+        writer->Field(unavailable_key, aoscm::DescribeFailure(errno));
+        return;
+    }
+    writer->Field(key, value != 0);
 }
 
 void WriteSelinuxContext(JsonWriter* writer) {
-  const Reading<std::string> context = aoscm::ReadTrimmedLine("/proc/self/attr/current");
-  if (!context.has_value()) {
-    writer->Field("selinux_context_unavailable", aoscm::DescribeFailure(context.error()));
-    return;
-  }
-  // The kernel terminates what it writes here, and a NUL is not whitespace, so it survives the trim
-  // and would otherwise cross to Kotlin escaped as \u0000 on the end of the domain name.
-  const std::string_view text(*context);
-  writer->Field("selinux_context", text.substr(0, text.find('\0')));
+    const Reading<std::string> context = aoscm::ReadTrimmedLine("/proc/self/attr/current");
+    if (!context.has_value()) {
+        writer->Field("selinux_context_unavailable", aoscm::DescribeFailure(context.error()));
+        return;
+    }
+    // The kernel terminates what it writes here, and a NUL is not whitespace, so it survives the
+    // trim and would otherwise cross to Kotlin escaped as \u0000 on the end of the domain name.
+    const std::string_view text(*context);
+    writer->Field("selinux_context", text.substr(0, text.find('\0')));
 }
 
 }  // namespace
@@ -226,45 +227,45 @@ void WriteSelinuxContext(JsonWriter* writer) {
  */
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeCredentialsInspector_getCredentialsNative(
-    JNIEnv* env, jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    const StatusLines status = aoscm::ReadProcStatus();
+        JNIEnv* env, jobject /* this */) {
+    return aoscm::ReturnJson(env, [] {
+        const StatusLines status = aoscm::ReadProcStatus();
 
-    JsonWriter writer;
-    writer.BeginObject();
+        JsonWriter writer;
+        writer.BeginObject();
 
-    writer.Field("pid", static_cast<uint64_t>(getpid()));
-    writer.Field("ppid", static_cast<uint64_t>(getppid()));
-    writer.Field("pgid", static_cast<uint64_t>(getpgrp()));
-    if (const pid_t session = getsid(0); session >= 0) {
-      writer.Field("sid", static_cast<uint64_t>(session));
-    }
+        writer.Field("pid", static_cast<uint64_t>(getpid()));
+        writer.Field("ppid", static_cast<uint64_t>(getppid()));
+        writer.Field("pgid", static_cast<uint64_t>(getpgrp()));
+        if (const pid_t session = getsid(0); session >= 0) {
+            writer.Field("sid", static_cast<uint64_t>(session));
+        }
 
-    WriteUserIds(&writer);
-    WriteGroupIds(&writer);
-    WriteSupplementaryGroups(&writer);
+        WriteUserIds(&writer);
+        WriteGroupIds(&writer);
+        WriteSupplementaryGroups(&writer);
 
-    writer.Key("capabilities").BeginObject();
-    for (const auto& [key, status_key] : kCapabilitySets) {
-      WriteCapabilitySet(&writer, status, key, status_key);
-    }
-    writer.EndObject();
+        writer.Key("capabilities").BeginObject();
+        for (const auto& [key, status_key] : kCapabilitySets) {
+            WriteCapabilitySet(&writer, status, key, status_key);
+        }
+        writer.EndObject();
 
-    WritePrctlFlag(&writer, "no_new_privs", "no_new_privs_unavailable", PR_GET_NO_NEW_PRIVS);
-    WritePrctlFlag(&writer, "dumpable", "dumpable_unavailable", PR_GET_DUMPABLE);
+        WritePrctlFlag(&writer, "no_new_privs", "no_new_privs_unavailable", PR_GET_NO_NEW_PRIVS);
+        WritePrctlFlag(&writer, "dumpable", "dumpable_unavailable", PR_GET_DUMPABLE);
 
-    WriteStatusNumber(&writer, status, "seccomp", "Seccomp");
-    WriteStatusNumber(&writer, status, "seccomp_filters", "Seccomp_filters");
+        WriteStatusNumber(&writer, status, "seccomp", "Seccomp");
+        WriteStatusNumber(&writer, status, "seccomp_filters", "Seccomp_filters");
 
-    // As a string, not a number: a umask is octal, and 0077 published as 77 decimal is a different
-    // mask that happens to print plausibly.
-    if (const std::string* umask = aoscm::FindStatus(status, "Umask")) {
-      writer.Field("umask", *umask);
-    }
+        // As a string, not a number: a umask is octal, and 0077 published as 77 decimal is a
+        // different mask that happens to print plausibly.
+        if (const std::string* umask = aoscm::FindStatus(status, "Umask")) {
+            writer.Field("umask", *umask);
+        }
 
-    WriteSelinuxContext(&writer);
+        WriteSelinuxContext(&writer);
 
-    writer.EndObject();
-    return writer.Take();
-  });
+        writer.EndObject();
+        return writer.Take();
+    });
 }

--- a/app/src/main/cpp/storage_info.cpp
+++ b/app/src/main/cpp/storage_info.cpp
@@ -19,40 +19,41 @@ using MountTable = std::unique_ptr<FILE, decltype([](FILE* table) { endmntent(ta
 
 /** Whether the mount was made read-only, which is the first option the kernel lists. */
 bool IsReadOnly(const char* options) {
-  if (options == nullptr) {
-    return false;
-  }
-  const std::string_view text(options);
-  return text == "ro" || text.starts_with("ro,");
+    if (options == nullptr) {
+        return false;
+    }
+    const std::string_view text(options);
+    return text == "ro" || text.starts_with("ro,");
 }
 
 void WriteUsage(JsonWriter* writer, const char* target) {
-  struct statvfs64 usage = {};
-  if (statvfs64(target, &usage) != 0) {
-    // Denied or gone: /proc, /sys and most of /mnt answer this way for an app. The mount is still
-    // listed — knowing it exists is part of the picture — with the reason in place of a capacity.
-    writer->Field("statvfs_ok", false);
-    writer->Field("statvfs_unavailable", aoscm::DescribeFailure(errno));
-    return;
-  }
+    struct statvfs64 usage = {};
+    if (statvfs64(target, &usage) != 0) {
+        // Denied or gone: /proc, /sys and most of /mnt answer this way for an app. The mount is
+        // still listed — knowing it exists is part of the picture — with the reason in place of a
+        // capacity.
+        writer->Field("statvfs_ok", false);
+        writer->Field("statvfs_unavailable", aoscm::DescribeFailure(errno));
+        return;
+    }
 
-  // f_frsize is the unit f_blocks counts in; f_bsize is the preferred I/O size and is not
-  // interchangeable with it, though on most Android filesystems the two happen to agree.
-  const uint64_t unit = usage.f_frsize != 0 ? usage.f_frsize : usage.f_bsize;
-  writer->Field("statvfs_ok", true);
-  writer->Field("total_bytes", static_cast<uint64_t>(usage.f_blocks) * unit);
-  writer->Field("free_bytes", static_cast<uint64_t>(usage.f_bfree) * unit);
-  writer->Field("available_bytes", static_cast<uint64_t>(usage.f_bavail) * unit);
+    // f_frsize is the unit f_blocks counts in; f_bsize is the preferred I/O size and is not
+    // interchangeable with it, though on most Android filesystems the two happen to agree.
+    const uint64_t unit = usage.f_frsize != 0 ? usage.f_frsize : usage.f_bsize;
+    writer->Field("statvfs_ok", true);
+    writer->Field("total_bytes", static_cast<uint64_t>(usage.f_blocks) * unit);
+    writer->Field("free_bytes", static_cast<uint64_t>(usage.f_bfree) * unit);
+    writer->Field("available_bytes", static_cast<uint64_t>(usage.f_bavail) * unit);
 
-  // A filesystem with no fixed inode table — erofs and f2fs among them — answers with every bit
-  // set rather than with a count. Published as a number it reaches the screen as
-  // "18446744073709551615 free", so it is left out instead: the count is genuinely unknown.
-  const auto inodes_total = static_cast<uint64_t>(usage.f_files);
-  const auto inodes_free = static_cast<uint64_t>(usage.f_ffree);
-  if (inodes_total != 0 && inodes_total != UINT64_MAX && inodes_free <= inodes_total) {
-    writer->Field("inodes_total", inodes_total);
-    writer->Field("inodes_free", inodes_free);
-  }
+    // A filesystem with no fixed inode table — erofs and f2fs among them — answers with every bit
+    // set rather than with a count. Published as a number it reaches the screen as
+    // "18446744073709551615 free", so it is left out instead: the count is genuinely unknown.
+    const auto inodes_total = static_cast<uint64_t>(usage.f_files);
+    const auto inodes_free = static_cast<uint64_t>(usage.f_ffree);
+    if (inodes_total != 0 && inodes_total != UINT64_MAX && inodes_free <= inodes_total) {
+        writer->Field("inodes_total", inodes_total);
+        writer->Field("inodes_free", inodes_free);
+    }
 }
 
 }  // namespace
@@ -67,30 +68,30 @@ void WriteUsage(JsonWriter* writer, const char* target) {
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeStorageInspector_getMountsNative(JNIEnv* env,
                                                                                jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    JsonWriter writer;
-    writer.BeginObject();
-    writer.Key("mounts").BeginArray();
-
-    if (const MountTable mounts{setmntent("/proc/self/mounts", "r")}) {
-      struct mntent entry = {};
-      char buffer[4096];
-      // The reentrant form: the plain getmntent() hands back a pointer to shared storage, which is
-      // a hazard worth avoiding in a library that any thread may call.
-      while (getmntent_r(mounts.get(), &entry, buffer, sizeof(buffer)) != nullptr) {
+    return aoscm::ReturnJson(env, [] {
+        JsonWriter writer;
         writer.BeginObject();
-        writer.Field("source", entry.mnt_fsname);
-        writer.Field("target", entry.mnt_dir);
-        writer.Field("fs_type", entry.mnt_type);
-        writer.Field("options", entry.mnt_opts);
-        writer.Field("readonly", IsReadOnly(entry.mnt_opts));
-        WriteUsage(&writer, entry.mnt_dir);
-        writer.EndObject();
-      }
-    }
+        writer.Key("mounts").BeginArray();
 
-    writer.EndArray();
-    writer.EndObject();
-    return writer.Take();
-  });
+        if (const MountTable mounts{setmntent("/proc/self/mounts", "r")}) {
+            struct mntent entry = {};
+            char buffer[4096];
+            // The reentrant form: the plain getmntent() hands back a pointer to shared storage,
+            // which is a hazard worth avoiding in a library that any thread may call.
+            while (getmntent_r(mounts.get(), &entry, buffer, sizeof(buffer)) != nullptr) {
+                writer.BeginObject();
+                writer.Field("source", entry.mnt_fsname);
+                writer.Field("target", entry.mnt_dir);
+                writer.Field("fs_type", entry.mnt_type);
+                writer.Field("options", entry.mnt_opts);
+                writer.Field("readonly", IsReadOnly(entry.mnt_opts));
+                WriteUsage(&writer, entry.mnt_dir);
+                writer.EndObject();
+            }
+        }
+
+        writer.EndArray();
+        writer.EndObject();
+        return writer.Take();
+    });
 }

--- a/app/src/main/cpp/system_monitor.cpp
+++ b/app/src/main/cpp/system_monitor.cpp
@@ -17,53 +17,53 @@
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getCpuInfoNative(JNIEnv* env,
                                                                              jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    std::ifstream stat_file("/proc/stat");
-    std::string line;
-    std::string result;
+    return aoscm::ReturnJson(env, [] {
+        std::ifstream stat_file("/proc/stat");
+        std::string line;
+        std::string result;
 
-    if (!stat_file.is_open()) {
-      LOGE("Failed to open /proc/stat");
-      return std::string("Error: Failed to read CPU information");
-    }
+        if (!stat_file.is_open()) {
+            LOGE("Failed to open /proc/stat");
+            return std::string("Error: Failed to read CPU information");
+        }
 
-    // Get the first line (total CPU information)
-    if (std::getline(stat_file, line)) {
-      result = line;
-    }
+        // Get the first line (total CPU information)
+        if (std::getline(stat_file, line)) {
+            result = line;
+        }
 
-    stat_file.close();
-    LOGI("Read CPU info: %s", result.c_str());
+        stat_file.close();
+        LOGI("Read CPU info: %s", result.c_str());
 
-    return result;
-  });
+        return result;
+    });
 }
 
 // Function to get memory information
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getMemInfoNative(JNIEnv* env,
                                                                              jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    std::ifstream meminfo_file("/proc/meminfo");
-    std::string line;
-    std::stringstream result;
+    return aoscm::ReturnJson(env, [] {
+        std::ifstream meminfo_file("/proc/meminfo");
+        std::string line;
+        std::stringstream result;
 
-    if (!meminfo_file.is_open()) {
-      LOGE("Failed to open /proc/meminfo");
-      return std::string("Error: Failed to read memory information");
-    }
+        if (!meminfo_file.is_open()) {
+            LOGE("Failed to open /proc/meminfo");
+            return std::string("Error: Failed to read memory information");
+        }
 
-    // Get the first few lines (main memory information)
-    int lines_to_read = 5;
-    while (lines_to_read-- > 0 && std::getline(meminfo_file, line)) {
-      result << line << "\n";
-    }
+        // Get the first few lines (main memory information)
+        int lines_to_read = 5;
+        while (lines_to_read-- > 0 && std::getline(meminfo_file, line)) {
+            result << line << "\n";
+        }
 
-    meminfo_file.close();
-    LOGI("Read memory info");
+        meminfo_file.close();
+        LOGI("Read memory info");
 
-    return result.str();
-  });
+        return result.str();
+    });
 }
 
 // A getProcessInfoNative(pid) returning /proc/<pid>/status verbatim used to sit here.
@@ -73,173 +73,173 @@ Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getMemInfoNative(JNI
 // Function to get network interface statistics
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getNetworkStatsNative(
-    JNIEnv* env, jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    std::ifstream net_dev_file("/proc/net/dev");
-    std::string line;
-    std::stringstream result;
-    std::string json = "{";
-    bool first_interface = true;
+        JNIEnv* env, jobject /* this */) {
+    return aoscm::ReturnJson(env, [] {
+        std::ifstream net_dev_file("/proc/net/dev");
+        std::string line;
+        std::stringstream result;
+        std::string json = "{";
+        bool first_interface = true;
 
-    if (!net_dev_file.is_open()) {
-      LOGE("Failed to open /proc/net/dev");
-      return std::string("Error: Failed to read network statistics");
-    }
+        if (!net_dev_file.is_open()) {
+            LOGE("Failed to open /proc/net/dev");
+            return std::string("Error: Failed to read network statistics");
+        }
 
-    // Skip header lines (first two lines)
-    std::getline(net_dev_file, line);  // Skip header line 1
-    std::getline(net_dev_file, line);  // Skip header line 2
+        // Skip header lines (first two lines)
+        std::getline(net_dev_file, line);  // Skip header line 1
+        std::getline(net_dev_file, line);  // Skip header line 2
 
-    // Process each network interface
-    while (std::getline(net_dev_file, line)) {
-      std::stringstream line_stream(line);
-      std::string interface_name;
+        // Process each network interface
+        while (std::getline(net_dev_file, line)) {
+            std::stringstream line_stream(line);
+            std::string interface_name;
 
-      // Extract interface name (format: "  interface_name: stats...")
-      std::getline(line_stream, interface_name, ':');
-      interface_name = interface_name.substr(interface_name.find_first_not_of(" \t"));
+            // Extract interface name (format: "  interface_name: stats...")
+            std::getline(line_stream, interface_name, ':');
+            interface_name = interface_name.substr(interface_name.find_first_not_of(" \t"));
 
-      // Skip loopback interface
-      if (interface_name == "lo") {
-        continue;
-      }
+            // Skip loopback interface
+            if (interface_name == "lo") {
+                continue;
+            }
 
-      // Read stats (in order):
-      // rx_bytes rx_packets rx_errs rx_drop rx_fifo rx_frame rx_compressed rx_multicast
-      // tx_bytes tx_packets tx_errs tx_drop tx_fifo tx_colls tx_carrier tx_compressed
-      unsigned long long rx_bytes, rx_packets, rx_errs, rx_drop;
-      unsigned long long tx_bytes, tx_packets, tx_errs, tx_drop;
+            // Read stats (in order):
+            // rx_bytes rx_packets rx_errs rx_drop rx_fifo rx_frame rx_compressed rx_multicast
+            // tx_bytes tx_packets tx_errs tx_drop tx_fifo tx_colls tx_carrier tx_compressed
+            unsigned long long rx_bytes, rx_packets, rx_errs, rx_drop;
+            unsigned long long tx_bytes, tx_packets, tx_errs, tx_drop;
 
-      line_stream >> rx_bytes >> rx_packets >> rx_errs >> rx_drop;
-      // Skip 4 fields
-      unsigned long long skip;
-      line_stream >> skip >> skip >> skip >> skip;
-      line_stream >> tx_bytes >> tx_packets >> tx_errs >> tx_drop;
+            line_stream >> rx_bytes >> rx_packets >> rx_errs >> rx_drop;
+            // Skip 4 fields
+            unsigned long long skip;
+            line_stream >> skip >> skip >> skip >> skip;
+            line_stream >> tx_bytes >> tx_packets >> tx_errs >> tx_drop;
 
-      // Format as JSON
-      if (!first_interface) {
-        json += ",";
-      }
-      first_interface = false;
+            // Format as JSON
+            if (!first_interface) {
+                json += ",";
+            }
+            first_interface = false;
 
-      json += "\"" + interface_name + "\":{";
-      json += "\"rx_bytes\":" + std::to_string(rx_bytes) + ",";
-      json += "\"rx_packets\":" + std::to_string(rx_packets) + ",";
-      json += "\"rx_errors\":" + std::to_string(rx_errs) + ",";
-      json += "\"rx_dropped\":" + std::to_string(rx_drop) + ",";
-      json += "\"tx_bytes\":" + std::to_string(tx_bytes) + ",";
-      json += "\"tx_packets\":" + std::to_string(tx_packets) + ",";
-      json += "\"tx_errors\":" + std::to_string(tx_errs) + ",";
-      json += "\"tx_dropped\":" + std::to_string(tx_drop);
-      json += "}";
-    }
+            json += "\"" + interface_name + "\":{";
+            json += "\"rx_bytes\":" + std::to_string(rx_bytes) + ",";
+            json += "\"rx_packets\":" + std::to_string(rx_packets) + ",";
+            json += "\"rx_errors\":" + std::to_string(rx_errs) + ",";
+            json += "\"rx_dropped\":" + std::to_string(rx_drop) + ",";
+            json += "\"tx_bytes\":" + std::to_string(tx_bytes) + ",";
+            json += "\"tx_packets\":" + std::to_string(tx_packets) + ",";
+            json += "\"tx_errors\":" + std::to_string(tx_errs) + ",";
+            json += "\"tx_dropped\":" + std::to_string(tx_drop);
+            json += "}";
+        }
 
-    json += "}";
-    net_dev_file.close();
-    LOGI("Read network interface statistics");
+        json += "}";
+        net_dev_file.close();
+        LOGI("Read network interface statistics");
 
-    return json;
-  });
+        return json;
+    });
 }
 
 // Function to retrieve TCP connection statistics
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeSystemMonitor_getTcpConnectionsNative(
-    JNIEnv* env, jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    std::ifstream tcp_file("/proc/net/tcp");
-    std::string line;
-    std::string json = "{\"connections\":[";
-    bool first_connection = true;
+        JNIEnv* env, jobject /* this */) {
+    return aoscm::ReturnJson(env, [] {
+        std::ifstream tcp_file("/proc/net/tcp");
+        std::string line;
+        std::string json = "{\"connections\":[";
+        bool first_connection = true;
 
-    if (!tcp_file.is_open()) {
-      LOGE("Failed to open /proc/net/tcp - Permission denied or file not available");
-      // Get detailed error information
-      char error_msg[256];
-      strerror_r(errno, error_msg, sizeof(error_msg));
-      std::string error_string = "Error: Failed to read TCP connection information. Reason: ";
-      error_string += error_msg;
-      return error_string;
-    }
+        if (!tcp_file.is_open()) {
+            LOGE("Failed to open /proc/net/tcp - Permission denied or file not available");
+            // Get detailed error information
+            char error_msg[256];
+            strerror_r(errno, error_msg, sizeof(error_msg));
+            std::string error_string = "Error: Failed to read TCP connection information. Reason: ";
+            error_string += error_msg;
+            return error_string;
+        }
 
-    // Skip header line
-    std::getline(tcp_file, line);
+        // Skip header line
+        std::getline(tcp_file, line);
 
-    // Process each TCP connection information
-    while (std::getline(tcp_file, line)) {
-      std::stringstream line_stream(line);
-      std::string sl, local_address, remote_address, status, tx_queue, rx_queue, tr, tm_when,
-          retrnsmt, uid_str, timeout, inode, rest;
+        // Process each TCP connection information
+        while (std::getline(tcp_file, line)) {
+            std::stringstream line_stream(line);
+            std::string sl, local_address, remote_address, status, tx_queue, rx_queue, tr, tm_when,
+                    retrnsmt, uid_str, timeout, inode, rest;
 
-      line_stream >> sl >> local_address >> remote_address >> status >> tx_queue >> rx_queue >>
-          tr >> tm_when >> retrnsmt >> uid_str >> timeout >> inode;
+            line_stream >> sl >> local_address >> remote_address >> status >> tx_queue >>
+                    rx_queue >> tr >> tm_when >> retrnsmt >> uid_str >> timeout >> inode;
 
-      // Convert hexadecimal status to integer
-      int status_int = 0;
-      std::stringstream ss;
-      ss << std::hex << status;
-      ss >> status_int;
+            // Convert hexadecimal status to integer
+            int status_int = 0;
+            std::stringstream ss;
+            ss << std::hex << status;
+            ss >> status_int;
 
-      // Convert status to string
-      std::string status_str;
-      switch (status_int) {
-        case 1:
-          status_str = "ESTABLISHED";
-          break;
-        case 2:
-          status_str = "SYN_SENT";
-          break;
-        case 3:
-          status_str = "SYN_RECV";
-          break;
-        case 4:
-          status_str = "FIN_WAIT1";
-          break;
-        case 5:
-          status_str = "FIN_WAIT2";
-          break;
-        case 6:
-          status_str = "TIME_WAIT";
-          break;
-        case 7:
-          status_str = "CLOSE";
-          break;
-        case 8:
-          status_str = "CLOSE_WAIT";
-          break;
-        case 9:
-          status_str = "LAST_ACK";
-          break;
-        case 10:
-          status_str = "LISTEN";
-          break;
-        case 11:
-          status_str = "CLOSING";
-          break;
-        default:
-          status_str = "UNKNOWN";
-          break;
-      }
+            // Convert status to string
+            std::string status_str;
+            switch (status_int) {
+                case 1:
+                    status_str = "ESTABLISHED";
+                    break;
+                case 2:
+                    status_str = "SYN_SENT";
+                    break;
+                case 3:
+                    status_str = "SYN_RECV";
+                    break;
+                case 4:
+                    status_str = "FIN_WAIT1";
+                    break;
+                case 5:
+                    status_str = "FIN_WAIT2";
+                    break;
+                case 6:
+                    status_str = "TIME_WAIT";
+                    break;
+                case 7:
+                    status_str = "CLOSE";
+                    break;
+                case 8:
+                    status_str = "CLOSE_WAIT";
+                    break;
+                case 9:
+                    status_str = "LAST_ACK";
+                    break;
+                case 10:
+                    status_str = "LISTEN";
+                    break;
+                case 11:
+                    status_str = "CLOSING";
+                    break;
+                default:
+                    status_str = "UNKNOWN";
+                    break;
+            }
 
-      // Add data in JSON format
-      if (!first_connection) {
-        json += ",";
-      }
-      first_connection = false;
+            // Add data in JSON format
+            if (!first_connection) {
+                json += ",";
+            }
+            first_connection = false;
 
-      json += "{";
-      json += "\"local_address\":\"" + local_address + "\",";
-      json += "\"remote_address\":\"" + remote_address + "\",";
-      json += "\"status\":\"" + status_str + "\",";
-      json += "\"uid\":" + uid_str + ",";
-      json += "\"inode\":\"" + inode + "\"";
-      json += "}";
-    }
+            json += "{";
+            json += "\"local_address\":\"" + local_address + "\",";
+            json += "\"remote_address\":\"" + remote_address + "\",";
+            json += "\"status\":\"" + status_str + "\",";
+            json += "\"uid\":" + uid_str + ",";
+            json += "\"inode\":\"" + inode + "\"";
+            json += "}";
+        }
 
-    json += "]}";
-    tcp_file.close();
-    LOGI("Read TCP connection statistics");
+        json += "]}";
+        tcp_file.close();
+        LOGI("Read TCP connection statistics");
 
-    return json;
-  });
+        return json;
+    });
 }

--- a/app/src/main/cpp/thread_info.cpp
+++ b/app/src/main/cpp/thread_info.cpp
@@ -37,10 +37,10 @@ constexpr size_t kRtPriorityField = 37;
 constexpr uint64_t kAssumedClockTicks = 100;
 
 std::optional<std::string_view> FieldAt(const std::vector<std::string_view>& fields, size_t index) {
-  if (index >= fields.size()) {
-    return std::nullopt;
-  }
-  return fields[index];
+    if (index >= fields.size()) {
+        return std::nullopt;
+    }
+    return fields[index];
 }
 
 /**
@@ -53,45 +53,45 @@ std::optional<std::string_view> FieldAt(const std::vector<std::string_view>& fie
  * The views point into `line`, which the caller keeps alive for as long as it reads them.
  */
 std::vector<std::string_view> StatFieldsAfterComm(std::string_view line) {
-  const size_t comm_end = line.rfind(") ");
-  if (comm_end == std::string_view::npos) {
-    return {};
-  }
-
-  std::vector<std::string_view> fields;
-  size_t start = comm_end + 2;
-  while (start < line.size()) {
-    const size_t end = line.find(' ', start);
-    if (end == std::string_view::npos) {
-      fields.push_back(line.substr(start));
-      break;
+    const size_t comm_end = line.rfind(") ");
+    if (comm_end == std::string_view::npos) {
+        return {};
     }
-    fields.push_back(line.substr(start, end - start));
-    start = end + 1;
-  }
-  return fields;
+
+    std::vector<std::string_view> fields;
+    size_t start = comm_end + 2;
+    while (start < line.size()) {
+        const size_t end = line.find(' ', start);
+        if (end == std::string_view::npos) {
+            fields.push_back(line.substr(start));
+            break;
+        }
+        fields.push_back(line.substr(start, end - start));
+        start = end + 1;
+    }
+    return fields;
 }
 
 /** The scheduling policy's name, as the SCHED_* constant it came back as. */
 const char* PolicyName(int policy) {
-  switch (policy) {
-    case SCHED_OTHER:
-      return "other";
-    case SCHED_FIFO:
-      return "fifo";
-    case SCHED_RR:
-      return "rr";
-    case SCHED_BATCH:
-      return "batch";
-    case SCHED_IDLE:
-      return "idle";
+    switch (policy) {
+        case SCHED_OTHER:
+            return "other";
+        case SCHED_FIFO:
+            return "fifo";
+        case SCHED_RR:
+            return "rr";
+        case SCHED_BATCH:
+            return "batch";
+        case SCHED_IDLE:
+            return "idle";
 #ifdef SCHED_DEADLINE
-    case SCHED_DEADLINE:
-      return "deadline";
+        case SCHED_DEADLINE:
+            return "deadline";
 #endif
-    default:
-      return "unknown";
-  }
+        default:
+            return "unknown";
+    }
 }
 
 /**
@@ -99,30 +99,30 @@ const char* PolicyName(int policy) {
  * /proc/self/status's Cpus_allowed_list, and reads better than eight ones and zeros.
  */
 std::string CpuList(const cpu_set_t& mask, int cpu_count) {
-  std::string list;
-  int run_start = -1;
+    std::string list;
+    int run_start = -1;
 
-  // Runs to cpu_count inclusive so that a run reaching the last CPU is closed by the same branch
-  // as every other run, rather than needing a second copy of it after the loop.
-  for (int cpu = 0; cpu <= cpu_count; ++cpu) {
-    const bool allowed = cpu < cpu_count && CPU_ISSET(cpu, &mask);
-    if (allowed && run_start < 0) {
-      run_start = cpu;
-      continue;
+    // Runs to cpu_count inclusive so that a run reaching the last CPU is closed by the same branch
+    // as every other run, rather than needing a second copy of it after the loop.
+    for (int cpu = 0; cpu <= cpu_count; ++cpu) {
+        const bool allowed = cpu < cpu_count && CPU_ISSET(cpu, &mask);
+        if (allowed && run_start < 0) {
+            run_start = cpu;
+            continue;
+        }
+        if (!allowed && run_start >= 0) {
+            if (!list.empty()) {
+                list.push_back(',');
+            }
+            list.append(std::to_string(run_start));
+            if (cpu - 1 > run_start) {
+                list.push_back('-');
+                list.append(std::to_string(cpu - 1));
+            }
+            run_start = -1;
+        }
     }
-    if (!allowed && run_start >= 0) {
-      if (!list.empty()) {
-        list.push_back(',');
-      }
-      list.append(std::to_string(run_start));
-      if (cpu - 1 > run_start) {
-        list.push_back('-');
-        list.append(std::to_string(cpu - 1));
-      }
-      run_start = -1;
-    }
-  }
-  return list;
+    return list;
 }
 
 /**
@@ -133,70 +133,73 @@ std::string CpuList(const cpu_set_t& mask, int cpu_count) {
  * process on some kernels.
  */
 void WriteAffinity(JsonWriter* writer, pid_t task, int cpu_count) {
-  cpu_set_t mask;
-  CPU_ZERO(&mask);
-  if (sched_getaffinity(task, sizeof(mask), &mask) != 0) {
-    writer->Field("affinity_unavailable", aoscm::DescribeFailure(errno));
-    return;
-  }
-  // The cpulist alone: the count of CPUs in it was published too, and it is the length of a list
-  // the reader already has.
-  writer->Field("affinity", CpuList(mask, cpu_count));
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+    if (sched_getaffinity(task, sizeof(mask), &mask) != 0) {
+        writer->Field("affinity_unavailable", aoscm::DescribeFailure(errno));
+        return;
+    }
+    // The cpulist alone: the count of CPUs in it was published too, and it is the length of a list
+    // the reader already has.
+    writer->Field("affinity", CpuList(mask, cpu_count));
 }
 
 void WriteSchedulerPolicy(JsonWriter* writer, pid_t task) {
-  const int policy = sched_getscheduler(task);
-  if (policy < 0) {
-    writer->Field("policy_unavailable", aoscm::DescribeFailure(errno));
-    return;
-  }
-  writer->Field("policy", PolicyName(policy));
+    const int policy = sched_getscheduler(task);
+    if (policy < 0) {
+        writer->Field("policy_unavailable", aoscm::DescribeFailure(errno));
+        return;
+    }
+    writer->Field("policy", PolicyName(policy));
 }
 
 void WriteThread(JsonWriter* writer, std::string_view tid_name, pid_t tid, int cpu_count) {
-  const std::string task = std::string("/proc/self/task/").append(tid_name);
-  const Reading<std::string> stat = aoscm::ReadTrimmedLine(task + "/stat");
-  if (!stat.has_value()) {
-    // The thread exited between listing the directory and reading it, which is ordinary: a thread
-    // that is gone has nothing to report and is left out rather than listed as a blank row.
-    return;
-  }
-  const std::vector<std::string_view> fields = StatFieldsAfterComm(*stat);
+    const std::string task = std::string("/proc/self/task/").append(tid_name);
+    const Reading<std::string> stat = aoscm::ReadTrimmedLine(task + "/stat");
+    if (!stat.has_value()) {
+        // The thread exited between listing the directory and reading it, which is ordinary: a
+        // thread that is gone has nothing to report and is left out rather than listed as a blank
+        // row.
+        return;
+    }
+    const std::vector<std::string_view> fields = StatFieldsAfterComm(*stat);
 
-  writer->BeginObject();
-  writer->Field("tid", static_cast<uint64_t>(tid));
+    writer->BeginObject();
+    writer->Field("tid", static_cast<uint64_t>(tid));
 
-  // comm rather than the name inside stat: the same string, but without the parentheses and the
-  // escaping that a name containing one would need.
-  const Reading<std::string> name = aoscm::ReadTrimmedLine(task + "/comm");
-  writer->FieldIfSet("name", name);
+    // comm rather than the name inside stat: the same string, but without the parentheses and the
+    // escaping that a name containing one would need.
+    const Reading<std::string> name = aoscm::ReadTrimmedLine(task + "/comm");
+    writer->FieldIfSet("name", name);
 
-  if (const auto state = FieldAt(fields, kStateField)) {
-    writer->Field("state", *state);
-  }
-  if (const auto utime = FieldAt(fields, kUtimeField).and_then(aoscm::ParseNumber<uint64_t>)) {
-    writer->Field("utime_ticks", *utime);
-  }
-  if (const auto stime = FieldAt(fields, kStimeField).and_then(aoscm::ParseNumber<uint64_t>)) {
-    writer->Field("stime_ticks", *stime);
-  }
-  if (const auto priority = FieldAt(fields, kPriorityField).and_then(aoscm::ParseNumber<int64_t>)) {
-    writer->Field("priority", *priority);
-  }
-  if (const auto nice = FieldAt(fields, kNiceField).and_then(aoscm::ParseNumber<int64_t>)) {
-    writer->Field("nice", *nice);
-  }
-  if (const auto last_cpu = FieldAt(fields, kLastCpuField).and_then(aoscm::ParseNumber<uint64_t>)) {
-    writer->Field("last_cpu", *last_cpu);
-  }
-  if (const auto rt_priority =
-          FieldAt(fields, kRtPriorityField).and_then(aoscm::ParseNumber<uint64_t>)) {
-    writer->Field("rt_priority", *rt_priority);
-  }
+    if (const auto state = FieldAt(fields, kStateField)) {
+        writer->Field("state", *state);
+    }
+    if (const auto utime = FieldAt(fields, kUtimeField).and_then(aoscm::ParseNumber<uint64_t>)) {
+        writer->Field("utime_ticks", *utime);
+    }
+    if (const auto stime = FieldAt(fields, kStimeField).and_then(aoscm::ParseNumber<uint64_t>)) {
+        writer->Field("stime_ticks", *stime);
+    }
+    if (const auto priority =
+                FieldAt(fields, kPriorityField).and_then(aoscm::ParseNumber<int64_t>)) {
+        writer->Field("priority", *priority);
+    }
+    if (const auto nice = FieldAt(fields, kNiceField).and_then(aoscm::ParseNumber<int64_t>)) {
+        writer->Field("nice", *nice);
+    }
+    if (const auto last_cpu =
+                FieldAt(fields, kLastCpuField).and_then(aoscm::ParseNumber<uint64_t>)) {
+        writer->Field("last_cpu", *last_cpu);
+    }
+    if (const auto rt_priority =
+                FieldAt(fields, kRtPriorityField).and_then(aoscm::ParseNumber<uint64_t>)) {
+        writer->Field("rt_priority", *rt_priority);
+    }
 
-  WriteSchedulerPolicy(writer, tid);
-  WriteAffinity(writer, tid, cpu_count);
-  writer->EndObject();
+    WriteSchedulerPolicy(writer, tid);
+    WriteAffinity(writer, tid, cpu_count);
+    writer->EndObject();
 }
 
 }  // namespace
@@ -213,36 +216,37 @@ void WriteThread(JsonWriter* writer, std::string_view tid_name, pid_t tid, int c
 extern "C" JNIEXPORT jstring JNICALL
 Java_com_aoscoremonitor_diagnostics_jni_NativeThreadInspector_getThreadsNative(JNIEnv* env,
                                                                                jobject /* this */) {
-  return aoscm::ReturnJson(env, [] {
-    const long configured_cpus = sysconf(_SC_NPROCESSORS_CONF);
-    const int cpu_count =
-        configured_cpus > 0 ? static_cast<int>(std::min<long>(configured_cpus, CPU_SETSIZE)) : 1;
-    const long clock_ticks = sysconf(_SC_CLK_TCK);
+    return aoscm::ReturnJson(env, [] {
+        const long configured_cpus = sysconf(_SC_NPROCESSORS_CONF);
+        const int cpu_count =
+                configured_cpus > 0 ? static_cast<int>(std::min<long>(configured_cpus, CPU_SETSIZE))
+                                    : 1;
+        const long clock_ticks = sysconf(_SC_CLK_TCK);
 
-    JsonWriter writer;
-    writer.BeginObject();
-    writer.Field("clock_ticks",
-                 clock_ticks > 0 ? static_cast<uint64_t>(clock_ticks) : kAssumedClockTicks);
+        JsonWriter writer;
+        writer.BeginObject();
+        writer.Field("clock_ticks",
+                     clock_ticks > 0 ? static_cast<uint64_t>(clock_ticks) : kAssumedClockTicks);
 
-    // The process's own mask, which is the ceiling every thread's mask sits under. Written with the
-    // same keys as a thread's so that one parser reads both.
-    WriteAffinity(&writer, 0, cpu_count);
+        // The process's own mask, which is the ceiling every thread's mask sits under. Written with
+        // the same keys as a thread's so that one parser reads both.
+        WriteAffinity(&writer, 0, cpu_count);
 
-    writer.Key("threads").BeginArray();
-    if (const TaskDir tasks{opendir("/proc/self/task")}) {
-      while (const dirent* entry = readdir(tasks.get())) {
-        const std::string_view name(entry->d_name);
-        const auto tid = aoscm::ParseNumber<pid_t>(name);
-        if (!tid.has_value()) {
-          // "." and "..", which readdir reports alongside the thread ids.
-          continue;
+        writer.Key("threads").BeginArray();
+        if (const TaskDir tasks{opendir("/proc/self/task")}) {
+            while (const dirent* entry = readdir(tasks.get())) {
+                const std::string_view name(entry->d_name);
+                const auto tid = aoscm::ParseNumber<pid_t>(name);
+                if (!tid.has_value()) {
+                    // "." and "..", which readdir reports alongside the thread ids.
+                    continue;
+                }
+                WriteThread(&writer, name, *tid, cpu_count);
+            }
         }
-        WriteThread(&writer, name, *tid, cpu_count);
-      }
-    }
-    writer.EndArray();
+        writer.EndArray();
 
-    writer.EndObject();
-    return writer.Take();
-  });
+        writer.EndObject();
+        return writer.Take();
+    });
 }


### PR DESCRIPTION
## Summary

- Configure VS Code IntelliSense for all Android ABIs
- Modernize the clang-format 18-compatible configuration
- Adopt AOSP-style 4-space indentation and sync `.editorconfig`
- Reformat the native C++ sources

## Verification

- `./scripts/format.sh --check cpp`
- `./gradlew :app:externalNativeBuildDebug`