### PR TITLE
 feat: Add two native screens for the GPU and the audio path

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Comprehensive monitoring software for deeply understanding the internal structure of AOS. Because sometimes you need to know what your Android system is secretly plotting.
 
-Nineteen screens, each with one subject. Everything shown is measured on the device — where a reading cannot be taken, the screen says which reading and why, rather than filling the gap with a plausible number.
+Twenty screens, each with one subject. Everything shown is measured on the device — where a reading cannot be taken, the screen says which reading and why, rather than filling the gap with a plausible number.
 
 ## What it inspects
 
@@ -12,9 +12,9 @@ Nineteen screens, each with one subject. Everything shown is measured on the dev
 
 **What it can reach** — Storage, Network Stats, TCP Connections
 
-**Display and frames** — Display, Frame Pacing
+**Display, frames and the GPU** — Display, Frame Pacing, Vulkan
 
-The native screens read what the Java API cannot reach: `dl_iterate_phdr` for the linker's module list, `mallinfo2` for the native heap, `sched_getaffinity` for a thread's CPU mask, `readlink` and `fcntl` for the open descriptors, the capability masks the kernel prints only in `/proc/self/status`. They are served by one shared library, `libsystem_monitor`, built from `app/src/main/cpp`.
+The native screens read what the Java API cannot reach: `dl_iterate_phdr` for the linker's module list, `mallinfo2` for the native heap, `sched_getaffinity` for a thread's CPU mask, `readlink` and `fcntl` for the open descriptors, the capability masks the kernel prints only in `/proc/self/status`, and Vulkan — a C API the platform has never given Java a binding to — for the GPU's driver, memory heaps and queue families. They are served by one shared library, `libsystem_monitor`, built from `app/src/main/cpp`.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Comprehensive monitoring software for deeply understanding the internal structure of AOS. Because sometimes you need to know what your Android system is secretly plotting.
 
-Twenty screens, each with one subject. Everything shown is measured on the device — where a reading cannot be taken, the screen says which reading and why, rather than filling the gap with a plausible number.
+Twenty-one screens, each with one subject. Everything shown is measured on the device — where a reading cannot be taken, the screen says which reading and why, rather than filling the gap with a plausible number.
 
 ## What it inspects
 
@@ -14,7 +14,11 @@ Twenty screens, each with one subject. Everything shown is measured on the devic
 
 **Display, frames and the GPU** — Display, Frame Pacing, Vulkan
 
-The native screens read what the Java API cannot reach: `dl_iterate_phdr` for the linker's module list, `mallinfo2` for the native heap, `sched_getaffinity` for a thread's CPU mask, `readlink` and `fcntl` for the open descriptors, the capability masks the kernel prints only in `/proc/self/status`, and Vulkan — a C API the platform has never given Java a binding to — for the GPU's driver, memory heaps and queue families. They are served by one shared library, `libsystem_monitor`, built from `app/src/main/cpp`.
+**Audio** — Audio Path
+
+The native screens read what the Java API cannot reach: `dl_iterate_phdr` for the linker's module list, `mallinfo2` for the native heap, `sched_getaffinity` for a thread's CPU mask, `readlink` and `fcntl` for the open descriptors, the capability masks the kernel prints only in `/proc/self/status`, and Vulkan — a C API the platform has never given Java a binding to — for the GPU's driver, memory heaps and queue families.
+
+Audio Path is the one that asks rather than reads. It opens four output streams with different requests and reports what the system granted against what was wanted — whether the exclusive MMAP path was on offer, what burst size the stream actually settled on, and what the hardware underneath runs at, which `AAudioStream_getHardwareSampleRate` reports and nothing in the framework does. None of the streams is ever started, so nothing is played and no audio focus is taken; the cost of stopping there is the underrun count, which means nothing on a stream that never ran. They are served by one shared library, `libsystem_monitor`, built from `app/src/main/cpp`.
 
 ## Building
 

--- a/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
+++ b/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
@@ -172,4 +172,59 @@ class NativeInspectorTest {
         assertTrue("No mounts reported", mounts!!.isNotEmpty())
         assertTrue("/proc is not mounted, which cannot be", mounts.any { it.target == "/proc" })
     }
+
+    /**
+     * Whatever Vulkan answers, it answers coherently.
+     *
+     * A device with no loader and one whose driver refuses to start are both allowed here — this
+     * suite runs on emulators as well as phones — so what is pinned is that the collector never
+     * reports devices it did not get, and that a device it did get is described completely.
+     */
+    @Test
+    fun vulkanInspectorDescribesWhateverItFinds() = runBlocking {
+        val snapshot = NativeVulkanInspector().read()
+
+        assertNotNull("Vulkan could not be queried at all", snapshot)
+        if (!snapshot!!.loaderPresent || !snapshot.instanceCreated) {
+            assertTrue(
+                "Devices were reported without an instance to enumerate them",
+                snapshot.devices.isEmpty()
+            )
+            return@runBlocking
+        }
+
+        assertNotNull("An instance was created without reporting its version", snapshot.instanceVersion)
+        snapshot.devices.forEach { device ->
+            assertTrue("A device arrived with no name", device.name.isNotEmpty())
+            // Every Vulkan implementation has at least one queue family and one memory heap; a
+            // device reporting neither means the second enumeration call was skipped.
+            assertTrue("${device.name} reported no queue families", device.queueFamilies.isNotEmpty())
+            assertTrue("${device.name} reported no memory heaps", device.memoryHeaps.isNotEmpty())
+            assertTrue("${device.name} reported no memory", device.totalMemoryBytes > 0)
+            assertTrue("${device.name} reported no extensions", device.extensions.isNotEmpty())
+        }
+    }
+
+    /**
+     * The instance is destroyed and the loader survives being reopened.
+     *
+     * Drivers cap how many live instances a process may hold, so a collector that leaked one would
+     * pass once and then fail — which is exactly what the screen's refresh does. This also covers
+     * the dlclose: closing the loader while the driver still held threads would crash here rather
+     * than in front of a user.
+     */
+    @Test
+    fun vulkanInspectorCanBeReadRepeatedly() = runBlocking {
+        val inspector = NativeVulkanInspector()
+        val readings = (1..3).map { inspector.read() }
+
+        readings.forEachIndexed { index, snapshot ->
+            assertNotNull("Reading ${index + 1} came back empty", snapshot)
+        }
+        assertEquals(
+            "Repeated readings disagreed about how many devices there are",
+            1,
+            readings.map { it?.devices?.size }.distinct().size
+        )
+    }
 }

--- a/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
+++ b/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -225,6 +226,57 @@ class NativeInspectorTest {
             "Repeated readings disagreed about how many devices there are",
             1,
             readings.map { it?.devices?.size }.distinct().size
+        )
+    }
+
+    /**
+     * Every probe puts its request and comes back with either an answer or a reason.
+     *
+     * A device with no audio HAL may refuse all four, and an emulator often refuses the exclusive
+     * one, so which of them open is not pinned. What is pinned is that a probe never reports
+     * readings it did not take, and never fails silently.
+     */
+    @Test
+    fun audioInspectorPutsEveryRequestToTheSystem() = runBlocking {
+        val snapshot = NativeAudioInspector().read()
+
+        assertNotNull("The audio path could not be read", snapshot)
+        assertEquals("Not every probe came back", 4, snapshot!!.probes.size)
+
+        snapshot.probes.forEach { probe ->
+            if (probe.opened) {
+                assertNotNull("${probe.label} opened and reported nothing", probe.granted)
+                // The collector writes the hardware object whenever the API-34 guard passes, so a
+                // device that can take the reading and an open stream must produce one.
+                if (snapshot.hardwareQueryAvailable) {
+                    assertNotNull("${probe.label} took no hardware reading", probe.hardware)
+                }
+            } else {
+                assertNotNull("${probe.label} was refused without saying why", probe.openError)
+                assertNull("${probe.label} was refused and still reported readings", probe.granted)
+            }
+        }
+    }
+
+    /**
+     * The probe streams are closed, not leaked.
+     *
+     * AAudio caps how many streams a process may hold open, so a collector that forgot to close
+     * them would pass once and then start reporting refusals — which is what the screen's refresh
+     * would do to it. Four readings is more than the cap allows to be leaked.
+     */
+    @Test
+    fun audioProbeStreamsAreClosedBetweenReadings() = runBlocking {
+        val inspector = NativeAudioInspector()
+        val opened = (1..4).map { reading ->
+            val snapshot = inspector.read()
+            assertNotNull("Reading $reading came back empty", snapshot)
+            snapshot!!.probes.count { it.opened }
+        }
+
+        assertTrue(
+            "Later readings opened fewer streams than the first, which is what a leak looks like: $opened",
+            opened.last() >= opened.first()
         )
     }
 }

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
     fd_info.cpp
     process_creds.cpp
     vulkan_info.cpp
+    audio_path.cpp
 )
 
 # The conversion warnings earn their place here: this code carries kernel counters — size_t,
@@ -53,4 +54,8 @@ target_link_options(system_monitor PRIVATE "-Wl,--version-script=${version_scrip
 # Editing the script alone is a reason to relink.
 set_target_properties(system_monitor PROPERTIES LINK_DEPENDS "${version_script}")
 
-target_link_libraries(system_monitor PRIVATE log)
+# aaudio is linked rather than dlopen'd, which vulkan_info.cpp does for libvulkan: that loader is
+# only present where a GPU driver is, so linking it would take the whole library down on a device
+# without one. libaaudio has shipped on every device since API 26 and this app's minSdk is 33, so
+# there is no such device to guard against.
+target_link_libraries(system_monitor PRIVATE log aaudio)

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
     thread_info.cpp
     fd_info.cpp
     process_creds.cpp
+    vulkan_info.cpp
 )
 
 # The conversion warnings earn their place here: this code carries kernel counters — size_t,

--- a/app/src/main/cpp/audio_path.cpp
+++ b/app/src/main/cpp/audio_path.cpp
@@ -1,0 +1,287 @@
+// Three of the readings below reached the NDK in API 34 and this app's minSdk is 33. Without this,
+// the NDK headers mark them `strict`, which hides them from a minSdk-33 build outright — a
+// `__builtin_available` guard does not help, and the build fails with "is unavailable: introduced
+// in Android 34". Defined it becomes a weak reference that the guard is then required to check.
+//
+// Scoped to this file rather than the whole library, and placed before the first include because
+// that is where it is read: nothing else here calls an API newer than minSdk, and a library-wide
+// definition would let the next file that does so link a weak symbol without anyone noticing.
+#define __ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__
+
+#include <aaudio/AAudio.h>
+#include <jni.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "native_util.h"
+
+namespace {
+
+using aoscm::JsonWriter;
+
+/** Deletes the builder however the scope is left, exception included. */
+using BuilderHandle =
+        std::unique_ptr<AAudioStreamBuilder, decltype([](AAudioStreamBuilder* builder) {
+                            AAudioStreamBuilder_delete(builder);
+                        })>;
+
+/** Closes the stream the same way. Never started, so closing is all there is to undo. */
+using StreamHandle =
+        std::unique_ptr<AAudioStream,
+                        decltype([](AAudioStream* stream) { AAudioStream_close(stream); })>;
+
+/** One configuration to ask for, and the name the screen files the answer under. */
+struct Request {
+    const char* label;
+    aaudio_performance_mode_t performance_mode;
+    aaudio_sharing_mode_t sharing_mode;
+    /** AAUDIO_UNSPECIFIED leaves the rate to the system, which is the usual way to open a stream.
+     */
+    int32_t sample_rate;
+};
+
+/**
+ * What to ask for, chosen so that the answers differ.
+ *
+ * A single stream would show what this device gave once and nothing about why. These four ask for
+ * progressively less, so the point where the system stops saying yes is visible: whether the
+ * exclusive MMAP path is on offer at all, whether low latency survives without it, and what the
+ * ordinary path costs in buffering by comparison.
+ */
+constexpr Request kProbes[] = {
+        {"low_latency_exclusive", AAUDIO_PERFORMANCE_MODE_LOW_LATENCY,
+         AAUDIO_SHARING_MODE_EXCLUSIVE, AAUDIO_UNSPECIFIED},
+        {"low_latency_shared", AAUDIO_PERFORMANCE_MODE_LOW_LATENCY, AAUDIO_SHARING_MODE_SHARED,
+         AAUDIO_UNSPECIFIED},
+        {"default_shared", AAUDIO_PERFORMANCE_MODE_NONE, AAUDIO_SHARING_MODE_SHARED,
+         AAUDIO_UNSPECIFIED},
+        // Asking for a rate the hardware does not run at is the only way to see the converter that
+        // gets inserted when it happens: the stream reports 44100 and the hardware reports its own
+        // rate, and the gap between the two is the resampler.
+        {"resample_44100", AAUDIO_PERFORMANCE_MODE_LOW_LATENCY, AAUDIO_SHARING_MODE_SHARED, 44100},
+};
+
+std::string_view PerformanceModeName(aaudio_performance_mode_t mode) {
+    switch (mode) {
+        case AAUDIO_PERFORMANCE_MODE_LOW_LATENCY:
+            return "low_latency";
+        case AAUDIO_PERFORMANCE_MODE_POWER_SAVING:
+            return "power_saving";
+        case AAUDIO_PERFORMANCE_MODE_POWER_SAVING_OFFLOADED:
+            return "power_saving_offloaded";
+        case AAUDIO_PERFORMANCE_MODE_NONE:
+            return "none";
+        default:
+            return "unknown";
+    }
+}
+
+std::string_view SharingModeName(aaudio_sharing_mode_t mode) {
+    switch (mode) {
+        case AAUDIO_SHARING_MODE_EXCLUSIVE:
+            return "exclusive";
+        case AAUDIO_SHARING_MODE_SHARED:
+            return "shared";
+        default:
+            return "unknown";
+    }
+}
+
+std::string_view FormatName(aaudio_format_t format) {
+    switch (format) {
+        case AAUDIO_FORMAT_PCM_I16:
+            return "pcm_i16";
+        case AAUDIO_FORMAT_PCM_FLOAT:
+            return "pcm_float";
+        case AAUDIO_FORMAT_PCM_I24_PACKED:
+            return "pcm_i24_packed";
+        case AAUDIO_FORMAT_PCM_I32:
+            return "pcm_i32";
+        case AAUDIO_FORMAT_IEC61937:
+            return "iec61937";
+        case AAUDIO_FORMAT_MP3:
+            return "mp3";
+        case AAUDIO_FORMAT_AAC_LC:
+            return "aac_lc";
+        case AAUDIO_FORMAT_AAC_HE_V1:
+            return "aac_he_v1";
+        case AAUDIO_FORMAT_AAC_HE_V2:
+            return "aac_he_v2";
+        case AAUDIO_FORMAT_AAC_ELD:
+            return "aac_eld";
+        case AAUDIO_FORMAT_AAC_XHE:
+            return "aac_xhe";
+        case AAUDIO_FORMAT_OPUS:
+            return "opus";
+        default:
+            // A format this app has no name for. It is still a format, so a stream carrying a
+            // named one really is being converted; only the name is missing.
+            return "unknown";
+    }
+}
+
+/**
+ * Writes a format, or nothing where the answer was not one.
+ *
+ * `AAudioStream_getHardwareFormat` is documented to answer AAUDIO_FORMAT_INVALID when the hardware
+ * runs something AAudio has no name for, and UNSPECIFIED is not a format either. Published as a
+ * token, either would compare unequal to the stream's own format and the screen would report a
+ * conversion nobody observed — the one thing this app must not do. Absent instead, like every
+ * other reading it could not take.
+ */
+void FieldFormatIfNamed(JsonWriter* writer, std::string_view key, aaudio_format_t format) {
+    if (format != AAUDIO_FORMAT_INVALID && format != AAUDIO_FORMAT_UNSPECIFIED) {
+        writer->Field(key, FormatName(format));
+    }
+}
+
+/** Writes a count the stream reports, leaving the key out where it reported none. */
+void FieldIfPositive(JsonWriter* writer, std::string_view key, int32_t value) {
+    if (value > 0) {
+        writer->Field(key, static_cast<int64_t>(value));
+    }
+}
+
+/**
+ * What the hardware behind the stream is actually running at.
+ *
+ * These three reached the NDK in API 34 and this app's minSdk is 33, so the NDK marks them
+ * available only from there — `-Werror` turns an unguarded call into a build failure rather than
+ * into a crash on a 33 device. Below 34 the keys are simply absent, which is how every other
+ * unavailable reading in this app crosses to Kotlin.
+ *
+ * The reading is worth the guard: it is the only way to see that a stream reporting 48 kHz is
+ * being fed to hardware running at something else, and nothing in the Java API reports it at all.
+ */
+void WriteHardware(JsonWriter* writer, AAudioStream* stream) {
+    if (__builtin_available(android 34, *)) {
+        writer->Key("hardware").BeginObject();
+        FieldIfPositive(writer, "sample_rate", AAudioStream_getHardwareSampleRate(stream));
+        FieldIfPositive(writer, "channel_count", AAudioStream_getHardwareChannelCount(stream));
+
+        const aaudio_format_t format = AAudioStream_getHardwareFormat(stream);
+        FieldFormatIfNamed(writer, "format", format);
+        // Kept apart from a reading that was simply not taken: the hardware does have a format, and
+        // AAudio saying it cannot name it is itself a fact about this device. The screen says so
+        // rather than leaving a gap that reads as "nobody looked".
+        if (format == AAUDIO_FORMAT_INVALID) {
+            writer->Field("format_unnameable", true);
+        }
+        writer->EndObject();
+    }
+}
+
+void WriteGranted(JsonWriter* writer, AAudioStream* stream) {
+    writer->Key("granted").BeginObject();
+    writer->Field("performance_mode", PerformanceModeName(AAudioStream_getPerformanceMode(stream)));
+    writer->Field("sharing_mode", SharingModeName(AAudioStream_getSharingMode(stream)));
+    FieldFormatIfNamed(writer, "format", AAudioStream_getFormat(stream));
+    FieldIfPositive(writer, "sample_rate", AAudioStream_getSampleRate(stream));
+    FieldIfPositive(writer, "channel_count", AAudioStream_getChannelCount(stream));
+    // The burst is the reading this screen exists for: AudioManager offers a device-wide
+    // recommendation, and this is what the stream actually settled on.
+    FieldIfPositive(writer, "frames_per_burst", AAudioStream_getFramesPerBurst(stream));
+    FieldIfPositive(writer, "buffer_capacity", AAudioStream_getBufferCapacityInFrames(stream));
+    FieldIfPositive(writer, "buffer_size", AAudioStream_getBufferSizeInFrames(stream));
+    FieldIfPositive(writer, "device_id", AAudioStream_getDeviceId(stream));
+    writer->EndObject();
+}
+
+void WriteProbe(JsonWriter* writer, const Request& request) {
+    writer->BeginObject();
+    writer->Field("label", request.label);
+
+    writer->Key("requested").BeginObject();
+    writer->Field("performance_mode", PerformanceModeName(request.performance_mode));
+    writer->Field("sharing_mode", SharingModeName(request.sharing_mode));
+    if (request.sample_rate != AAUDIO_UNSPECIFIED) {
+        writer->Field("sample_rate", static_cast<int64_t>(request.sample_rate));
+    }
+    writer->EndObject();
+
+    AAudioStreamBuilder* raw_builder = nullptr;
+    const aaudio_result_t built = AAudio_createStreamBuilder(&raw_builder);
+    const BuilderHandle builder(raw_builder);
+    if (built != AAUDIO_OK || !builder) {
+        writer->Field("open_ok", false);
+        writer->Field("open_error", AAudio_convertResultToText(built));
+        writer->EndObject();
+        return;
+    }
+
+    // Output only. An input stream would need RECORD_AUDIO, and a screen that reads the device
+    // should not be the reason an app holds the microphone permission.
+    AAudioStreamBuilder_setDirection(builder.get(), AAUDIO_DIRECTION_OUTPUT);
+    AAudioStreamBuilder_setPerformanceMode(builder.get(), request.performance_mode);
+    AAudioStreamBuilder_setSharingMode(builder.get(), request.sharing_mode);
+    if (request.sample_rate != AAUDIO_UNSPECIFIED) {
+        AAudioStreamBuilder_setSampleRate(builder.get(), request.sample_rate);
+    }
+
+    AAudioStream* raw_stream = nullptr;
+    const aaudio_result_t opened = AAudioStreamBuilder_openStream(builder.get(), &raw_stream);
+    const StreamHandle stream(raw_stream);
+    if (opened != AAUDIO_OK || !stream) {
+        // A refusal is a reading: an exclusive request that this device will not grant fails here
+        // on some implementations rather than quietly coming back shared.
+        writer->Field("open_ok", false);
+        writer->Field("open_error", AAudio_convertResultToText(opened));
+        writer->EndObject();
+        return;
+    }
+
+    // The stream is opened and never started. AAudioStream_requestStart is what powers the path
+    // and begins consuming the buffer; without it nothing is played, no audio focus is taken, and
+    // every reading below is still answered. The cost of stopping here is getXRunCount and
+    // getTimestamp, which mean nothing on a stream that never ran — this app reads, and playing
+    // silence to collect two more numbers is not reading.
+    writer->Field("open_ok", true);
+    WriteGranted(writer, stream.get());
+    WriteHardware(writer, stream.get());
+    writer->EndObject();
+}
+
+std::string Collect() {
+    JsonWriter writer;
+    writer.BeginObject();
+
+    // Said once at the top rather than inferred from three missing keys per probe: a device on
+    // API 33 cannot take the hardware readings at all, which is a property of the device and not
+    // of any one probe.
+    bool hardware_available = false;
+    if (__builtin_available(android 34, *)) {
+        hardware_available = true;
+    }
+    writer.Field("hardware_query_available", hardware_available);
+
+    writer.Key("probes").BeginArray();
+    for (const Request& request : kProbes) {
+        WriteProbe(&writer, request);
+    }
+    writer.EndArray();
+
+    writer.EndObject();
+    return writer.Take();
+}
+
+}  // namespace
+
+/**
+ * What this device's audio path grants, against what was asked of it.
+ *
+ * Three layers that need not agree, and the Java API reaches none of them. What was requested is
+ * this collector's own doing; what the stream settled on is AAudio's answer, which
+ * `AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER` only approximates with a device-wide
+ * recommendation; and what the hardware runs at is reported by nothing in the framework at all.
+ *
+ * Four streams are opened and closed. None is started, so nothing is played and no audio focus is
+ * taken.
+ */
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_aoscoremonitor_diagnostics_jni_NativeAudioInspector_getAudioPathNative(
+        JNIEnv* env, jobject /* this */) {
+    return aoscm::ReturnJson(env, [] { return Collect(); });
+}

--- a/app/src/main/cpp/vulkan_info.cpp
+++ b/app/src/main/cpp/vulkan_info.cpp
@@ -1,0 +1,495 @@
+// The loader is reached through dlopen below rather than linked, so the prototypes this header
+// would otherwise declare would be undefined symbols in a library that links no libvulkan.
+#define VK_NO_PROTOTYPES
+
+#include <dlfcn.h>
+#include <jni.h>
+#include <vulkan/vulkan.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "native_util.h"
+
+namespace {
+
+using aoscm::JsonWriter;
+
+constexpr char kHexDigits[] = "0123456789abcdef";
+
+/**
+ * The entry points this collector calls.
+ *
+ * Vulkan has no link-time ABI worth binding to: every function past `vkGetInstanceProcAddr` is
+ * fetched by name, and which of them exist depends on the version the loader in front of the
+ * driver implements. Holding them in one struct is what lets the collector ask whether a function
+ * is there instead of assuming it.
+ */
+struct VulkanApi {
+    PFN_vkGetInstanceProcAddr GetInstanceProcAddr = nullptr;
+    PFN_vkEnumerateInstanceVersion EnumerateInstanceVersion = nullptr;
+    PFN_vkCreateInstance CreateInstance = nullptr;
+    PFN_vkDestroyInstance DestroyInstance = nullptr;
+    PFN_vkEnumeratePhysicalDevices EnumeratePhysicalDevices = nullptr;
+    PFN_vkGetPhysicalDeviceProperties GetPhysicalDeviceProperties = nullptr;
+    PFN_vkGetPhysicalDeviceProperties2 GetPhysicalDeviceProperties2 = nullptr;
+    PFN_vkGetPhysicalDeviceMemoryProperties GetPhysicalDeviceMemoryProperties = nullptr;
+    PFN_vkGetPhysicalDeviceQueueFamilyProperties GetPhysicalDeviceQueueFamilyProperties = nullptr;
+    PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties = nullptr;
+};
+
+template <typename Fn>
+[[nodiscard]] Fn Resolve(PFN_vkGetInstanceProcAddr get, VkInstance instance, const char* name) {
+    return reinterpret_cast<Fn>(get(instance, name));
+}
+
+/**
+ * Holds the loader open for as long as anything fetched from it is in use.
+ *
+ * dlopen rather than a link against libvulkan: linking would make the whole of
+ * libsystem_monitor.so fail to load on a device with no Vulkan loader, and with it every other
+ * native reading in this app. Opening it here costs one failed dlopen on such a device and lets
+ * the screen say so.
+ */
+class Loader {
+public:
+    Loader() : handle_(dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL)) {}
+    ~Loader() {
+        if (handle_ != nullptr) {
+            dlclose(handle_);
+        }
+    }
+    Loader(const Loader&) = delete;
+    Loader& operator=(const Loader&) = delete;
+
+    [[nodiscard]] void* get() const { return handle_; }
+
+private:
+    void* handle_;
+};
+
+/** Destroys the instance however the scope is left, exception included. */
+class ScopedInstance {
+public:
+    ScopedInstance(PFN_vkDestroyInstance destroy, VkInstance instance)
+        : destroy_(destroy), instance_(instance) {}
+    ~ScopedInstance() {
+        if (destroy_ != nullptr && instance_ != VK_NULL_HANDLE) {
+            destroy_(instance_, nullptr);
+        }
+    }
+    ScopedInstance(const ScopedInstance&) = delete;
+    ScopedInstance& operator=(const ScopedInstance&) = delete;
+
+private:
+    PFN_vkDestroyInstance destroy_;
+    VkInstance instance_;
+};
+
+/** A packed Vulkan version as the three numbers it encodes. */
+std::string VersionString(uint32_t version) {
+    return std::to_string(VK_API_VERSION_MAJOR(version)) + '.' +
+           std::to_string(VK_API_VERSION_MINOR(version)) + '.' +
+           std::to_string(VK_API_VERSION_PATCH(version));
+}
+
+/** The four numbers a conformance version carries, which is one more than a Vulkan version has. */
+std::string ConformanceString(const VkConformanceVersion& version) {
+    return std::to_string(static_cast<unsigned>(version.major)) + '.' +
+           std::to_string(static_cast<unsigned>(version.minor)) + '.' +
+           std::to_string(static_cast<unsigned>(version.subminor)) + '.' +
+           std::to_string(static_cast<unsigned>(version.patch));
+}
+
+std::string HexBytes(const uint8_t* bytes, size_t count) {
+    std::string hex;
+    hex.reserve(count * 2);
+    for (size_t i = 0; i < count; ++i) {
+        hex.push_back(kHexDigits[bytes[i] >> 4]);
+        hex.push_back(kHexDigits[bytes[i] & 0xF]);
+    }
+    return hex;
+}
+
+std::string_view DeviceTypeName(VkPhysicalDeviceType type) {
+    switch (type) {
+        case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+            return "integrated_gpu";
+        case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+            return "discrete_gpu";
+        case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+            return "virtual_gpu";
+        case VK_PHYSICAL_DEVICE_TYPE_CPU:
+            return "cpu";
+        case VK_PHYSICAL_DEVICE_TYPE_OTHER:
+            return "other";
+        default:
+            return "unknown";
+    }
+}
+
+/**
+ * The driver behind the device, as the one enum that names it.
+ *
+ * This is the reading the whole screen is for: nothing in the Java API distinguishes a Qualcomm
+ * driver from a Mesa one, and the renderer string GLES offers is vendor-formatted prose. Only the
+ * ids that turn up on Android are named; anything else is reported by number instead of guessed at.
+ */
+std::string_view DriverIdName(VkDriverId id) {
+    switch (id) {
+        case VK_DRIVER_ID_QUALCOMM_PROPRIETARY:
+            return "qualcomm_proprietary";
+        case VK_DRIVER_ID_ARM_PROPRIETARY:
+            return "arm_proprietary";
+        case VK_DRIVER_ID_IMAGINATION_PROPRIETARY:
+            return "imagination_proprietary";
+        case VK_DRIVER_ID_IMAGINATION_OPEN_SOURCE_MESA:
+            return "imagination_mesa";
+        case VK_DRIVER_ID_SAMSUNG_PROPRIETARY:
+            return "samsung_proprietary";
+        case VK_DRIVER_ID_BROADCOM_PROPRIETARY:
+            return "broadcom_proprietary";
+        case VK_DRIVER_ID_VERISILICON_PROPRIETARY:
+            return "verisilicon_proprietary";
+        case VK_DRIVER_ID_MESA_TURNIP:
+            return "mesa_turnip";
+        case VK_DRIVER_ID_MESA_PANVK:
+            return "mesa_panvk";
+        case VK_DRIVER_ID_MESA_V3DV:
+            return "mesa_v3dv";
+        case VK_DRIVER_ID_MESA_VENUS:
+            return "mesa_venus";
+        case VK_DRIVER_ID_MESA_LLVMPIPE:
+            return "mesa_llvmpipe";
+        case VK_DRIVER_ID_GOOGLE_SWIFTSHADER:
+            return "google_swiftshader";
+        default:
+            return "";
+    }
+}
+
+/** The results this collector can actually provoke. Anything else crosses as its number. */
+std::string_view ResultName(VkResult result) {
+    switch (result) {
+        case VK_ERROR_OUT_OF_HOST_MEMORY:
+            return "out_of_host_memory";
+        case VK_ERROR_OUT_OF_DEVICE_MEMORY:
+            return "out_of_device_memory";
+        case VK_ERROR_INITIALIZATION_FAILED:
+            return "initialization_failed";
+        case VK_ERROR_LAYER_NOT_PRESENT:
+            return "layer_not_present";
+        case VK_ERROR_EXTENSION_NOT_PRESENT:
+            return "extension_not_present";
+        case VK_ERROR_INCOMPATIBLE_DRIVER:
+            return "incompatible_driver";
+        default:
+            return "";
+    }
+}
+
+void WriteFailure(JsonWriter* writer, VkResult result) {
+    const std::string_view name = ResultName(result);
+    if (!name.empty()) {
+        writer->Field("instance_error", name);
+    } else {
+        writer->Field("instance_error_code", static_cast<int64_t>(result));
+    }
+}
+
+void WriteMemory(JsonWriter* writer, const VulkanApi& api, VkPhysicalDevice device) {
+    VkPhysicalDeviceMemoryProperties memory = {};
+    api.GetPhysicalDeviceMemoryProperties(device, &memory);
+
+    writer->Key("memory_heaps").BeginArray();
+    for (uint32_t index = 0; index < memory.memoryHeapCount; ++index) {
+        const VkMemoryHeap& heap = memory.memoryHeaps[index];
+        writer->BeginObject();
+        writer->Field("index", static_cast<uint64_t>(index));
+        writer->Field("size_bytes", static_cast<uint64_t>(heap.size));
+        writer->Field("device_local", (heap.flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) != 0);
+        writer->EndObject();
+    }
+    writer->EndArray();
+
+    writer->Key("memory_types").BeginArray();
+    for (uint32_t index = 0; index < memory.memoryTypeCount; ++index) {
+        const VkMemoryType& type = memory.memoryTypes[index];
+        const VkMemoryPropertyFlags flags = type.propertyFlags;
+        writer->BeginObject();
+        writer->Field("index", static_cast<uint64_t>(index));
+        writer->Field("heap", static_cast<uint64_t>(type.heapIndex));
+        writer->Field("device_local", (flags & VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) != 0);
+        writer->Field("host_visible", (flags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) != 0);
+        writer->Field("host_coherent", (flags & VK_MEMORY_PROPERTY_HOST_COHERENT_BIT) != 0);
+        writer->Field("host_cached", (flags & VK_MEMORY_PROPERTY_HOST_CACHED_BIT) != 0);
+        writer->Field("lazily_allocated", (flags & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) != 0);
+        writer->Field("protected_memory", (flags & VK_MEMORY_PROPERTY_PROTECTED_BIT) != 0);
+        writer->EndObject();
+    }
+    writer->EndArray();
+}
+
+void WriteQueueFamilies(JsonWriter* writer, const VulkanApi& api, VkPhysicalDevice device) {
+    uint32_t count = 0;
+    api.GetPhysicalDeviceQueueFamilyProperties(device, &count, nullptr);
+    std::vector<VkQueueFamilyProperties> families(count);
+    if (count > 0) {
+        api.GetPhysicalDeviceQueueFamilyProperties(device, &count, families.data());
+        families.resize(count);
+    }
+
+    writer->Key("queue_families").BeginArray();
+    for (size_t index = 0; index < families.size(); ++index) {
+        const VkQueueFamilyProperties& family = families[index];
+        const VkQueueFlags flags = family.queueFlags;
+        writer->BeginObject();
+        writer->Field("index", static_cast<uint64_t>(index));
+        writer->Field("count", static_cast<uint64_t>(family.queueCount));
+        writer->Field("graphics", (flags & VK_QUEUE_GRAPHICS_BIT) != 0);
+        writer->Field("compute", (flags & VK_QUEUE_COMPUTE_BIT) != 0);
+        writer->Field("transfer", (flags & VK_QUEUE_TRANSFER_BIT) != 0);
+        writer->Field("sparse_binding", (flags & VK_QUEUE_SPARSE_BINDING_BIT) != 0);
+        writer->Field("protected_memory", (flags & VK_QUEUE_PROTECTED_BIT) != 0);
+        writer->Field("timestamp_bits", static_cast<uint64_t>(family.timestampValidBits));
+        writer->EndObject();
+    }
+    writer->EndArray();
+}
+
+void WriteLimits(JsonWriter* writer, const VkPhysicalDeviceLimits& limits) {
+    writer->Key("limits").BeginObject();
+    writer->Field("max_image_dimension_2d", static_cast<uint64_t>(limits.maxImageDimension2D));
+    writer->Field("max_bound_descriptor_sets",
+                  static_cast<uint64_t>(limits.maxBoundDescriptorSets));
+    writer->Field("max_push_constants_size", static_cast<uint64_t>(limits.maxPushConstantsSize));
+    writer->Field("max_memory_allocation_count",
+                  static_cast<uint64_t>(limits.maxMemoryAllocationCount));
+    writer->Field("max_compute_shared_memory_size",
+                  static_cast<uint64_t>(limits.maxComputeSharedMemorySize));
+    writer->Field("max_compute_work_group_invocations",
+                  static_cast<uint64_t>(limits.maxComputeWorkGroupInvocations));
+    writer->EndObject();
+}
+
+void WriteExtensions(JsonWriter* writer, const VulkanApi& api, VkPhysicalDevice device) {
+    uint32_t count = 0;
+    if (api.EnumerateDeviceExtensionProperties(device, nullptr, &count, nullptr) != VK_SUCCESS) {
+        return;
+    }
+    std::vector<VkExtensionProperties> extensions(count);
+    if (count > 0) {
+        if (api.EnumerateDeviceExtensionProperties(device, nullptr, &count, extensions.data()) !=
+            VK_SUCCESS) {
+            return;
+        }
+        extensions.resize(count);
+    }
+
+    writer->Key("extensions").BeginArray();
+    for (const VkExtensionProperties& extension : extensions) {
+        writer->Value(extension.extensionName);
+    }
+    writer->EndArray();
+}
+
+void WriteDevice(JsonWriter* writer, const VulkanApi& api, VkPhysicalDevice device) {
+    VkPhysicalDeviceDriverProperties driver = {};
+    driver.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES;
+
+    VkPhysicalDeviceProperties2 properties2 = {};
+    properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+    properties2.pNext = &driver;
+
+    if (api.GetPhysicalDeviceProperties2 != nullptr) {
+        api.GetPhysicalDeviceProperties2(device, &properties2);
+    } else {
+        api.GetPhysicalDeviceProperties(device, &properties2.properties);
+    }
+    const VkPhysicalDeviceProperties& properties = properties2.properties;
+
+    writer->Field("name", properties.deviceName);
+    writer->Field("type", DeviceTypeName(properties.deviceType));
+    writer->Field("api_version", VersionString(properties.apiVersion));
+    writer->FieldHex("vendor_id", static_cast<uint64_t>(properties.vendorID));
+    writer->FieldHex("device_id", static_cast<uint64_t>(properties.deviceID));
+
+    // How a driver packs its own version is vendor-defined, so the number is published as it was
+    // read. The conventional major.minor.patch split is offered beside it rather than instead of
+    // it: on a driver that packs differently the split is wrong, and the raw value never is.
+    writer->Field("driver_version_raw", static_cast<uint64_t>(properties.driverVersion));
+    writer->Field("driver_version", VersionString(properties.driverVersion));
+
+    // What changes when the driver is updated, which is the one identifier that does.
+    writer->Field("pipeline_cache_uuid", HexBytes(properties.pipelineCacheUUID, VK_UUID_SIZE));
+
+    // VkPhysicalDeviceDriverProperties reached core in Vulkan 1.2. A 1.1 driver answers the
+    // properties2 query but leaves a structure it does not know untouched, so the zero it was
+    // initialised with is how "this driver does not report a driver id" arrives — no VkDriverId is
+    // zero.
+    if (driver.driverID != 0) {
+        const std::string_view name = DriverIdName(driver.driverID);
+        if (!name.empty()) {
+            writer->Field("driver_id_name", name);
+        }
+        writer->Field("driver_id", static_cast<uint64_t>(driver.driverID));
+        writer->Field("driver_name", driver.driverName);
+        writer->Field("driver_info", driver.driverInfo);
+        writer->Field("conformance_version", ConformanceString(driver.conformanceVersion));
+    }
+
+    WriteLimits(writer, properties.limits);
+    WriteMemory(writer, api, device);
+    WriteQueueFamilies(writer, api, device);
+    WriteExtensions(writer, api, device);
+}
+
+/** Fetches the instance-level functions. False when one that is core in 1.0 is missing. */
+bool ResolveInstanceFunctions(VulkanApi* api, VkInstance instance) {
+    const PFN_vkGetInstanceProcAddr get = api->GetInstanceProcAddr;
+
+    api->DestroyInstance = Resolve<PFN_vkDestroyInstance>(get, instance, "vkDestroyInstance");
+    api->EnumeratePhysicalDevices =
+            Resolve<PFN_vkEnumeratePhysicalDevices>(get, instance, "vkEnumeratePhysicalDevices");
+    api->GetPhysicalDeviceProperties = Resolve<PFN_vkGetPhysicalDeviceProperties>(
+            get, instance, "vkGetPhysicalDeviceProperties");
+    api->GetPhysicalDeviceMemoryProperties = Resolve<PFN_vkGetPhysicalDeviceMemoryProperties>(
+            get, instance, "vkGetPhysicalDeviceMemoryProperties");
+    api->GetPhysicalDeviceQueueFamilyProperties =
+            Resolve<PFN_vkGetPhysicalDeviceQueueFamilyProperties>(
+                    get, instance, "vkGetPhysicalDeviceQueueFamilyProperties");
+    api->EnumerateDeviceExtensionProperties = Resolve<PFN_vkEnumerateDeviceExtensionProperties>(
+            get, instance, "vkEnumerateDeviceExtensionProperties");
+
+    // Core since 1.1 and legitimately absent below it, so its absence is a fallback rather than a
+    // failure. It is the only way to the driver id.
+    api->GetPhysicalDeviceProperties2 = Resolve<PFN_vkGetPhysicalDeviceProperties2>(
+            get, instance, "vkGetPhysicalDeviceProperties2");
+
+    return api->DestroyInstance != nullptr && api->EnumeratePhysicalDevices != nullptr &&
+           api->GetPhysicalDeviceProperties != nullptr &&
+           api->GetPhysicalDeviceMemoryProperties != nullptr &&
+           api->GetPhysicalDeviceQueueFamilyProperties != nullptr &&
+           api->EnumerateDeviceExtensionProperties != nullptr;
+}
+
+std::string Collect() {
+    JsonWriter writer;
+    writer.BeginObject();
+
+    // Declared before the instance below, so that the instance — which holds pointers into this
+    // library — is destroyed before the library is closed.
+    const Loader loader;
+    if (loader.get() == nullptr) {
+        writer.Field("loader_present", false);
+        writer.EndObject();
+        return writer.Take();
+    }
+    writer.Field("loader_present", true);
+
+    VulkanApi api;
+    api.GetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(
+            dlsym(loader.get(), "vkGetInstanceProcAddr"));
+    if (api.GetInstanceProcAddr == nullptr) {
+        writer.Field("instance_ok", false);
+        writer.Field("instance_error", "initialization_failed");
+        writer.EndObject();
+        return writer.Take();
+    }
+
+    // Absent on a 1.0 loader, and there is no other way to tell one apart: every other version
+    // query needs an instance, and creating one means naming the version first.
+    api.EnumerateInstanceVersion = Resolve<PFN_vkEnumerateInstanceVersion>(
+            api.GetInstanceProcAddr, nullptr, "vkEnumerateInstanceVersion");
+    uint32_t instance_version = VK_API_VERSION_1_0;
+    if (api.EnumerateInstanceVersion == nullptr ||
+        api.EnumerateInstanceVersion(&instance_version) != VK_SUCCESS) {
+        instance_version = VK_API_VERSION_1_0;
+    }
+    writer.Field("instance_version", VersionString(instance_version));
+
+    api.CreateInstance =
+            Resolve<PFN_vkCreateInstance>(api.GetInstanceProcAddr, nullptr, "vkCreateInstance");
+    if (api.CreateInstance == nullptr) {
+        writer.Field("instance_ok", false);
+        writer.Field("instance_error", "initialization_failed");
+        writer.EndObject();
+        return writer.Take();
+    }
+
+    VkApplicationInfo application = {};
+    application.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    application.pApplicationName = "AOS Core Monitor";
+    // Asking for more than the loader reported fails outright with VK_ERROR_INCOMPATIBLE_DRIVER, so
+    // the request is capped at what it just said. 1.1 is as high as this collector needs: that is
+    // where vkGetPhysicalDeviceProperties2 became core.
+    application.apiVersion = std::min<uint32_t>(instance_version, VK_API_VERSION_1_1);
+
+    // No layers and no extensions: this reads the physical devices and never presents anything, so
+    // it needs neither a surface nor a swapchain, and it creates no logical device.
+    VkInstanceCreateInfo create = {};
+    create.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    create.pApplicationInfo = &application;
+
+    VkInstance instance = VK_NULL_HANDLE;
+    const VkResult created = api.CreateInstance(&create, nullptr, &instance);
+    if (created != VK_SUCCESS) {
+        // A device with no Vulkan driver behind the loader answers here, and so does one whose
+        // driver refused to start. Which of the two it was is what the result carries.
+        writer.Field("instance_ok", false);
+        WriteFailure(&writer, created);
+        writer.EndObject();
+        return writer.Take();
+    }
+
+    const bool resolved = ResolveInstanceFunctions(&api, instance);
+    const ScopedInstance scoped(api.DestroyInstance, instance);
+    if (!resolved) {
+        writer.Field("instance_ok", false);
+        writer.Field("instance_error", "initialization_failed");
+        writer.EndObject();
+        return writer.Take();
+    }
+    writer.Field("instance_ok", true);
+
+    uint32_t device_count = 0;
+    api.EnumeratePhysicalDevices(instance, &device_count, nullptr);
+    std::vector<VkPhysicalDevice> devices(device_count);
+    if (device_count > 0) {
+        api.EnumeratePhysicalDevices(instance, &device_count, devices.data());
+        devices.resize(device_count);
+    }
+
+    writer.Key("devices").BeginArray();
+    for (VkPhysicalDevice device : devices) {
+        writer.BeginObject();
+        WriteDevice(&writer, api, device);
+        writer.EndObject();
+    }
+    writer.EndArray();
+
+    writer.EndObject();
+    return writer.Take();
+}
+
+}  // namespace
+
+/**
+ * The GPUs Vulkan can see, and which driver is behind each.
+ *
+ * Vulkan has no Java binding on Android — it is a C API and the platform has never wrapped it — so
+ * none of this is reachable from the framework. What the Java side can reach is the GLES renderer
+ * string, which is three lines of vendor-formatted prose; the driver id, the conformance version
+ * the driver passed, the memory heaps and the queue families are only here.
+ *
+ * Nothing is drawn and no logical device is created: the instance exists to enumerate physical
+ * devices and is destroyed before this returns.
+ */
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_aoscoremonitor_diagnostics_jni_NativeVulkanInspector_getVulkanNative(JNIEnv* env,
+                                                                              jobject /* this */) {
+    return aoscm::ReturnJson(env, [] { return Collect(); });
+}

--- a/app/src/main/cpp/vulkan_info.cpp
+++ b/app/src/main/cpp/vulkan_info.cpp
@@ -455,12 +455,24 @@ std::string Collect() {
     }
     writer.Field("instance_ok", true);
 
+    // Both results are checked, because the vector is sized from the first call and filled by the
+    // second: a failure in either leaves entries value-initialised — a null VkPhysicalDevice — and
+    // the loop below would hand one to vkGetPhysicalDeviceProperties. VK_INCOMPLETE is not a
+    // failure; it says the list grew between the two calls and device_count holds how many were
+    // written.
     uint32_t device_count = 0;
-    api.EnumeratePhysicalDevices(instance, &device_count, nullptr);
+    if (api.EnumeratePhysicalDevices(instance, &device_count, nullptr) != VK_SUCCESS) {
+        device_count = 0;
+    }
     std::vector<VkPhysicalDevice> devices(device_count);
     if (device_count > 0) {
-        api.EnumeratePhysicalDevices(instance, &device_count, devices.data());
-        devices.resize(device_count);
+        const VkResult listed =
+                api.EnumeratePhysicalDevices(instance, &device_count, devices.data());
+        if (listed != VK_SUCCESS && listed != VK_INCOMPLETE) {
+            devices.clear();
+        } else {
+            devices.resize(device_count);
+        }
     }
 
     writer.Key("devices").BeginArray();

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeAudioInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeAudioInspector.kt
@@ -1,0 +1,219 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/**
+ * Whether a stream has the device to itself.
+ *
+ * The Java API has no equivalent concept: an `AudioTrack` is always mixed. Exclusive is the MMAP
+ * path, and asking for it is not the same as getting it.
+ */
+enum class AudioSharingMode {
+    Exclusive,
+    Shared,
+    Unknown;
+
+    internal companion object {
+        fun of(token: String?): AudioSharingMode = when (token) {
+            "exclusive" -> Exclusive
+            "shared" -> Shared
+            else -> Unknown
+        }
+    }
+}
+
+/** How hard the system was asked to work to keep the path short. */
+enum class AudioPerformanceMode {
+    LowLatency,
+    PowerSaving,
+    PowerSavingOffloaded,
+    None,
+    Unknown;
+
+    internal companion object {
+        fun of(token: String?): AudioPerformanceMode = when (token) {
+            "low_latency" -> LowLatency
+            "power_saving" -> PowerSaving
+            "power_saving_offloaded" -> PowerSavingOffloaded
+            "none" -> None
+            else -> Unknown
+        }
+    }
+}
+
+/** What one probe asked the system for. */
+data class AudioRequest(
+    val performanceMode: AudioPerformanceMode,
+    val sharingMode: AudioSharingMode,
+    /** Null where the rate was left to the system, which is how a stream is usually opened. */
+    val sampleRate: Int? = null
+)
+
+/**
+ * What the stream settled on.
+ *
+ * @param framesPerBurst the reading this screen exists for. `AudioManager` offers
+ *   `PROPERTY_OUTPUT_FRAMES_PER_BUFFER`, which is a device-wide recommendation; this is what this
+ *   stream actually got.
+ */
+data class AudioGranted(
+    val performanceMode: AudioPerformanceMode,
+    val sharingMode: AudioSharingMode,
+    /** Null where AAudio answered with something that is not a format. See [AudioHardware.format]. */
+    val format: String? = null,
+    val sampleRate: Int? = null,
+    val channelCount: Int? = null,
+    val framesPerBurst: Int? = null,
+    val bufferCapacity: Int? = null,
+    val bufferSize: Int? = null,
+    val deviceId: Int? = null
+)
+
+/**
+ * What the hardware under the stream runs at. Reported by nothing in the Java API.
+ *
+ * @param format null where AAudio would not name one, which is not the same as the hardware having
+ *   no format. [formatUnnameable] tells the two apart.
+ * @param formatUnnameable AAudio answered `AAUDIO_FORMAT_INVALID`: the hardware runs a format the
+ *   API has no constant for. Whether anything is converted cannot be said from that, so nothing
+ *   claims it is.
+ */
+data class AudioHardware(
+    val sampleRate: Int? = null,
+    val channelCount: Int? = null,
+    val format: String? = null,
+    val formatUnnameable: Boolean = false
+)
+
+/**
+ * One request, and the two answers to it.
+ *
+ * @param openError AAudio's own name for the failure, as `AAudio_convertResultToText` gives it.
+ *   Null when the stream opened.
+ */
+data class AudioProbe(
+    val label: String,
+    val requested: AudioRequest,
+    val opened: Boolean,
+    val openError: String? = null,
+    val granted: AudioGranted? = null,
+    val hardware: AudioHardware? = null
+) {
+    val sharingModeAsRequested: Boolean get() = granted?.sharingMode == requested.sharingMode
+
+    val performanceModeAsRequested: Boolean get() = granted?.performanceMode == requested.performanceMode
+
+    /** A rate left to the system is granted by definition; one that was named may not be. */
+    val sampleRateAsRequested: Boolean
+        get() = requested.sampleRate == null || granted?.sampleRate == requested.sampleRate
+
+    /** Nothing was substituted. */
+    val grantedAsRequested: Boolean
+        get() = opened && sharingModeAsRequested && performanceModeAsRequested && sampleRateAsRequested
+
+    /**
+     * The stream runs at one rate and the hardware at another, so something converts between them.
+     *
+     * This is the whole reason the fourth probe asks for a rate the hardware is unlikely to have:
+     * a resampler is invisible from the Java side, and the gap between these two numbers is it.
+     */
+    val isResampled: Boolean
+        get() {
+            val stream = granted?.sampleRate ?: return false
+            val hardware = hardware?.sampleRate ?: return false
+            return stream != hardware
+        }
+
+    /** The same, for a sample format the hardware does not take directly. */
+    val isFormatConverted: Boolean
+        get() {
+            val stream = granted?.format ?: return false
+            val hardware = hardware?.format ?: return false
+            return stream != hardware
+        }
+}
+
+/**
+ * The probes, and whether this device can answer for its hardware at all.
+ *
+ * @param hardwareQueryAvailable false below API 34, where the three hardware readings do not exist.
+ *   Carried once rather than inferred from missing keys on each probe: it is a property of the
+ *   device, not of any one request.
+ */
+data class AudioPathSnapshot(val hardwareQueryAvailable: Boolean = false, val probes: List<AudioProbe> = emptyList())
+
+/**
+ * Asks the audio system for several paths and reports what it granted.
+ *
+ * Four output streams are opened and closed. None is started, so nothing is played and no audio
+ * focus is taken — which is also why there is no XRun count here: it means nothing on a stream
+ * that never ran.
+ */
+class NativeAudioInspector {
+
+    external fun getAudioPathNative(): String
+
+    suspend fun read(): AudioPathSnapshot? = withContext(Dispatchers.IO) {
+        if (!NativeLibrary.isAvailable) return@withContext null
+        try {
+            parseAudioPath(getAudioPathNative())
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing the audio path", e)
+            null
+        }
+    }
+
+    private companion object {
+        const val TAG = "NativeAudioInspector"
+    }
+}
+
+internal fun parseAudioPath(json: String): AudioPathSnapshot {
+    val root = JSONObject(json)
+
+    val probes = root.optJSONArray("probes")?.mapObjects { probe ->
+        val requested = probe.optJSONObject("requested")
+        val granted = probe.optJSONObject("granted")
+        val hardware = probe.optJSONObject("hardware")
+
+        AudioProbe(
+            label = probe.optString("label"),
+            requested = AudioRequest(
+                performanceMode = AudioPerformanceMode.of(requested?.stringOrNull("performance_mode")),
+                sharingMode = AudioSharingMode.of(requested?.stringOrNull("sharing_mode")),
+                sampleRate = requested?.intOrNull("sample_rate")
+            ),
+            opened = probe.optBoolean("open_ok"),
+            openError = probe.stringOrNull("open_error"),
+            granted = granted?.let {
+                AudioGranted(
+                    performanceMode = AudioPerformanceMode.of(it.stringOrNull("performance_mode")),
+                    sharingMode = AudioSharingMode.of(it.stringOrNull("sharing_mode")),
+                    format = it.stringOrNull("format"),
+                    sampleRate = it.intOrNull("sample_rate"),
+                    channelCount = it.intOrNull("channel_count"),
+                    framesPerBurst = it.intOrNull("frames_per_burst"),
+                    bufferCapacity = it.intOrNull("buffer_capacity"),
+                    bufferSize = it.intOrNull("buffer_size"),
+                    deviceId = it.intOrNull("device_id")
+                )
+            },
+            hardware = hardware?.let {
+                AudioHardware(
+                    sampleRate = it.intOrNull("sample_rate"),
+                    channelCount = it.intOrNull("channel_count"),
+                    format = it.stringOrNull("format"),
+                    formatUnnameable = it.optBoolean("format_unnameable")
+                )
+            }
+        )
+    }.orEmpty()
+
+    return AudioPathSnapshot(
+        hardwareQueryAvailable = root.optBoolean("hardware_query_available"),
+        probes = probes
+    )
+}

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeVulkanInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeVulkanInspector.kt
@@ -1,0 +1,210 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/** What kind of device the driver says it is. */
+enum class VulkanDeviceType {
+    IntegratedGpu,
+    DiscreteGpu,
+    VirtualGpu,
+    Cpu,
+    Other,
+
+    /** A type this version of Vulkan did not define when the app was built. */
+    Unknown;
+
+    internal companion object {
+        fun of(token: String?): VulkanDeviceType = when (token) {
+            "integrated_gpu" -> IntegratedGpu
+            "discrete_gpu" -> DiscreteGpu
+            "virtual_gpu" -> VirtualGpu
+            "cpu" -> Cpu
+            "other" -> Other
+            else -> Unknown
+        }
+    }
+}
+
+/**
+ * A pool of device memory, and whether it is the GPU's own.
+ *
+ * A phone reports one heap that is both — the GPU and the CPU share the same physical memory — so
+ * a second heap on a handset is worth noticing rather than assuming.
+ */
+data class VulkanMemoryHeap(val index: Int, val sizeBytes: Long, val isDeviceLocal: Boolean)
+
+/** One way of allocating out of a heap, as the combination of properties it carries. */
+data class VulkanMemoryType(
+    val index: Int,
+    val heapIndex: Int,
+    val isDeviceLocal: Boolean = false,
+    val isHostVisible: Boolean = false,
+    val isHostCoherent: Boolean = false,
+    val isHostCached: Boolean = false,
+    val isLazilyAllocated: Boolean = false,
+    val isProtected: Boolean = false
+)
+
+/** A group of interchangeable queues, and the work they accept. */
+data class VulkanQueueFamily(
+    val index: Int,
+    val queueCount: Int,
+    val graphics: Boolean = false,
+    val compute: Boolean = false,
+    val transfer: Boolean = false,
+    val sparseBinding: Boolean = false,
+    val protectedMemory: Boolean = false,
+    val timestampBits: Int = 0
+)
+
+/**
+ * One physical device, as its driver describes it.
+ *
+ * @param driverIdName the driver behind the device, named. Null both where the driver is one this
+ *   app has no name for and where the device implements Vulkan 1.1, which predates the query.
+ * @param driverVersionRaw the driver's own version number, unpacked. Its encoding is the vendor's
+ *   choice, so [driverVersion] — the conventional split — is a reading of it rather than a fact
+ *   about it.
+ */
+data class VulkanDevice(
+    val name: String,
+    val type: VulkanDeviceType,
+    val apiVersion: String,
+    val driverVersion: String,
+    val driverVersionRaw: Long,
+    val vendorId: String,
+    val deviceId: String,
+    val pipelineCacheUuid: String? = null,
+    val driverId: Int? = null,
+    val driverIdName: String? = null,
+    val driverName: String? = null,
+    val driverInfo: String? = null,
+    val conformanceVersion: String? = null,
+    val limits: Map<String, Long> = emptyMap(),
+    val memoryHeaps: List<VulkanMemoryHeap> = emptyList(),
+    val memoryTypes: List<VulkanMemoryType> = emptyList(),
+    val queueFamilies: List<VulkanQueueFamily> = emptyList(),
+    val extensions: List<String> = emptyList()
+) {
+    /** The total the heaps add up to, which is what the device can allocate at all. */
+    val totalMemoryBytes: Long get() = memoryHeaps.sumOf { it.sizeBytes }
+}
+
+/**
+ * What Vulkan reported, or how far the collector got before it could not.
+ *
+ * The three ways this comes back empty say different things, and the screen words them
+ * differently: no loader on the device at all, a loader with no driver behind it, and a driver that
+ * started but enumerated nothing.
+ *
+ * @param instanceError the failure that stopped `vkCreateInstance`, named where it is one this app
+ *   knows. Null when the instance was created.
+ * @param instanceErrorCode the same failure as its raw `VkResult`, carried only when the name is not
+ *   known.
+ */
+data class VulkanSnapshot(
+    val loaderPresent: Boolean = false,
+    val instanceVersion: String? = null,
+    val instanceCreated: Boolean = false,
+    val instanceError: String? = null,
+    val instanceErrorCode: Int? = null,
+    val devices: List<VulkanDevice> = emptyList()
+)
+
+/**
+ * Asks Vulkan what GPUs this device has.
+ *
+ * Vulkan is a C API with no Java binding on Android, so every reading here is one the framework
+ * cannot take: the driver id, the version the driver passed conformance at, the memory heaps, the
+ * queue families. What Java can reach is the GLES renderer string, which is prose.
+ */
+class NativeVulkanInspector {
+
+    external fun getVulkanNative(): String
+
+    suspend fun read(): VulkanSnapshot? = withContext(Dispatchers.IO) {
+        if (!NativeLibrary.isAvailable) return@withContext null
+        try {
+            parseVulkan(getVulkanNative())
+        } catch (e: Exception) {
+            Log.e(TAG, "Error parsing Vulkan properties", e)
+            null
+        }
+    }
+
+    private companion object {
+        const val TAG = "NativeVulkanInspector"
+    }
+}
+
+internal fun parseVulkan(json: String): VulkanSnapshot {
+    val root = JSONObject(json)
+
+    val devices = root.optJSONArray("devices")?.mapObjects { device ->
+        VulkanDevice(
+            name = device.optString("name"),
+            type = VulkanDeviceType.of(device.stringOrNull("type")),
+            apiVersion = device.optString("api_version"),
+            driverVersion = device.optString("driver_version"),
+            driverVersionRaw = device.optLong("driver_version_raw"),
+            vendorId = device.optString("vendor_id"),
+            deviceId = device.optString("device_id"),
+            pipelineCacheUuid = device.stringOrNull("pipeline_cache_uuid"),
+            driverId = device.intOrNull("driver_id"),
+            driverIdName = device.stringOrNull("driver_id_name"),
+            driverName = device.stringOrNull("driver_name"),
+            driverInfo = device.stringOrNull("driver_info"),
+            conformanceVersion = device.stringOrNull("conformance_version"),
+            limits = device.longMap("limits"),
+            memoryHeaps = device.optJSONArray("memory_heaps")?.mapObjects { heap ->
+                VulkanMemoryHeap(
+                    index = heap.optInt("index"),
+                    sizeBytes = heap.optLong("size_bytes"),
+                    isDeviceLocal = heap.optBoolean("device_local")
+                )
+            }.orEmpty(),
+            memoryTypes = device.optJSONArray("memory_types")?.mapObjects { type ->
+                VulkanMemoryType(
+                    index = type.optInt("index"),
+                    heapIndex = type.optInt("heap"),
+                    isDeviceLocal = type.optBoolean("device_local"),
+                    isHostVisible = type.optBoolean("host_visible"),
+                    isHostCoherent = type.optBoolean("host_coherent"),
+                    isHostCached = type.optBoolean("host_cached"),
+                    isLazilyAllocated = type.optBoolean("lazily_allocated"),
+                    isProtected = type.optBoolean("protected_memory")
+                )
+            }.orEmpty(),
+            queueFamilies = device.optJSONArray("queue_families")?.mapObjects { family ->
+                VulkanQueueFamily(
+                    index = family.optInt("index"),
+                    queueCount = family.optInt("count"),
+                    graphics = family.optBoolean("graphics"),
+                    compute = family.optBoolean("compute"),
+                    transfer = family.optBoolean("transfer"),
+                    sparseBinding = family.optBoolean("sparse_binding"),
+                    protectedMemory = family.optBoolean("protected_memory"),
+                    timestampBits = family.optInt("timestamp_bits")
+                )
+            }.orEmpty(),
+            // Sorted because the driver's own order is not one: the list is what the device
+            // supports, and a name is how anyone looks for an entry in it.
+            extensions = device.optJSONArray("extensions")
+                ?.let { array -> (0 until array.length()).map(array::optString) }
+                .orEmpty()
+                .sorted()
+        )
+    }.orEmpty()
+
+    return VulkanSnapshot(
+        loaderPresent = root.optBoolean("loader_present"),
+        instanceVersion = root.stringOrNull("instance_version"),
+        instanceCreated = root.optBoolean("instance_ok"),
+        instanceError = root.stringOrNull("instance_error"),
+        instanceErrorCode = root.intOrNull("instance_error_code"),
+        devices = devices
+    )
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.VerifiedUser
+import androidx.compose.material.icons.filled.ViewInAr
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation3.runtime.NavKey
 import com.aoscoremonitor.R
@@ -209,6 +210,14 @@ sealed interface Destination : NavKey {
         @Transient
         override val icon: ImageVector = Icons.Default.Speed
     }
+
+    @Serializable
+    data object Vulkan : Destination {
+        override val titleRes get() = R.string.vulkan_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.ViewInAr
+    }
 }
 
 /** A named run of the home grid. */
@@ -224,8 +233,8 @@ data class DestinationGroup(@get:StringRes val titleRes: Int, val destinations: 
  *
  * Within the native run the order goes outwards from the process: what it is running (CPU,
  * threads), what it is holding (memory, libraries, descriptors), who it is (credentials), and what
- * it can reach (storage, network). The display and the frames it is served close the list, being
- * the one layer the app can watch itself being drawn onto.
+ * it can reach (storage, network). The display, the frames it is served and the GPU behind both
+ * close the list, being the one layer the app can watch itself being drawn onto.
  *
  * Named groups rather than one long list, because that order was the only thing carrying the
  * structure and nothing on screen showed it: nineteen tiles arrived looking equally related to each
@@ -262,7 +271,7 @@ val HomeGroups: List<DestinationGroup> = listOf(
     ),
     DestinationGroup(
         R.string.home_group_display,
-        listOf(Destination.DisplayPanel, Destination.FramePacing)
+        listOf(Destination.DisplayPanel, Destination.FramePacing, Destination.Vulkan)
     )
 )
 
@@ -293,4 +302,5 @@ val Destination.shortTitleRes: Int
         Destination.ProcessCredentials -> R.string.destination_credentials
         Destination.DisplayPanel -> R.string.destination_display
         Destination.FramePacing -> R.string.destination_frames
+        Destination.Vulkan -> R.string.destination_vulkan
     }

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/Destination.kt
@@ -11,6 +11,7 @@ import androidx.compose.material.icons.filled.Computer
 import androidx.compose.material.icons.filled.DataUsage
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.DeveloperBoard
+import androidx.compose.material.icons.filled.GraphicEq
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Monitor
@@ -218,6 +219,14 @@ sealed interface Destination : NavKey {
         @Transient
         override val icon: ImageVector = Icons.Default.ViewInAr
     }
+
+    @Serializable
+    data object AudioPath : Destination {
+        override val titleRes get() = R.string.audio_title
+
+        @Transient
+        override val icon: ImageVector = Icons.Default.GraphicEq
+    }
 }
 
 /** A named run of the home grid. */
@@ -272,7 +281,10 @@ val HomeGroups: List<DestinationGroup> = listOf(
     DestinationGroup(
         R.string.home_group_display,
         listOf(Destination.DisplayPanel, Destination.FramePacing, Destination.Vulkan)
-    )
+    ),
+    // A group of one. The audio path is not a display reading and not a process reading, and
+    // filing it under either would say something untrue about it to make the grid look even.
+    DestinationGroup(R.string.home_group_audio, listOf(Destination.AudioPath))
 )
 
 /** Every destination the grid offers, flattened. What the navigation test walks. */
@@ -303,4 +315,5 @@ val Destination.shortTitleRes: Int
         Destination.DisplayPanel -> R.string.destination_display
         Destination.FramePacing -> R.string.destination_frames
         Destination.Vulkan -> R.string.destination_vulkan
+        Destination.AudioPath -> R.string.destination_audio
     }

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import com.aoscoremonitor.ui.screens.AudioPathScreen
 import com.aoscoremonitor.ui.screens.CpuCoresScreen
 import com.aoscoremonitor.ui.screens.DescriptorsScreen
 import com.aoscoremonitor.ui.screens.DisplayScreen
@@ -95,6 +96,7 @@ fun MonitorNavHost(modifier: Modifier = Modifier) {
                 entry<Destination.DisplayPanel> { DisplayScreen(onNavigateBack = goBack) }
                 entry<Destination.FramePacing> { FramePacingScreen(onNavigateBack = goBack) }
                 entry<Destination.Vulkan> { VulkanScreen(onNavigateBack = goBack) }
+                entry<Destination.AudioPath> { AudioPathScreen(onNavigateBack = goBack) }
             }
         }
     )

--- a/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/navigation/MonitorNavHost.kt
@@ -28,6 +28,7 @@ import com.aoscoremonitor.ui.screens.SystemDiagnosticsScreen
 import com.aoscoremonitor.ui.screens.SystemInfoScreen
 import com.aoscoremonitor.ui.screens.TcpConnectionsScreen
 import com.aoscoremonitor.ui.screens.ThreadsScreen
+import com.aoscoremonitor.ui.screens.VulkanScreen
 
 /**
  * The app's single navigation host.
@@ -93,6 +94,7 @@ fun MonitorNavHost(modifier: Modifier = Modifier) {
                 entry<Destination.ProcessCredentials> { ProcessCredentialsScreen(onNavigateBack = goBack) }
                 entry<Destination.DisplayPanel> { DisplayScreen(onNavigateBack = goBack) }
                 entry<Destination.FramePacing> { FramePacingScreen(onNavigateBack = goBack) }
+                entry<Destination.Vulkan> { VulkanScreen(onNavigateBack = goBack) }
             }
         }
     )

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/AudioPathScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/AudioPathScreen.kt
@@ -1,0 +1,408 @@
+package com.aoscoremonitor.ui.screens
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.GraphicEq
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.jni.AudioGranted
+import com.aoscoremonitor.diagnostics.jni.AudioHardware
+import com.aoscoremonitor.diagnostics.jni.AudioPathSnapshot
+import com.aoscoremonitor.diagnostics.jni.AudioPerformanceMode
+import com.aoscoremonitor.diagnostics.jni.AudioProbe
+import com.aoscoremonitor.diagnostics.jni.AudioRequest
+import com.aoscoremonitor.diagnostics.jni.AudioSharingMode
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.LabeledValue
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.MonitorTag
+import com.aoscoremonitor.ui.components.ReadingStatus
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.MonitorPreviews
+import com.aoscoremonitor.ui.theme.MonitorTypography
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.AudioPathUiState
+import com.aoscoremonitor.ui.viewmodel.AudioPathViewModel
+
+@Composable
+fun AudioPathScreen(onNavigateBack: () -> Unit, modifier: Modifier = Modifier, viewModel: AudioPathViewModel = viewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    AudioPathContent(
+        uiState = uiState,
+        onNavigateBack = onNavigateBack,
+        onRefresh = viewModel::refresh,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun AudioPathContent(uiState: AudioPathUiState, onNavigateBack: () -> Unit, onRefresh: () -> Unit, modifier: Modifier = Modifier) {
+    MonitorScaffold(
+        title = stringResource(R.string.audio_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier,
+        floatingActionButton = {
+            // Worth offering here in a way it is not on the other native screens: what the system
+            // grants depends on what else is playing, so the answer can change between taps.
+            FloatingActionButton(onClick = onRefresh) {
+                Icon(
+                    imageVector = Icons.Default.Refresh,
+                    contentDescription = stringResource(R.string.action_refresh)
+                )
+            }
+        }
+    ) { innerPadding ->
+        val snapshot = uiState.audio
+        if (snapshot == null || snapshot.probes.isEmpty()) {
+            FullScreenMessage(
+                message = stringResource(
+                    when {
+                        !uiState.hasLoaded -> R.string.audio_loading
+                        snapshot == null -> R.string.audio_unavailable
+                        else -> R.string.audio_no_probes
+                    }
+                ),
+                icon = Icons.Default.GraphicEq,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            item(key = "summary-header") {
+                SectionHeader(
+                    title = stringResource(R.string.audio_summary_section),
+                    subtitle = pluralStringResource(
+                        R.plurals.audio_summary,
+                        snapshot.probes.size,
+                        snapshot.probes.size
+                    ),
+                    icon = Icons.Default.GraphicEq
+                )
+            }
+
+            // Said before the readings rather than after them: a screen that opens audio streams
+            // owes the reader an account of what it did to the device.
+            item(key = "no-playback") {
+                Text(
+                    text = stringResource(R.string.audio_no_playback_note),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+
+            if (!snapshot.hardwareQueryAvailable) {
+                item(key = "no-hardware-query") {
+                    Text(
+                        text = stringResource(R.string.audio_hardware_unavailable_note),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(bottom = Spacing.Small)
+                    )
+                }
+            }
+
+            items(snapshot.probes, key = { probe -> probe.label }) { probe -> ProbeCard(probe) }
+        }
+    }
+}
+
+@Composable
+private fun ProbeCard(probe: AudioProbe, modifier: Modifier = Modifier) {
+    MonitorCard(
+        modifier = modifier,
+        // The one place a status is earned: a request the system would not open at all is a
+        // different outcome from one it answered, and StatusRow's wording carries it to TalkBack.
+        status = if (probe.opened) ReadingStatus.Neutral else ReadingStatus.Warning
+    ) {
+        Text(
+            text = stringResource(probe.labelRes),
+            style = MaterialTheme.typography.titleMedium
+        )
+        LabeledValue(
+            label = stringResource(R.string.audio_requested),
+            value = probe.requested.describe()
+        )
+
+        if (!probe.opened) {
+            Text(
+                text = stringResource(R.string.audio_refused),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            if (probe.openError != null) {
+                Text(
+                    text = probe.openError,
+                    style = MonitorTypography.machineText,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            return@MonitorCard
+        }
+
+        val granted = probe.granted ?: return@MonitorCard
+        if (probe.grantedAsRequested) {
+            Text(
+                text = stringResource(R.string.audio_as_requested),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        // Substitutions are spelled out in words rather than marked with a colour: a pill that
+        // changes shade says nothing to a screen reader, and "shared (asked exclusive)" does.
+        NegotiatedRow(
+            labelRes = R.string.audio_row_sharing,
+            granted = stringResource(granted.sharingMode.labelRes),
+            requested = stringResource(probe.requested.sharingMode.labelRes),
+            asRequested = probe.sharingModeAsRequested
+        )
+        NegotiatedRow(
+            labelRes = R.string.audio_row_performance,
+            granted = stringResource(granted.performanceMode.labelRes),
+            requested = stringResource(probe.requested.performanceMode.labelRes),
+            asRequested = probe.performanceModeAsRequested
+        )
+        if (granted.sampleRate != null) {
+            NegotiatedRow(
+                labelRes = R.string.audio_row_sample_rate,
+                granted = stringResource(R.string.audio_hz, granted.sampleRate),
+                requested = probe.requested.sampleRate?.let { stringResource(R.string.audio_hz, it) }.orEmpty(),
+                asRequested = probe.sampleRateAsRequested
+            )
+        }
+
+        if (granted.format != null) {
+            LabeledValue(
+                label = stringResource(R.string.audio_row_format),
+                value = granted.format,
+                valueStyle = MonitorTypography.machineText
+            )
+        }
+        if (granted.channelCount != null) {
+            LabeledValue(
+                label = stringResource(R.string.audio_row_channels),
+                value = granted.channelCount.toString(),
+                valueStyle = MonitorTypography.machineText
+            )
+        }
+        if (granted.framesPerBurst != null) {
+            LabeledValue(
+                label = stringResource(R.string.audio_row_burst),
+                value = granted.framesPerBurst.toString(),
+                valueStyle = MonitorTypography.machineText
+            )
+        }
+        if (granted.bufferSize != null && granted.bufferCapacity != null) {
+            LabeledValue(
+                label = stringResource(R.string.audio_row_buffer),
+                value = stringResource(R.string.audio_buffer_value, granted.bufferSize, granted.bufferCapacity),
+                valueStyle = MonitorTypography.machineText
+            )
+        }
+        if (granted.deviceId != null) {
+            LabeledValue(
+                label = stringResource(R.string.audio_row_device),
+                value = granted.deviceId.toString(),
+                valueStyle = MonitorTypography.machineText
+            )
+        }
+
+        if (probe.hardware != null) {
+            HardwareBlock(probe.hardware, probe.isResampled, probe.isFormatConverted)
+        }
+    }
+}
+
+/**
+ * A value the system chose, next to the one that was asked for when the two differ.
+ *
+ * When they agree there is nothing to compare, so only the value is shown: repeating the request
+ * on every row would bury the two rows where the system said no.
+ */
+@Composable
+private fun NegotiatedRow(
+    @StringRes labelRes: Int,
+    granted: String,
+    requested: String,
+    asRequested: Boolean,
+    modifier: Modifier = Modifier
+) {
+    LabeledValue(
+        label = stringResource(labelRes),
+        value = if (asRequested) granted else stringResource(R.string.audio_substituted, granted, requested),
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun HardwareBlock(hardware: AudioHardware, isResampled: Boolean, isFormatConverted: Boolean, modifier: Modifier = Modifier) {
+    Text(
+        text = stringResource(R.string.audio_row_hardware),
+        style = MaterialTheme.typography.titleSmall,
+        modifier = modifier.padding(top = Spacing.Small)
+    )
+    if (hardware.sampleRate != null) {
+        LabeledValue(
+            label = stringResource(R.string.audio_row_sample_rate),
+            value = stringResource(R.string.audio_hz, hardware.sampleRate),
+            valueStyle = MonitorTypography.machineText
+        )
+    }
+    if (hardware.channelCount != null) {
+        LabeledValue(
+            label = stringResource(R.string.audio_row_channels),
+            value = hardware.channelCount.toString(),
+            valueStyle = MonitorTypography.machineText
+        )
+    }
+    if (hardware.format != null) {
+        LabeledValue(
+            label = stringResource(R.string.audio_row_format),
+            value = hardware.format,
+            valueStyle = MonitorTypography.machineText
+        )
+    }
+    // A named gap rather than a blank: the hardware has a format, AAudio just has no constant for
+    // it, and that is a different thing from the reading not having been taken.
+    if (hardware.formatUnnameable) {
+        Text(
+            text = stringResource(R.string.audio_format_unnameable),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+    if (isResampled || isFormatConverted) {
+        Row(
+            modifier = Modifier.padding(top = Spacing.ExtraSmall),
+            horizontalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            if (isResampled) MonitorTag(stringResource(R.string.audio_tag_resampled))
+            if (isFormatConverted) MonitorTag(stringResource(R.string.audio_tag_converted))
+        }
+    }
+}
+
+@Composable
+private fun AudioRequest.describe(): String = if (sampleRate != null) {
+    stringResource(
+        R.string.audio_requested_value_rate,
+        stringResource(performanceMode.labelRes),
+        stringResource(sharingMode.labelRes),
+        sampleRate
+    )
+} else {
+    stringResource(
+        R.string.audio_requested_value,
+        stringResource(performanceMode.labelRes),
+        stringResource(sharingMode.labelRes)
+    )
+}
+
+/** The probe labels the native side files its answers under. */
+@get:StringRes
+private val AudioProbe.labelRes: Int
+    get() = when (label) {
+        "low_latency_exclusive" -> R.string.audio_probe_low_latency_exclusive
+        "low_latency_shared" -> R.string.audio_probe_low_latency_shared
+        "default_shared" -> R.string.audio_probe_default_shared
+        "resample_44100" -> R.string.audio_probe_resample
+        else -> R.string.audio_probe_unknown
+    }
+
+@get:StringRes
+private val AudioSharingMode.labelRes: Int
+    get() = when (this) {
+        AudioSharingMode.Exclusive -> R.string.audio_sharing_exclusive
+        AudioSharingMode.Shared -> R.string.audio_sharing_shared
+        AudioSharingMode.Unknown -> R.string.audio_mode_unknown
+    }
+
+@get:StringRes
+private val AudioPerformanceMode.labelRes: Int
+    get() = when (this) {
+        AudioPerformanceMode.LowLatency -> R.string.audio_performance_low_latency
+        AudioPerformanceMode.PowerSaving -> R.string.audio_performance_power_saving
+        AudioPerformanceMode.PowerSavingOffloaded -> R.string.audio_performance_power_saving_offloaded
+        AudioPerformanceMode.None -> R.string.audio_performance_none
+        AudioPerformanceMode.Unknown -> R.string.audio_mode_unknown
+    }
+
+@MonitorPreviews
+@Composable
+private fun AudioPathPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        AudioPathContent(
+            uiState = AudioPathUiState(
+                audio = AudioPathSnapshot(
+                    hardwareQueryAvailable = true,
+                    probes = listOf(
+                        AudioProbe(
+                            label = "low_latency_exclusive",
+                            requested = AudioRequest(AudioPerformanceMode.LowLatency, AudioSharingMode.Exclusive),
+                            opened = true,
+                            granted = AudioGranted(
+                                performanceMode = AudioPerformanceMode.LowLatency,
+                                sharingMode = AudioSharingMode.Shared,
+                                format = "pcm_float",
+                                sampleRate = 48000,
+                                channelCount = 2,
+                                framesPerBurst = 96,
+                                bufferCapacity = 3840,
+                                bufferSize = 192,
+                                deviceId = 3
+                            ),
+                            hardware = AudioHardware(sampleRate = 48000, channelCount = 2, format = "pcm_i16")
+                        ),
+                        AudioProbe(
+                            label = "resample_44100",
+                            requested = AudioRequest(AudioPerformanceMode.LowLatency, AudioSharingMode.Shared, 44100),
+                            opened = true,
+                            granted = AudioGranted(
+                                performanceMode = AudioPerformanceMode.LowLatency,
+                                sharingMode = AudioSharingMode.Shared,
+                                format = "pcm_float",
+                                sampleRate = 44100,
+                                channelCount = 2,
+                                framesPerBurst = 96,
+                                bufferCapacity = 3840,
+                                bufferSize = 192,
+                                deviceId = 3
+                            ),
+                            hardware = AudioHardware(sampleRate = 48000, channelCount = 2, format = "pcm_i16")
+                        )
+                    )
+                ),
+                hasLoaded = true
+            ),
+            onNavigateBack = {},
+            onRefresh = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/AudioPathScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/AudioPathScreen.kt
@@ -138,8 +138,10 @@ private fun AudioPathContent(uiState: AudioPathUiState, onNavigateBack: () -> Un
 private fun ProbeCard(probe: AudioProbe, modifier: Modifier = Modifier) {
     MonitorCard(
         modifier = modifier,
-        // The one place a status is earned: a request the system would not open at all is a
-        // different outcome from one it answered, and StatusRow's wording carries it to TalkBack.
+        // The colour is decoration and nothing more — MonitorCard's status sets the container and
+        // content colours and adds no semantics, so it says nothing to a screen reader. What
+        // carries the refusal is the sentence in the card body, which is why that sentence is
+        // there rather than left to the shade of the card.
         status = if (probe.opened) ReadingStatus.Neutral else ReadingStatus.Warning
     ) {
         Text(

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/VulkanScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/VulkanScreen.kt
@@ -1,0 +1,426 @@
+package com.aoscoremonitor.ui.screens
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.ViewInAr
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.aoscoremonitor.R
+import com.aoscoremonitor.diagnostics.formatBytes
+import com.aoscoremonitor.diagnostics.jni.VulkanDevice
+import com.aoscoremonitor.diagnostics.jni.VulkanDeviceType
+import com.aoscoremonitor.diagnostics.jni.VulkanMemoryHeap
+import com.aoscoremonitor.diagnostics.jni.VulkanQueueFamily
+import com.aoscoremonitor.diagnostics.jni.VulkanSnapshot
+import com.aoscoremonitor.ui.components.ExpandableTextCard
+import com.aoscoremonitor.ui.components.FullScreenMessage
+import com.aoscoremonitor.ui.components.LabeledValue
+import com.aoscoremonitor.ui.components.MonitorCard
+import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.MonitorTag
+import com.aoscoremonitor.ui.components.SectionHeader
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import com.aoscoremonitor.ui.theme.MonitorPreviews
+import com.aoscoremonitor.ui.theme.MonitorTypography
+import com.aoscoremonitor.ui.theme.Spacing
+import com.aoscoremonitor.ui.viewmodel.VulkanUiState
+import com.aoscoremonitor.ui.viewmodel.VulkanViewModel
+
+@Composable
+fun VulkanScreen(onNavigateBack: () -> Unit, modifier: Modifier = Modifier, viewModel: VulkanViewModel = viewModel()) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    VulkanContent(
+        uiState = uiState,
+        onNavigateBack = onNavigateBack,
+        onRefresh = viewModel::refresh,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun VulkanContent(uiState: VulkanUiState, onNavigateBack: () -> Unit, onRefresh: () -> Unit, modifier: Modifier = Modifier) {
+    MonitorScaffold(
+        title = stringResource(R.string.vulkan_title),
+        onNavigateBack = onNavigateBack,
+        modifier = modifier,
+        floatingActionButton = {
+            // Nothing here changes while the app runs, so a new reading has to be asked for.
+            FloatingActionButton(onClick = onRefresh) {
+                Icon(
+                    imageVector = Icons.Default.Refresh,
+                    contentDescription = stringResource(R.string.action_refresh)
+                )
+            }
+        }
+    ) { innerPadding ->
+        val snapshot = uiState.vulkan
+        val message = unavailableMessage(snapshot, uiState.hasLoaded)
+        if (message != null) {
+            FullScreenMessage(
+                message = message,
+                icon = Icons.Default.ViewInAr,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentPadding = PaddingValues(Spacing.Large),
+            verticalArrangement = Arrangement.spacedBy(Spacing.Small)
+        ) {
+            item(key = "summary-header") {
+                SectionHeader(
+                    title = stringResource(R.string.vulkan_summary_section),
+                    subtitle = pluralStringResource(
+                        R.plurals.vulkan_summary,
+                        snapshot!!.devices.size,
+                        snapshot.devices.size,
+                        snapshot.instanceVersion.orEmpty()
+                    ),
+                    icon = Icons.Default.ViewInAr
+                )
+            }
+
+            snapshot!!.devices.forEachIndexed { index, device ->
+                item(key = "device-$index") { DeviceCard(device) }
+                item(key = "memory-$index") { MemoryCard(device) }
+                item(key = "queues-$index") { QueueCard(device) }
+                item(key = "limits-$index") { LimitsCard(device) }
+                if (device.extensions.isNotEmpty()) {
+                    item(key = "extensions-$index") {
+                        ExpandableTextCard(
+                            title = stringResource(R.string.vulkan_extensions_section),
+                            text = device.extensions.joinToString(separator = "\n"),
+                            icon = Icons.Default.ViewInAr,
+                            supportingText = stringResource(
+                                R.string.vulkan_extensions_summary,
+                                device.extensions.size
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * The wording for a screen with nothing to show, or null when there is something.
+ *
+ * Four ways of having no devices, which are four different statements: the app's own library did
+ * not load, the device has no Vulkan loader at all, the loader is there with no driver behind it,
+ * and a driver that started and enumerated nothing. Collapsing them into one "unavailable" would
+ * throw away the only part of the reading that survived.
+ */
+@Composable
+private fun unavailableMessage(snapshot: VulkanSnapshot?, hasLoaded: Boolean): String? = when {
+    snapshot == null && !hasLoaded -> stringResource(R.string.vulkan_loading)
+    snapshot == null -> stringResource(R.string.vulkan_unavailable)
+    !snapshot.loaderPresent -> stringResource(R.string.vulkan_no_loader)
+    !snapshot.instanceCreated && snapshot.instanceError != null ->
+        stringResource(R.string.vulkan_instance_failed, snapshot.instanceError)
+    !snapshot.instanceCreated ->
+        stringResource(R.string.vulkan_instance_failed_code, snapshot.instanceErrorCode ?: 0)
+    snapshot.devices.isEmpty() -> stringResource(R.string.vulkan_no_devices)
+    else -> null
+}
+
+@Composable
+private fun DeviceCard(device: VulkanDevice, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = device.name,
+                style = MaterialTheme.typography.titleMedium,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                // Weighted, so that a long name is ellipsised rather than measured at its full
+                // width: an unweighted child takes the whole row and pushes the tag off the edge,
+                // which is what "Goldfish GFXStream (llvmpipe (LLVM 21.1.4, 128 bits))" did.
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(end = Spacing.Small)
+            )
+            MonitorTag(stringResource(device.type.labelRes))
+        }
+
+        LabeledValue(
+            label = stringResource(R.string.vulkan_device_api),
+            value = device.apiVersion,
+            valueStyle = MonitorTypography.machineText
+        )
+
+        if (device.driverName != null) {
+            LabeledValue(
+                label = stringResource(R.string.vulkan_device_driver),
+                value = device.driverName
+            )
+        }
+        if (device.driverInfo != null) {
+            Text(
+                text = device.driverInfo,
+                style = MonitorTypography.machineText,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        LabeledValue(
+            label = stringResource(R.string.vulkan_device_driver_version),
+            // The packed split beside the number it came from: how a vendor encodes its driver
+            // version is the vendor's business, so only the raw value is certainly right.
+            value = stringResource(
+                R.string.vulkan_device_driver_version_value,
+                device.driverVersion,
+                device.driverVersionRaw
+            ),
+            valueStyle = MonitorTypography.machineText
+        )
+
+        LabeledValue(
+            label = stringResource(R.string.vulkan_device_ids),
+            value = stringResource(R.string.vulkan_device_ids_value, device.vendorId, device.deviceId),
+            valueStyle = MonitorTypography.machineText
+        )
+
+        if (device.conformanceVersion != null) {
+            LabeledValue(
+                label = stringResource(R.string.vulkan_device_conformance),
+                value = device.conformanceVersion,
+                valueStyle = MonitorTypography.machineText
+            )
+        }
+
+        if (device.pipelineCacheUuid != null) {
+            LabeledValue(
+                label = stringResource(R.string.vulkan_device_cache_uuid),
+                value = device.pipelineCacheUuid,
+                valueStyle = MonitorTypography.machineText
+            )
+        }
+
+        // Said rather than left blank: the driver identity query reached core in Vulkan 1.2, so a
+        // 1.1 device is silent here for a reason the screen can name.
+        if (device.driverName == null) {
+            Text(
+                text = stringResource(R.string.vulkan_device_no_driver_properties),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun MemoryCard(device: VulkanDevice, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.vulkan_memory_section),
+            style = MaterialTheme.typography.titleSmall
+        )
+        Text(
+            text = pluralStringResource(
+                R.plurals.vulkan_memory_summary,
+                device.memoryHeaps.size,
+                device.memoryHeaps.size,
+                formatBytes(device.totalMemoryBytes)
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        device.memoryHeaps.forEach { heap -> HeapRow(heap) }
+        Text(
+            text = pluralStringResource(
+                R.plurals.vulkan_memory_types,
+                device.memoryTypes.size,
+                device.memoryTypes.size
+            ),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun HeapRow(heap: VulkanMemoryHeap, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = stringResource(R.string.vulkan_heap, heap.index),
+            style = MonitorTypography.machineText
+        )
+        Row(horizontalArrangement = Arrangement.spacedBy(Spacing.Small)) {
+            if (heap.isDeviceLocal) MonitorTag(stringResource(R.string.vulkan_heap_device_local))
+            Text(
+                text = formatBytes(heap.sizeBytes),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun QueueCard(device: VulkanDevice, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.vulkan_queues_section),
+            style = MaterialTheme.typography.titleSmall
+        )
+        device.queueFamilies.forEach { family -> QueueFamilyRow(family) }
+    }
+}
+
+@Composable
+private fun QueueFamilyRow(family: VulkanQueueFamily, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = Spacing.ExtraSmall),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = stringResource(R.string.vulkan_queue_family, family.index),
+            style = MonitorTypography.machineText
+        )
+        Text(
+            text = pluralStringResource(R.plurals.vulkan_queue_count, family.queueCount, family.queueCount),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+    Row(horizontalArrangement = Arrangement.spacedBy(Spacing.Small)) {
+        if (family.graphics) MonitorTag(stringResource(R.string.vulkan_queue_graphics))
+        if (family.compute) MonitorTag(stringResource(R.string.vulkan_queue_compute))
+        if (family.transfer) MonitorTag(stringResource(R.string.vulkan_queue_transfer))
+        if (family.sparseBinding) MonitorTag(stringResource(R.string.vulkan_queue_sparse))
+        if (family.protectedMemory) MonitorTag(stringResource(R.string.vulkan_queue_protected))
+    }
+}
+
+@Composable
+private fun LimitsCard(device: VulkanDevice, modifier: Modifier = Modifier) {
+    MonitorCard(modifier = modifier) {
+        Text(
+            text = stringResource(R.string.vulkan_limits_section),
+            style = MaterialTheme.typography.titleSmall
+        )
+        // Named here rather than iterated out of the map: the order the native side wrote them in
+        // is not part of the contract, and a raw key is not a label.
+        ShownLimits.forEach { limit ->
+            val value = device.limits[limit.key] ?: return@forEach
+            LabeledValue(
+                label = stringResource(limit.labelRes),
+                value = if (limit.isBytes) formatBytes(value) else value.toString(),
+                valueStyle = MonitorTypography.machineText
+            )
+        }
+    }
+}
+
+/** One limit the screen shows, and whether its number is a byte count or a plain one. */
+private data class ShownLimit(val key: String, @param:StringRes val labelRes: Int, val isBytes: Boolean = false)
+
+private val ShownLimits = listOf(
+    ShownLimit("max_image_dimension_2d", R.string.vulkan_limit_image_2d),
+    ShownLimit("max_bound_descriptor_sets", R.string.vulkan_limit_descriptor_sets),
+    ShownLimit("max_push_constants_size", R.string.vulkan_limit_push_constants, isBytes = true),
+    ShownLimit("max_memory_allocation_count", R.string.vulkan_limit_allocations),
+    ShownLimit("max_compute_shared_memory_size", R.string.vulkan_limit_compute_shared, isBytes = true),
+    ShownLimit("max_compute_work_group_invocations", R.string.vulkan_limit_compute_invocations)
+)
+
+@get:StringRes
+private val VulkanDeviceType.labelRes: Int
+    get() = when (this) {
+        VulkanDeviceType.IntegratedGpu -> R.string.vulkan_type_integrated
+        VulkanDeviceType.DiscreteGpu -> R.string.vulkan_type_discrete
+        VulkanDeviceType.VirtualGpu -> R.string.vulkan_type_virtual
+        VulkanDeviceType.Cpu -> R.string.vulkan_type_cpu
+        VulkanDeviceType.Other -> R.string.vulkan_type_other
+        VulkanDeviceType.Unknown -> R.string.vulkan_type_unknown
+    }
+
+@MonitorPreviews
+@Composable
+private fun VulkanPreview() {
+    AOSCoreMonitorTheme(dynamicColor = false) {
+        VulkanContent(
+            uiState = VulkanUiState(
+                vulkan = VulkanSnapshot(
+                    loaderPresent = true,
+                    instanceVersion = "1.3.275",
+                    instanceCreated = true,
+                    devices = listOf(
+                        VulkanDevice(
+                            name = "Adreno (TM) 740",
+                            type = VulkanDeviceType.IntegratedGpu,
+                            apiVersion = "1.3.275",
+                            driverVersion = "512.780.0",
+                            driverVersionRaw = 2_150_573_056,
+                            vendorId = "0x5143",
+                            deviceId = "0x43050a01",
+                            pipelineCacheUuid = "1d3f5e0a9c4b2761d8e0f3a4b5c60718",
+                            driverId = 8,
+                            driverIdName = "qualcomm_proprietary",
+                            driverName = "Qualcomm Technologies Inc. Adreno Vulkan Driver",
+                            driverInfo = "Vulkan 1.3.275 (Adreno 740)",
+                            conformanceVersion = "1.3.6.3",
+                            limits = mapOf(
+                                "max_image_dimension_2d" to 16_384,
+                                "max_bound_descriptor_sets" to 4,
+                                "max_push_constants_size" to 128,
+                                "max_memory_allocation_count" to 4_294_967_295,
+                                "max_compute_shared_memory_size" to 32_768,
+                                "max_compute_work_group_invocations" to 1_024
+                            ),
+                            memoryHeaps = listOf(
+                                VulkanMemoryHeap(index = 0, sizeBytes = 11_453_246_976, isDeviceLocal = true)
+                            ),
+                            queueFamilies = listOf(
+                                VulkanQueueFamily(
+                                    index = 0,
+                                    queueCount = 3,
+                                    graphics = true,
+                                    compute = true,
+                                    transfer = true,
+                                    timestampBits = 48
+                                )
+                            ),
+                            extensions = listOf("VK_KHR_16bit_storage", "VK_KHR_swapchain")
+                        )
+                    )
+                ),
+                hasLoaded = true
+            ),
+            onNavigateBack = {},
+            onRefresh = {}
+        )
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/VulkanScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/VulkanScreen.kt
@@ -72,8 +72,22 @@ private fun VulkanContent(uiState: VulkanUiState, onNavigateBack: () -> Unit, on
             }
         }
     ) { innerPadding ->
+        // Checked here rather than folded into unavailableMessage, so that the compiler carries the
+        // result: with the null case decided in another function nothing but a `!!` reached the
+        // readings below, and an edit that dropped a branch there would have compiled and thrown.
         val snapshot = uiState.vulkan
-        val message = unavailableMessage(snapshot, uiState.hasLoaded)
+        if (snapshot == null) {
+            FullScreenMessage(
+                message = stringResource(
+                    if (uiState.hasLoaded) R.string.vulkan_unavailable else R.string.vulkan_loading
+                ),
+                icon = Icons.Default.ViewInAr,
+                modifier = Modifier.padding(innerPadding)
+            )
+            return@MonitorScaffold
+        }
+
+        val message = unavailableMessage(snapshot)
         if (message != null) {
             FullScreenMessage(
                 message = message,
@@ -95,7 +109,7 @@ private fun VulkanContent(uiState: VulkanUiState, onNavigateBack: () -> Unit, on
                     title = stringResource(R.string.vulkan_summary_section),
                     subtitle = pluralStringResource(
                         R.plurals.vulkan_summary,
-                        snapshot!!.devices.size,
+                        snapshot.devices.size,
                         snapshot.devices.size,
                         snapshot.instanceVersion.orEmpty()
                     ),
@@ -103,7 +117,7 @@ private fun VulkanContent(uiState: VulkanUiState, onNavigateBack: () -> Unit, on
                 )
             }
 
-            snapshot!!.devices.forEachIndexed { index, device ->
+            snapshot.devices.forEachIndexed { index, device ->
                 item(key = "device-$index") { DeviceCard(device) }
                 item(key = "memory-$index") { MemoryCard(device) }
                 item(key = "queues-$index") { QueueCard(device) }
@@ -127,17 +141,18 @@ private fun VulkanContent(uiState: VulkanUiState, onNavigateBack: () -> Unit, on
 }
 
 /**
- * The wording for a screen with nothing to show, or null when there is something.
+ * The wording for a reading that found no devices, or null when it found some.
  *
- * Four ways of having no devices, which are four different statements: the app's own library did
- * not load, the device has no Vulkan loader at all, the loader is there with no driver behind it,
- * and a driver that started and enumerated nothing. Collapsing them into one "unavailable" would
- * throw away the only part of the reading that survived.
+ * Three ways of having none, which are three different statements: the device has no Vulkan loader
+ * at all, the loader is there with no driver behind it, and a driver that started and enumerated
+ * nothing. Collapsing them into one "unavailable" would throw away the only part of the reading
+ * that survived.
+ *
+ * A snapshot that was never taken is the caller's case, not this one — it is the only branch that
+ * decides whether the rest of the screen can run, so it stays where the compiler can see it.
  */
 @Composable
-private fun unavailableMessage(snapshot: VulkanSnapshot?, hasLoaded: Boolean): String? = when {
-    snapshot == null && !hasLoaded -> stringResource(R.string.vulkan_loading)
-    snapshot == null -> stringResource(R.string.vulkan_unavailable)
+private fun unavailableMessage(snapshot: VulkanSnapshot): String? = when {
     !snapshot.loaderPresent -> stringResource(R.string.vulkan_no_loader)
     !snapshot.instanceCreated && snapshot.instanceError != null ->
         stringResource(R.string.vulkan_instance_failed, snapshot.instanceError)

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/AudioPathViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/AudioPathViewModel.kt
@@ -1,0 +1,48 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.jni.AudioPathSnapshot
+import com.aoscoremonitor.diagnostics.jni.NativeAudioInspector
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class AudioPathUiState(val audio: AudioPathSnapshot? = null, val hasLoaded: Boolean = false, val isRefreshing: Boolean = false)
+
+/**
+ * Opens the four probe streams once, and again when asked.
+ *
+ * This one has a reason to be re-read that the other native screens do not: what the system grants
+ * depends on what else is playing. An exclusive request that comes back shared while music is
+ * running may be granted once the other app lets go, and the refresh is how that becomes visible.
+ *
+ * It does not poll. Opening four streams a second to watch for that would be a stream of open and
+ * close calls against the audio HAL for a reading that changes when the user changes it.
+ */
+class AudioPathViewModel : ViewModel() {
+
+    private val inspector = NativeAudioInspector()
+    private val _uiState = MutableStateFlow(AudioPathUiState())
+    val uiState: StateFlow<AudioPathUiState> = _uiState.asStateFlow()
+
+    private var refreshJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        // Two sets of probe streams open at once would contend for the very exclusive path they
+        // are measuring, so the second tap would read the first one's answer.
+        if (refreshJob?.isActive == true) return
+
+        refreshJob = viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isRefreshing = true)
+            val snapshot = inspector.read()
+            _uiState.value = AudioPathUiState(audio = snapshot, hasLoaded = true, isRefreshing = false)
+        }
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/viewmodel/VulkanViewModel.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/viewmodel/VulkanViewModel.kt
@@ -1,0 +1,46 @@
+package com.aoscoremonitor.ui.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.aoscoremonitor.diagnostics.jni.NativeVulkanInspector
+import com.aoscoremonitor.diagnostics.jni.VulkanSnapshot
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class VulkanUiState(val vulkan: VulkanSnapshot? = null, val hasLoaded: Boolean = false, val isRefreshing: Boolean = false)
+
+/**
+ * Reads the Vulkan device properties once, and again when asked.
+ *
+ * Nothing here changes while the app runs — a physical device's limits and driver are fixed until
+ * the driver itself is replaced — so polling would create and destroy an instance every second to
+ * produce the same answer. The refresh exists for the one case that does change it: a driver
+ * updated underneath a running app through the GPU driver update path.
+ */
+class VulkanViewModel : ViewModel() {
+
+    private val inspector = NativeVulkanInspector()
+    private val _uiState = MutableStateFlow(VulkanUiState())
+    val uiState: StateFlow<VulkanUiState> = _uiState.asStateFlow()
+
+    private var refreshJob: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        // Creating a second instance while the first read is still in flight would have two
+        // coroutines racing their results into the state.
+        if (refreshJob?.isActive == true) return
+
+        refreshJob = viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(isRefreshing = true)
+            val snapshot = inspector.read()
+            _uiState.value = VulkanUiState(vulkan = snapshot, hasLoaded = true, isRefreshing = false)
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="home_group_framework">Android framework</string>
     <string name="home_group_native">This process and the kernel</string>
     <string name="home_group_reach">Storage and network</string>
-    <string name="home_group_display">Display and frames</string>
+    <string name="home_group_display">Display, frames and the GPU</string>
     <string name="destination_system_info">System Info</string>
     <string name="destination_logs">System Logs</string>
     <string name="destination_diagnostics">Diagnostics</string>
@@ -39,6 +39,7 @@
     <string name="destination_credentials">Credentials</string>
     <string name="destination_display">Display</string>
     <string name="destination_frames">Frame Pacing</string>
+    <string name="destination_vulkan">Vulkan</string>
 
     <!-- System logs -->
     <string name="logs_title">System Logs</string>
@@ -574,4 +575,64 @@
     <string name="frames_presentation_deadline">Presentation deadline</string>
     <string name="frames_millis">%1$.2f ms</string>
     <string name="frames_seconds">%1$.1f s</string>
+
+    <!-- Vulkan -->
+    <string name="vulkan_title">Vulkan</string>
+    <string name="vulkan_loading">Asking the Vulkan loader what this device has…</string>
+    <string name="vulkan_unavailable">The native library did not load, so Vulkan cannot be asked.</string>
+    <string name="vulkan_no_loader">This device has no Vulkan loader, so there is nothing to ask.</string>
+    <string name="vulkan_instance_failed">The loader is here, but no Vulkan instance could be created: %1$s.</string>
+    <string name="vulkan_instance_failed_code">The loader is here, but no Vulkan instance could be created (VkResult %1$d).</string>
+    <string name="vulkan_no_devices">A Vulkan instance was created and reported no physical devices.</string>
+    <string name="vulkan_summary_section">Physical devices</string>
+    <plurals name="vulkan_summary">
+        <item quantity="one">%1$d device · instance %2$s</item>
+        <item quantity="other">%1$d devices · instance %2$s</item>
+    </plurals>
+    <string name="vulkan_device_api">API version</string>
+    <string name="vulkan_device_driver">Driver</string>
+    <string name="vulkan_device_driver_version">Driver version</string>
+    <string name="vulkan_device_driver_version_value">%1$s · raw %2$d</string>
+    <string name="vulkan_device_ids">Vendor · Device</string>
+    <string name="vulkan_device_ids_value">%1$s · %2$s</string>
+    <string name="vulkan_device_conformance">Conformance</string>
+    <string name="vulkan_device_cache_uuid">Pipeline cache UUID</string>
+    <string name="vulkan_device_no_driver_properties">This device implements Vulkan 1.1, which predates the query that names a driver.</string>
+    <string name="vulkan_type_integrated">Integrated GPU</string>
+    <string name="vulkan_type_discrete">Discrete GPU</string>
+    <string name="vulkan_type_virtual">Virtual GPU</string>
+    <string name="vulkan_type_cpu">CPU</string>
+    <string name="vulkan_type_other">Other</string>
+    <string name="vulkan_type_unknown">Unnamed type</string>
+    <string name="vulkan_memory_section">Memory heaps</string>
+    <plurals name="vulkan_memory_summary">
+        <item quantity="one">%1$d heap · %2$s in total</item>
+        <item quantity="other">%1$d heaps · %2$s in total</item>
+    </plurals>
+    <string name="vulkan_heap">Heap %1$d</string>
+    <string name="vulkan_heap_device_local">device local</string>
+    <plurals name="vulkan_memory_types">
+        <item quantity="one">%1$d memory type</item>
+        <item quantity="other">%1$d memory types</item>
+    </plurals>
+    <string name="vulkan_queues_section">Queue families</string>
+    <string name="vulkan_queue_family">Family %1$d</string>
+    <plurals name="vulkan_queue_count">
+        <item quantity="one">%1$d queue</item>
+        <item quantity="other">%1$d queues</item>
+    </plurals>
+    <string name="vulkan_queue_graphics">graphics</string>
+    <string name="vulkan_queue_compute">compute</string>
+    <string name="vulkan_queue_transfer">transfer</string>
+    <string name="vulkan_queue_sparse">sparse</string>
+    <string name="vulkan_queue_protected">protected</string>
+    <string name="vulkan_limits_section">Limits</string>
+    <string name="vulkan_limit_image_2d">Max 2D image</string>
+    <string name="vulkan_limit_descriptor_sets">Bound descriptor sets</string>
+    <string name="vulkan_limit_push_constants">Push constants</string>
+    <string name="vulkan_limit_allocations">Memory allocations</string>
+    <string name="vulkan_limit_compute_shared">Compute shared memory</string>
+    <string name="vulkan_limit_compute_invocations">Compute invocations</string>
+    <string name="vulkan_extensions_section">Device extensions</string>
+    <string name="vulkan_extensions_summary">%1$d supported by this device</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="home_group_native">This process and the kernel</string>
     <string name="home_group_reach">Storage and network</string>
     <string name="home_group_display">Display, frames and the GPU</string>
+    <string name="home_group_audio">Audio</string>
     <string name="destination_system_info">System Info</string>
     <string name="destination_logs">System Logs</string>
     <string name="destination_diagnostics">Diagnostics</string>
@@ -40,6 +41,7 @@
     <string name="destination_display">Display</string>
     <string name="destination_frames">Frame Pacing</string>
     <string name="destination_vulkan">Vulkan</string>
+    <string name="destination_audio">Audio Path</string>
 
     <!-- System logs -->
     <string name="logs_title">System Logs</string>
@@ -635,4 +637,49 @@
     <string name="vulkan_limit_compute_invocations">Compute invocations</string>
     <string name="vulkan_extensions_section">Device extensions</string>
     <string name="vulkan_extensions_summary">%1$d supported by this device</string>
+
+    <!-- Audio path -->
+    <string name="audio_title">Audio Path</string>
+    <string name="audio_loading">Opening probe streams…</string>
+    <string name="audio_unavailable">The native library did not load, so the audio path cannot be asked.</string>
+    <string name="audio_no_probes">No probe answered, which cannot happen on a device with an audio HAL.</string>
+    <string name="audio_summary_section">Requested against granted</string>
+    <plurals name="audio_summary">
+        <item quantity="one">%1$d request put to the audio system</item>
+        <item quantity="other">%1$d requests put to the audio system</item>
+    </plurals>
+    <string name="audio_no_playback_note">Each probe opens an output stream and closes it without ever starting it, so nothing is played and no audio focus is taken. That is also why there is no underrun count here: it means nothing on a stream that never ran.</string>
+    <string name="audio_hardware_unavailable_note">This device is on API 33, where AAudio does not report what the hardware underneath runs at. The stream\'s own numbers are still shown.</string>
+    <string name="audio_probe_low_latency_exclusive">Low latency, exclusive</string>
+    <string name="audio_probe_low_latency_shared">Low latency, shared</string>
+    <string name="audio_probe_default_shared">Default, shared</string>
+    <string name="audio_probe_resample">44.1 kHz, against whatever the hardware runs at</string>
+    <string name="audio_probe_unknown">Unnamed probe</string>
+    <string name="audio_requested">Asked for</string>
+    <string name="audio_requested_value">%1$s · %2$s</string>
+    <string name="audio_requested_value_rate">%1$s · %2$s · %3$d Hz</string>
+    <string name="audio_as_requested">Granted as asked.</string>
+    <string name="audio_refused">The system would not open this request.</string>
+    <string name="audio_substituted">%1$s (asked %2$s)</string>
+    <string name="audio_row_sharing">Sharing mode</string>
+    <string name="audio_row_performance">Performance mode</string>
+    <string name="audio_row_sample_rate">Sample rate</string>
+    <string name="audio_row_channels">Channels</string>
+    <string name="audio_row_format">Format</string>
+    <string name="audio_row_burst">Frames per burst</string>
+    <string name="audio_row_buffer">Buffer</string>
+    <string name="audio_row_device">Output device</string>
+    <string name="audio_row_hardware">Hardware underneath</string>
+    <string name="audio_hz">%1$d Hz</string>
+    <string name="audio_buffer_value">%1$d of %2$d frames</string>
+    <string name="audio_sharing_exclusive">exclusive</string>
+    <string name="audio_sharing_shared">shared</string>
+    <string name="audio_performance_low_latency">low latency</string>
+    <string name="audio_performance_power_saving">power saving</string>
+    <string name="audio_performance_power_saving_offloaded">power saving, offloaded</string>
+    <string name="audio_performance_none">none</string>
+    <string name="audio_mode_unknown">unnamed</string>
+    <string name="audio_format_unnameable">AAudio has no name for the format this hardware runs, so whether the samples are converted on the way cannot be said from here.</string>
+    <string name="audio_tag_resampled">resampled</string>
+    <string name="audio_tag_converted">format converted</string>
 </resources>

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/AudioPathParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/AudioPathParsingTest.kt
@@ -1,0 +1,224 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AudioPathParsingTest {
+
+    @Test
+    fun readsARequestAndTheTwoAnswersToIt() {
+        val snapshot = parseAudioPath(
+            """
+            {"hardware_query_available":true,"probes":[
+              {"label":"low_latency_shared",
+               "requested":{"performance_mode":"low_latency","sharing_mode":"shared"},
+               "open_ok":true,
+               "granted":{"performance_mode":"low_latency","sharing_mode":"shared",
+                          "format":"pcm_float","sample_rate":48000,"channel_count":2,
+                          "frames_per_burst":96,"buffer_capacity":3840,"buffer_size":192,
+                          "device_id":3},
+               "hardware":{"sample_rate":48000,"channel_count":2,"format":"pcm_i16"}}]}
+            """.trimIndent()
+        )
+
+        assertTrue(snapshot.hardwareQueryAvailable)
+        val probe = snapshot.probes.single()
+        assertTrue(probe.opened)
+        assertEquals(AudioPerformanceMode.LowLatency, probe.requested.performanceMode)
+        assertEquals(96, probe.granted?.framesPerBurst)
+        assertEquals(48000, probe.hardware?.sampleRate)
+        assertTrue(probe.grantedAsRequested)
+    }
+
+    /**
+     * An exclusive request that comes back shared is the reading, not a parse failure.
+     *
+     * This is the case the screen exists for: nothing in the Java API can say that the MMAP path
+     * was asked for and refused, because nothing in it can ask.
+     */
+    @Test
+    fun anExclusiveRequestGrantedAsSharedIsRecordedAsASubstitution() {
+        val snapshot = parseAudioPath(
+            """
+            {"probes":[
+              {"label":"low_latency_exclusive",
+               "requested":{"performance_mode":"low_latency","sharing_mode":"exclusive"},
+               "open_ok":true,
+               "granted":{"performance_mode":"low_latency","sharing_mode":"shared",
+                          "format":"pcm_float","sample_rate":48000}}]}
+            """.trimIndent()
+        )
+
+        val probe = snapshot.probes.single()
+        assertEquals(AudioSharingMode.Exclusive, probe.requested.sharingMode)
+        assertEquals(AudioSharingMode.Shared, probe.granted?.sharingMode)
+        assertFalse(probe.sharingModeAsRequested)
+        assertTrue(probe.performanceModeAsRequested)
+        assertFalse(probe.grantedAsRequested)
+    }
+
+    @Test
+    fun aStreamRateThatDiffersFromTheHardwareIsAResampler() {
+        val snapshot = parseAudioPath(
+            """
+            {"hardware_query_available":true,"probes":[
+              {"label":"resample_44100",
+               "requested":{"performance_mode":"low_latency","sharing_mode":"shared","sample_rate":44100},
+               "open_ok":true,
+               "granted":{"performance_mode":"low_latency","sharing_mode":"shared",
+                          "format":"pcm_float","sample_rate":44100},
+               "hardware":{"sample_rate":48000,"format":"pcm_i16"}}]}
+            """.trimIndent()
+        )
+
+        val probe = snapshot.probes.single()
+        assertTrue(probe.isResampled)
+        assertTrue(probe.isFormatConverted)
+        // The rate was granted exactly as asked. That it does not match the hardware is a separate
+        // statement, and conflating the two would report the request as refused.
+        assertTrue(probe.sampleRateAsRequested)
+        assertTrue(probe.grantedAsRequested)
+    }
+
+    @Test
+    fun aStreamThatMatchesItsHardwareIsNotResampled() {
+        val snapshot = parseAudioPath(
+            """
+            {"hardware_query_available":true,"probes":[
+              {"label":"default_shared","requested":{"performance_mode":"none","sharing_mode":"shared"},
+               "open_ok":true,
+               "granted":{"performance_mode":"none","sharing_mode":"shared","format":"pcm_i16",
+                          "sample_rate":48000},
+               "hardware":{"sample_rate":48000,"format":"pcm_i16"}}]}
+            """.trimIndent()
+        )
+
+        val probe = snapshot.probes.single()
+        assertFalse(probe.isResampled)
+        assertFalse(probe.isFormatConverted)
+    }
+
+    /**
+     * A format AAudio would not name is not evidence of a conversion.
+     *
+     * `AAudioStream_getHardwareFormat` answers `AAUDIO_FORMAT_INVALID` when the hardware runs
+     * something the API has no constant for. Carried across as a token it would compare unequal to
+     * the stream's own format and the screen would report a conversion nobody observed, which is
+     * the one thing this app is built not to do. The native side leaves the key out instead and
+     * says why separately.
+     */
+    @Test
+    fun anUnnameableHardwareFormatIsNotReportedAsAConversion() {
+        val snapshot = parseAudioPath(
+            """
+            {"hardware_query_available":true,"probes":[
+              {"label":"default_shared","requested":{"performance_mode":"none","sharing_mode":"shared"},
+               "open_ok":true,
+               "granted":{"performance_mode":"none","sharing_mode":"shared","format":"pcm_float",
+                          "sample_rate":48000},
+               "hardware":{"sample_rate":48000,"format_unnameable":true}}]}
+            """.trimIndent()
+        )
+
+        val probe = snapshot.probes.single()
+        assertNull("An unnameable format must not arrive as a format", probe.hardware?.format)
+        assertTrue(probe.hardware?.formatUnnameable == true)
+        assertFalse("Claimed a conversion it did not observe", probe.isFormatConverted)
+        // The rate was still read, and it matches, so nothing is claimed there either.
+        assertFalse(probe.isResampled)
+    }
+
+    /** The same on the stream's own side: no format read means no comparison to make. */
+    @Test
+    fun aStreamWithoutAReadableFormatIsNotReportedAsAConversion() {
+        val snapshot = parseAudioPath(
+            """
+            {"hardware_query_available":true,"probes":[
+              {"label":"default_shared","requested":{"performance_mode":"none","sharing_mode":"shared"},
+               "open_ok":true,
+               "granted":{"performance_mode":"none","sharing_mode":"shared","sample_rate":48000},
+               "hardware":{"sample_rate":48000,"format":"pcm_i16"}}]}
+            """.trimIndent()
+        )
+
+        val probe = snapshot.probes.single()
+        assertNull(probe.granted?.format)
+        assertFalse(probe.isFormatConverted)
+    }
+
+    @Test
+    fun aRefusedRequestCarriesTheReasonAndNoReadings() {
+        val snapshot = parseAudioPath(
+            """
+            {"probes":[
+              {"label":"low_latency_exclusive",
+               "requested":{"performance_mode":"low_latency","sharing_mode":"exclusive"},
+               "open_ok":false,"open_error":"AAUDIO_ERROR_INVALID_STATE"}]}
+            """.trimIndent()
+        )
+
+        val probe = snapshot.probes.single()
+        assertFalse(probe.opened)
+        assertEquals("AAUDIO_ERROR_INVALID_STATE", probe.openError)
+        assertNull(probe.granted)
+        assertNull(probe.hardware)
+        assertFalse(probe.grantedAsRequested)
+        // Nothing to compare against, so a refusal must not read as a resampled path.
+        assertFalse(probe.isResampled)
+    }
+
+    /** Below API 34 the hardware readings do not exist, which is not the same as matching. */
+    @Test
+    fun withoutTheHardwareQueryNothingIsClaimedAboutConversion() {
+        val snapshot = parseAudioPath(
+            """
+            {"hardware_query_available":false,"probes":[
+              {"label":"default_shared","requested":{"performance_mode":"none","sharing_mode":"shared"},
+               "open_ok":true,
+               "granted":{"performance_mode":"none","sharing_mode":"shared","format":"pcm_float",
+                          "sample_rate":48000}}]}
+            """.trimIndent()
+        )
+
+        val probe = snapshot.probes.single()
+        assertFalse(snapshot.hardwareQueryAvailable)
+        assertNull(probe.hardware)
+        assertFalse(probe.isResampled)
+        assertFalse(probe.isFormatConverted)
+    }
+
+    @Test
+    fun aRateLeftToTheSystemIsGrantedByDefinition() {
+        val snapshot = parseAudioPath(
+            """
+            {"probes":[
+              {"label":"default_shared","requested":{"performance_mode":"none","sharing_mode":"shared"},
+               "open_ok":true,
+               "granted":{"performance_mode":"none","sharing_mode":"shared","format":"pcm_float",
+                          "sample_rate":48000}}]}
+            """.trimIndent()
+        )
+
+        val probe = snapshot.probes.single()
+        assertNull(probe.requested.sampleRate)
+        assertTrue(probe.sampleRateAsRequested)
+    }
+
+    @Test
+    fun anUnnamedModeIsUnknownRatherThanAGuess() {
+        val snapshot = parseAudioPath(
+            """
+            {"probes":[
+              {"label":"x","requested":{"performance_mode":"turbo","sharing_mode":"borrowed"},
+               "open_ok":false}]}
+            """.trimIndent()
+        )
+
+        val probe = snapshot.probes.single()
+        assertEquals(AudioPerformanceMode.Unknown, probe.requested.performanceMode)
+        assertEquals(AudioSharingMode.Unknown, probe.requested.sharingMode)
+    }
+}

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/VulkanParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/VulkanParsingTest.kt
@@ -1,0 +1,167 @@
+package com.aoscoremonitor.diagnostics.jni
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VulkanParsingTest {
+
+    @Test
+    fun readsADeviceAndItsDriver() {
+        val snapshot = parseVulkan(
+            """
+            {"loader_present":true,"instance_version":"1.3.275","instance_ok":true,"devices":[
+              {"name":"Adreno (TM) 740","type":"integrated_gpu","api_version":"1.3.275",
+               "vendor_id":"0x5143","device_id":"0x43050a01",
+               "driver_version_raw":2150573056,"driver_version":"512.780.0",
+               "pipeline_cache_uuid":"1d3f5e0a9c4b2761",
+               "driver_id":8,"driver_id_name":"qualcomm_proprietary",
+               "driver_name":"Qualcomm Adreno Vulkan Driver","driver_info":"Vulkan 1.3.275",
+               "conformance_version":"1.3.6.3"}]}
+            """.trimIndent()
+        )
+
+        assertTrue(snapshot.loaderPresent)
+        assertTrue(snapshot.instanceCreated)
+        assertEquals("1.3.275", snapshot.instanceVersion)
+
+        val device = snapshot.devices.single()
+        assertEquals("Adreno (TM) 740", device.name)
+        assertEquals(VulkanDeviceType.IntegratedGpu, device.type)
+        assertEquals("qualcomm_proprietary", device.driverIdName)
+        assertEquals(8, device.driverId)
+        assertEquals("1.3.6.3", device.conformanceVersion)
+        // The raw number survives the trip: it is the only part of the driver version that is
+        // certainly right, since the packing is the vendor's own.
+        assertEquals(2_150_573_056L, device.driverVersionRaw)
+        assertEquals("512.780.0", device.driverVersion)
+    }
+
+    /** A 1.1 device answers the properties query and says nothing about its driver. */
+    @Test
+    fun aDeviceWithoutDriverPropertiesReportsNoneRatherThanAnEmptyString() {
+        val snapshot = parseVulkan(
+            """
+            {"loader_present":true,"instance_ok":true,"devices":[
+              {"name":"Mali-G78","type":"integrated_gpu","api_version":"1.1.128",
+               "vendor_id":"0x13b5","device_id":"0x70930000",
+               "driver_version_raw":1,"driver_version":"0.0.1"}]}
+            """.trimIndent()
+        )
+
+        val device = snapshot.devices.single()
+        assertNull(device.driverIdName)
+        assertNull(device.driverId)
+        assertNull(device.driverName)
+        assertNull(device.conformanceVersion)
+    }
+
+    @Test
+    fun readsHeapsTypesAndQueueFamilies() {
+        val snapshot = parseVulkan(
+            """
+            {"loader_present":true,"instance_ok":true,"devices":[
+              {"name":"g","type":"integrated_gpu","api_version":"1.3.0","vendor_id":"0x1",
+               "device_id":"0x2","driver_version_raw":1,"driver_version":"0.0.1",
+               "memory_heaps":[{"index":0,"size_bytes":1024,"device_local":true},
+                               {"index":1,"size_bytes":512,"device_local":false}],
+               "memory_types":[{"index":0,"heap":0,"device_local":true,"host_visible":false}],
+               "queue_families":[{"index":0,"count":3,"graphics":true,"compute":true,
+                                  "transfer":true,"timestamp_bits":48}]}]}
+            """.trimIndent()
+        )
+
+        val device = snapshot.devices.single()
+        assertEquals(1536L, device.totalMemoryBytes)
+        assertEquals(listOf(true, false), device.memoryHeaps.map { it.isDeviceLocal })
+        assertEquals(1, device.memoryTypes.size)
+        assertFalse(device.memoryTypes.single().isHostVisible)
+
+        val family = device.queueFamilies.single()
+        assertEquals(3, family.queueCount)
+        assertEquals(48, family.timestampBits)
+        assertTrue(family.graphics && family.compute && family.transfer)
+        assertFalse(family.sparseBinding)
+    }
+
+    @Test
+    fun extensionsArriveSorted() {
+        val snapshot = parseVulkan(
+            """
+            {"loader_present":true,"instance_ok":true,"devices":[
+              {"name":"g","type":"cpu","api_version":"1.0.0","vendor_id":"0x1","device_id":"0x2",
+               "driver_version_raw":1,"driver_version":"0.0.1",
+               "extensions":["VK_KHR_swapchain","VK_EXT_debug_marker","VK_KHR_16bit_storage"]}]}
+            """.trimIndent()
+        )
+
+        assertEquals(
+            listOf("VK_EXT_debug_marker", "VK_KHR_16bit_storage", "VK_KHR_swapchain"),
+            snapshot.devices.single().extensions
+        )
+    }
+
+    /**
+     * The three ways of having no devices stay apart.
+     *
+     * A device with no loader, a loader with no driver behind it and a driver that enumerated
+     * nothing are different statements, and the screen words each of them differently. A parser
+     * that flattened them into an empty list would leave it nothing to say.
+     */
+    @Test
+    fun aDeviceWithNoLoaderSaysSoRatherThanReportingNoDevices() {
+        val snapshot = parseVulkan("""{"loader_present":false}""")
+
+        assertFalse(snapshot.loaderPresent)
+        assertFalse(snapshot.instanceCreated)
+        assertTrue(snapshot.devices.isEmpty())
+        assertNull(snapshot.instanceVersion)
+    }
+
+    @Test
+    fun aFailedInstanceCarriesTheResultThatStoppedIt() {
+        val snapshot = parseVulkan(
+            """{"loader_present":true,"instance_version":"1.1.0","instance_ok":false,
+                "instance_error":"incompatible_driver"}"""
+        )
+
+        assertTrue(snapshot.loaderPresent)
+        assertFalse(snapshot.instanceCreated)
+        assertEquals("incompatible_driver", snapshot.instanceError)
+        assertNull(snapshot.instanceErrorCode)
+    }
+
+    /** A result this app has no name for crosses as its number rather than as a wrong name. */
+    @Test
+    fun anUnnamedResultCarriesItsCode() {
+        val snapshot = parseVulkan(
+            """{"loader_present":true,"instance_ok":false,"instance_error_code":-13}"""
+        )
+
+        assertNull(snapshot.instanceError)
+        assertEquals(-13, snapshot.instanceErrorCode)
+    }
+
+    @Test
+    fun anInstanceThatEnumeratedNothingIsNotAFailure() {
+        val snapshot = parseVulkan("""{"loader_present":true,"instance_ok":true,"devices":[]}""")
+
+        assertTrue(snapshot.instanceCreated)
+        assertTrue(snapshot.devices.isEmpty())
+    }
+
+    @Test
+    fun anUnnamedDeviceTypeIsUnknownRatherThanAGuess() {
+        val snapshot = parseVulkan(
+            """
+            {"loader_present":true,"instance_ok":true,"devices":[
+              {"name":"g","type":"quantum_gpu","api_version":"1.3.0","vendor_id":"0x1",
+               "device_id":"0x2","driver_version_raw":1,"driver_version":"0.0.1"}]}
+            """.trimIndent()
+        )
+
+        assertEquals(VulkanDeviceType.Unknown, snapshot.devices.single().type)
+    }
+}


### PR DESCRIPTION
## What this adds

**Vulkan** — physical device properties: driver identity, memory heaps, queue
families, device extensions. Vulkan is a C API with no Java binding on Android,
so none of this is reachable from the framework — the nearest Java equivalent is
the GLES renderer string.

**Audio Path** — opens four output streams with different requests and reports
what the system granted against what was asked: whether the exclusive MMAP path
is on offer, the burst size the stream actually settled on, and what the
hardware underneath runs at (`AAudioStream_getHardwareSampleRate`, API 34),
which nothing in the framework reports.

## Worth a look during review

- **libvulkan is `dlopen`ed, libaaudio is linked.** The Vulkan loader is only
  present where a GPU driver is, so linking it would take the whole of
  `libsystem_monitor` down — and every other native screen with it — on a device
  without one. libaaudio has shipped since API 26, so there is no such device to
  guard against.
- **`__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__` is scoped to `audio_path.cpp`.**
  The three hardware readings are API 34 against a minSdk of 33; without it the
  NDK marks them `strict` and a `__builtin_available` guard does not compile.
  Library-wide, it would let a later file link a weak symbol unnoticed.
- **Audio Path opens streams and never starts them.** Nothing is played and no
  audio focus is taken. The cost is the underrun count and the latency, which
  mean nothing on a stream that never ran — the screen says so rather than
  leaving the gap unexplained.
- **New "Audio" home group, one tile.** Filing it under the display readings or
  the process readings would say something untrue about it to even out the grid.
- No new permissions. The version script needed no change: both JNI names match
  the package wildcard it already exports.

## Verification

- `assembleDebug` across all four ABIs with `-Werror`
- `testDebugUnitTest` — 19 new parser tests (9 Vulkan, 10 Audio Path)
- `connectedDebugAndroidTest` — 15 collector tests pass on a Pixel 10 Pro AVD,
  four of them new, including a leak check that reads the audio probes
  repeatedly and fails if later reads open fewer streams
- `ktlintCheck`, `lint`, `scripts/format.sh --check`
- Both screens read on a device; the emulator's exclusive request comes back
  shared and the 44.1 kHz probe shows a resampler, which is what they are for