### PR TITLE
fix: Correct the Vulkan and audio collectors, and show what they already read

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Comprehensive monitoring software for deeply understanding the internal structure of AOS. Because sometimes you need to know what your Android system is secretly plotting.
 
-Twenty-one screens, each with one subject. Everything shown is measured on the device — where a reading cannot be taken, the screen says which reading and why, rather than filling the gap with a plausible number.
+Twenty-one screens, each with one subject. Device readings are kept distinct from built-in sample data: when the app cannot reach a source and shows an example instead, the screen labels it as sample data and says which source was unavailable.
 
 ## What it inspects
 
@@ -30,12 +30,12 @@ Audio Path is the one that asks rather than reads. It opens four output streams 
 | CMake | 3.31.6 |
 | C++ | 23 |
 
-The NDK and CMake versions are pinned rather than preferred: earlier NDKs align a library's load segments for a 4 KB page, which cannot be mapped on the 16 KB-page devices Android 15 introduced, and AGP's bundled CMake 3.22.1 has no flag mapping for C++23.
+The NDK and CMake versions are pinned so local and CI builds use the same native toolchain. NDK r28 and newer produce 16 KB-aligned native libraries by default; this project uses r29. CMake 3.20 and newer support C++23, and the project currently declares and pins 3.31.6.
 
 ```bash
 ./gradlew assembleDebug          # app plus the native library, for all four ABIs
 ./gradlew testDebugUnitTest      # parsers and arithmetic, off-device
-./gradlew connectedDebugAndroidTest   # needs a device: runs every native collector for real
+./gradlew connectedDebugAndroidTest   # needs a device: instrumented UI and JNI collector tests
 ./gradlew lint
 ```
 

--- a/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
+++ b/app/src/androidTest/java/com/aoscoremonitor/diagnostics/jni/NativeInspectorTest.kt
@@ -8,6 +8,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -210,9 +211,9 @@ class NativeInspectorTest {
      * The instance is destroyed and the loader survives being reopened.
      *
      * Drivers cap how many live instances a process may hold, so a collector that leaked one would
-     * pass once and then fail — which is exactly what the screen's refresh does. This also covers
-     * the dlclose: closing the loader while the driver still held threads would crash here rather
-     * than in front of a user.
+     * pass once and then fail — which is exactly what the screen's refresh does. It also exercises
+     * the loader across readings: a collector that unloaded libvulkan between them would crash here,
+     * on a thread the driver owns, rather than in front of a user.
      */
     @Test
     fun vulkanInspectorCanBeReadRepeatedly() = runBlocking {
@@ -264,6 +265,12 @@ class NativeInspectorTest {
      * AAudio caps how many streams a process may hold open, so a collector that forgot to close
      * them would pass once and then start reporting refusals — which is what the screen's refresh
      * would do to it. Four readings is more than the cap allows to be leaked.
+     *
+     * One probe rather than the count of all four. What the system grants is not device-constant:
+     * another app taking the exclusive MMAP path between two readings legitimately turns a granted
+     * exclusive stream into a refused one, and a test that counted every probe would call that a
+     * leak. The ordinary shared path is the one a device with a working audio HAL always grants, and
+     * a leak is exactly what would stop it.
      */
     @Test
     fun audioProbeStreamsAreClosedBetweenReadings() = runBlocking {
@@ -271,12 +278,26 @@ class NativeInspectorTest {
         val opened = (1..4).map { reading ->
             val snapshot = inspector.read()
             assertNotNull("Reading $reading came back empty", snapshot)
-            snapshot!!.probes.count { it.opened }
+            val probe = snapshot!!.probes.find { it.label == ORDINARY_PROBE }
+            assertNotNull("Reading $reading did not put the $ORDINARY_PROBE request at all", probe)
+            probe!!.opened
         }
 
-        assertTrue(
-            "Later readings opened fewer streams than the first, which is what a leak looks like: $opened",
-            opened.last() >= opened.first()
+        // Skipped rather than passed on a device that grants nothing: with every reading refused the
+        // comparison below holds for a collector that leaks every stream it opens, and a test that
+        // reports success for proving nothing is worse than one that says it did not run.
+        assumeTrue(
+            "This device does not grant the ordinary shared path at all, so a leak would not show here",
+            opened.first()
         )
+        assertTrue(
+            "The ordinary shared stream stopped opening across repeated readings, which is what a leak looks like: $opened",
+            opened.all { it }
+        )
+    }
+
+    private companion object {
+        /** The probe that any device with an audio HAL grants, whatever else is playing. */
+        const val ORDINARY_PROBE = "default_shared"
     }
 }

--- a/app/src/androidTest/java/com/aoscoremonitor/ui/components/RefreshFabTest.kt
+++ b/app/src/androidTest/java/com/aoscoremonitor/ui/components/RefreshFabTest.kt
@@ -1,0 +1,63 @@
+package com.aoscoremonitor.ui.components
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.aoscoremonitor.R
+import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Checks that a reading in flight reaches a screen reader, not only the eye.
+ *
+ * The screens using this button do not poll, so a tap is the only way to a new reading — and the
+ * readings take about a second, during which the view model drops further taps. Swapping the icon
+ * for a spinner says so to a sighted user and to nobody else: `FloatingActionButton` has no enabled
+ * parameter, so without the `disabled` semantics TalkBack and Switch Access go on offering a button
+ * that silently does nothing.
+ */
+@RunWith(AndroidJUnit4::class)
+class RefreshFabTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun aRefreshInFlightIsOfferedAsDisabledAndTakesNoTaps() {
+        var taps = 0
+        composeRule.setContent {
+            AOSCoreMonitorTheme(dynamicColor = false) {
+                RefreshFab(onRefresh = { taps++ }, isRefreshing = true)
+            }
+        }
+
+        val button = composeRule.onNodeWithContentDescription(string(R.string.action_refreshing))
+        button.assertIsNotEnabled()
+        button.performClick()
+        assertEquals("A refresh already in flight must not start another", 0, taps)
+    }
+
+    @Test
+    fun anIdleButtonIsOfferedAndAsksForAReading() {
+        var taps = 0
+        composeRule.setContent {
+            AOSCoreMonitorTheme(dynamicColor = false) {
+                RefreshFab(onRefresh = { taps++ }, isRefreshing = false)
+            }
+        }
+
+        val button = composeRule.onNodeWithContentDescription(string(R.string.action_refresh))
+        button.assertIsEnabled()
+        button.performClick()
+        assertEquals(1, taps)
+    }
+
+    private fun string(id: Int): String = InstrumentationRegistry.getInstrumentation().targetContext.getString(id)
+}

--- a/app/src/main/cpp/vulkan_info.cpp
+++ b/app/src/main/cpp/vulkan_info.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -47,29 +48,24 @@ template <typename Fn>
 }
 
 /**
- * Holds the loader open for as long as anything fetched from it is in use.
+ * The Vulkan loader, opened once and left open for the life of the process.
  *
  * dlopen rather than a link against libvulkan: linking would make the whole of
  * libsystem_monitor.so fail to load on a device with no Vulkan loader, and with it every other
  * native reading in this app. Opening it here costs one failed dlopen on such a device and lets
  * the screen say so.
+ *
+ * Never closed, which is the ordinary practice for a graphics driver on Android. A driver starts
+ * helper threads and registers pthread_key destructors of its own while an instance exists, and
+ * several do not take them down with the instance; dropping the last reference would unmap the
+ * driver underneath them, and the crash would land on a thread this app does not own — after the
+ * screen had finished loading, or on the next refresh. The cost of keeping it is one mapping in a
+ * process that has already asked for Vulkan once.
  */
-class Loader {
-public:
-    Loader() : handle_(dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL)) {}
-    ~Loader() {
-        if (handle_ != nullptr) {
-            dlclose(handle_);
-        }
-    }
-    Loader(const Loader&) = delete;
-    Loader& operator=(const Loader&) = delete;
-
-    [[nodiscard]] void* get() const { return handle_; }
-
-private:
-    void* handle_;
-};
+void* Loader() {
+    static void* const handle = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+    return handle;
+}
 
 /** Destroys the instance however the scope is left, exception included. */
 class ScopedInstance {
@@ -275,39 +271,95 @@ void WriteLimits(JsonWriter* writer, const VkPhysicalDeviceLimits& limits) {
     writer->EndObject();
 }
 
-void WriteExtensions(JsonWriter* writer, const VulkanApi& api, VkPhysicalDevice device) {
+/** The device's extension names, or nothing where the enumeration itself failed. */
+std::optional<std::vector<std::string>> ReadExtensions(const VulkanApi& api,
+                                                       VkPhysicalDevice device) {
     uint32_t count = 0;
     if (api.EnumerateDeviceExtensionProperties(device, nullptr, &count, nullptr) != VK_SUCCESS) {
-        return;
+        return std::nullopt;
     }
-    std::vector<VkExtensionProperties> extensions(count);
+    std::vector<VkExtensionProperties> properties(count);
     if (count > 0) {
-        if (api.EnumerateDeviceExtensionProperties(device, nullptr, &count, extensions.data()) !=
-            VK_SUCCESS) {
-            return;
+        // VK_INCOMPLETE is not a failure here any more than it is for the physical devices in
+        // Collect(): it says the list grew between the sizing call and this one, and `count` holds
+        // how many were written. Treating it as a failure would drop every extension the driver
+        // just handed over and take the whole card off the screen with them.
+        const VkResult listed =
+                api.EnumerateDeviceExtensionProperties(device, nullptr, &count, properties.data());
+        if (listed != VK_SUCCESS && listed != VK_INCOMPLETE) {
+            return std::nullopt;
         }
-        extensions.resize(count);
+        properties.resize(count);
     }
 
+    std::vector<std::string> names;
+    names.reserve(properties.size());
+    for (const VkExtensionProperties& property : properties) {
+        names.emplace_back(property.extensionName);
+    }
+    return names;
+}
+
+/** Absent where the enumeration failed, which is not the same as a device supporting none. */
+void WriteExtensions(JsonWriter* writer,
+                     const std::optional<std::vector<std::string>>& extensions) {
+    if (!extensions.has_value()) {
+        return;
+    }
     writer->Key("extensions").BeginArray();
-    for (const VkExtensionProperties& extension : extensions) {
-        writer->Value(extension.extensionName);
+    for (const std::string& name : *extensions) {
+        writer->Value(name);
     }
     writer->EndArray();
 }
 
+/**
+ * Whether this device can be asked which driver is behind it.
+ *
+ * Three separate conditions, and none of them implies another. `vkGetPhysicalDeviceProperties2` is
+ * the entry point the query is chained onto and reached core in Vulkan 1.1; the structure being
+ * chained, `VkPhysicalDeviceDriverProperties`, reached core in 1.2 and exists below that only where
+ * the device enumerates `VK_KHR_driver_properties`. Chaining a structure a device supports neither
+ * way is not something an implementation is required to tolerate, so it is not chained.
+ *
+ * Asked per physical device rather than per instance. The device reports its own API version, which
+ * is not the version the instance was created with and need not be the same on two devices of one
+ * machine — a discrete GPU and a software rasteriser in the same process routinely differ.
+ */
+bool CanQueryDriver(const VulkanApi& api, uint32_t device_api_version,
+                    const std::optional<std::vector<std::string>>& extensions) {
+    if (api.GetPhysicalDeviceProperties2 == nullptr) {
+        return false;
+    }
+    if (device_api_version >= VK_API_VERSION_1_2) {
+        return true;
+    }
+    if (!extensions.has_value()) {
+        return false;
+    }
+    return std::find(extensions->begin(), extensions->end(),
+                     VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME) != extensions->end();
+}
+
 void WriteDevice(JsonWriter* writer, const VulkanApi& api, VkPhysicalDevice device) {
+    // The 1.0 query first, because it is the one every implementation has and because what it
+    // reports — this device's own API version — is what decides whether the driver structure below
+    // may be chained at all.
+    VkPhysicalDeviceProperties base = {};
+    api.GetPhysicalDeviceProperties(device, &base);
+
+    const std::optional<std::vector<std::string>> extensions = ReadExtensions(api, device);
+    const bool driver_query = CanQueryDriver(api, base.apiVersion, extensions);
+
     VkPhysicalDeviceDriverProperties driver = {};
     driver.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES;
 
     VkPhysicalDeviceProperties2 properties2 = {};
     properties2.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-    properties2.pNext = &driver;
-
-    if (api.GetPhysicalDeviceProperties2 != nullptr) {
+    properties2.properties = base;
+    if (driver_query) {
+        properties2.pNext = &driver;
         api.GetPhysicalDeviceProperties2(device, &properties2);
-    } else {
-        api.GetPhysicalDeviceProperties(device, &properties2.properties);
     }
     const VkPhysicalDeviceProperties& properties = properties2.properties;
 
@@ -326,10 +378,13 @@ void WriteDevice(JsonWriter* writer, const VulkanApi& api, VkPhysicalDevice devi
     // What changes when the driver is updated, which is the one identifier that does.
     writer->Field("pipeline_cache_uuid", HexBytes(properties.pipelineCacheUUID, VK_UUID_SIZE));
 
-    // VkPhysicalDeviceDriverProperties reached core in Vulkan 1.2. A 1.1 driver answers the
-    // properties2 query but leaves a structure it does not know untouched, so the zero it was
-    // initialised with is how "this driver does not report a driver id" arrives — no VkDriverId is
-    // zero.
+    // Said per device, because it is decided per device: whether this one could be asked which
+    // driver is behind it. Where it could not, the keys below are absent because no query was made;
+    // where it could and they are still absent, the driver was asked and did not answer — it may
+    // leave a structure it supports untouched, and the zero it was initialised with is how that
+    // arrives, since no VkDriverId is zero.
+    writer->Field("driver_query_available", driver_query);
+
     if (driver.driverID != 0) {
         const std::string_view name = DriverIdName(driver.driverID);
         if (!name.empty()) {
@@ -344,14 +399,32 @@ void WriteDevice(JsonWriter* writer, const VulkanApi& api, VkPhysicalDevice devi
     WriteLimits(writer, properties.limits);
     WriteMemory(writer, api, device);
     WriteQueueFamilies(writer, api, device);
-    WriteExtensions(writer, api, device);
+    WriteExtensions(writer, extensions);
 }
 
-/** Fetches the instance-level functions. False when one that is core in 1.0 is missing. */
+/**
+ * Fetches `vkDestroyInstance` on its own, ahead of everything else.
+ *
+ * It is the one function whose absence would strand the instance that was just created, so it is
+ * resolved first and the guard is built from it before anything that can leave the scope runs.
+ * `vkGetInstanceProcAddr` is required to answer for a core 1.0 entry point given a live instance,
+ * and the loader exports the symbol directly as well — a loader that answers one and not the other
+ * still gets its instance destroyed.
+ */
+PFN_vkDestroyInstance ResolveDestroyInstance(PFN_vkGetInstanceProcAddr get, void* loader,
+                                             VkInstance instance) {
+    const auto destroy = Resolve<PFN_vkDestroyInstance>(get, instance, "vkDestroyInstance");
+    if (destroy != nullptr) {
+        return destroy;
+    }
+    return reinterpret_cast<PFN_vkDestroyInstance>(dlsym(loader, "vkDestroyInstance"));
+}
+
+/** Fetches the remaining instance-level functions. False when one that is core in 1.0 is missing.
+ */
 bool ResolveInstanceFunctions(VulkanApi* api, VkInstance instance) {
     const PFN_vkGetInstanceProcAddr get = api->GetInstanceProcAddr;
 
-    api->DestroyInstance = Resolve<PFN_vkDestroyInstance>(get, instance, "vkDestroyInstance");
     api->EnumeratePhysicalDevices =
             Resolve<PFN_vkEnumeratePhysicalDevices>(get, instance, "vkEnumeratePhysicalDevices");
     api->GetPhysicalDeviceProperties = Resolve<PFN_vkGetPhysicalDeviceProperties>(
@@ -369,7 +442,7 @@ bool ResolveInstanceFunctions(VulkanApi* api, VkInstance instance) {
     api->GetPhysicalDeviceProperties2 = Resolve<PFN_vkGetPhysicalDeviceProperties2>(
             get, instance, "vkGetPhysicalDeviceProperties2");
 
-    return api->DestroyInstance != nullptr && api->EnumeratePhysicalDevices != nullptr &&
+    return api->EnumeratePhysicalDevices != nullptr &&
            api->GetPhysicalDeviceProperties != nullptr &&
            api->GetPhysicalDeviceMemoryProperties != nullptr &&
            api->GetPhysicalDeviceQueueFamilyProperties != nullptr &&
@@ -380,10 +453,8 @@ std::string Collect() {
     JsonWriter writer;
     writer.BeginObject();
 
-    // Declared before the instance below, so that the instance — which holds pointers into this
-    // library — is destroyed before the library is closed.
-    const Loader loader;
-    if (loader.get() == nullptr) {
+    void* const loader = Loader();
+    if (loader == nullptr) {
         writer.Field("loader_present", false);
         writer.EndObject();
         return writer.Take();
@@ -391,8 +462,8 @@ std::string Collect() {
     writer.Field("loader_present", true);
 
     VulkanApi api;
-    api.GetInstanceProcAddr = reinterpret_cast<PFN_vkGetInstanceProcAddr>(
-            dlsym(loader.get(), "vkGetInstanceProcAddr"));
+    api.GetInstanceProcAddr =
+            reinterpret_cast<PFN_vkGetInstanceProcAddr>(dlsym(loader, "vkGetInstanceProcAddr"));
     if (api.GetInstanceProcAddr == nullptr) {
         writer.Field("instance_ok", false);
         writer.Field("instance_error", "initialization_failed");
@@ -445,9 +516,14 @@ std::string Collect() {
         return writer.Take();
     }
 
-    const bool resolved = ResolveInstanceFunctions(&api, instance);
+    // Resolved and guarded before anything else runs against the instance: every branch below this
+    // point can leave the scope, and the guard is the only thing that destroys what was just
+    // created. A null here is a loader that answers neither query for a core 1.0 entry point, which
+    // leaves no way to destroy the instance at all — so the collector stops rather than going on to
+    // read a device with an instance it cannot give back.
+    api.DestroyInstance = ResolveDestroyInstance(api.GetInstanceProcAddr, loader, instance);
     const ScopedInstance scoped(api.DestroyInstance, instance);
-    if (!resolved) {
+    if (api.DestroyInstance == nullptr || !ResolveInstanceFunctions(&api, instance)) {
         writer.Field("instance_ok", false);
         writer.Field("instance_error", "initialization_failed");
         writer.EndObject();

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeAudioInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeAudioInspector.kt
@@ -86,7 +86,18 @@ data class AudioHardware(
     val channelCount: Int? = null,
     val format: String? = null,
     val formatUnnameable: Boolean = false
-)
+) {
+    /**
+     * Whether the queries answered anything at all.
+     *
+     * The collector writes this object whenever the device is new enough to be asked, so its
+     * presence says the questions were put — not that the HAL answered them. A legacy shared stream
+     * answers all three with an error, and the screen has to say that rather than show a heading
+     * with nothing under it.
+     */
+    val hasReadings: Boolean
+        get() = sampleRate != null || channelCount != null || format != null || formatUnnameable
+}
 
 /**
  * One request, and the two answers to it.

--- a/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeVulkanInspector.kt
+++ b/app/src/main/java/com/aoscoremonitor/diagnostics/jni/NativeVulkanInspector.kt
@@ -63,8 +63,14 @@ data class VulkanQueueFamily(
 /**
  * One physical device, as its driver describes it.
  *
- * @param driverIdName the driver behind the device, named. Null both where the driver is one this
- *   app has no name for and where the device implements Vulkan 1.1, which predates the query.
+ * @param driverId the driver behind the device, as the enum value that identifies it. Null where
+ *   the driver reported none — see [driverQueryAvailable] for the two reasons that happens.
+ * @param driverIdName the same id, named. Null where [driverId] is, and also where the id is one
+ *   this app has no name for — the number is still there.
+ * @param driverQueryAvailable whether this device could be asked which driver is behind it at all.
+ *   The query needs Vulkan 1.2 or the `VK_KHR_driver_properties` extension, both of which are
+ *   properties of this device rather than of the instance, so two devices in one process can
+ *   differ. False means [driverId] is absent because nothing was asked.
  * @param driverVersionRaw the driver's own version number, unpacked. Its encoding is the vendor's
  *   choice, so [driverVersion] — the conventional split — is a reading of it rather than a fact
  *   about it.
@@ -80,6 +86,7 @@ data class VulkanDevice(
     val pipelineCacheUuid: String? = null,
     val driverId: Int? = null,
     val driverIdName: String? = null,
+    val driverQueryAvailable: Boolean = false,
     val driverName: String? = null,
     val driverInfo: String? = null,
     val conformanceVersion: String? = null,
@@ -140,8 +147,18 @@ class NativeVulkanInspector {
     }
 }
 
-internal fun parseVulkan(json: String): VulkanSnapshot {
+/**
+ * The reading, or null where the collector produced none.
+ *
+ * A collector that threw hands back an empty object, and every field of a snapshot built from one
+ * would be a default that reads as a statement about the device — `loaderPresent = false` says this
+ * phone has no Vulkan loader, which is a claim the app would be making about its own failure. The
+ * loader is the one thing the collector reports whatever else happened, so its absence is how an
+ * empty document is told apart from a device with nothing to report.
+ */
+internal fun parseVulkan(json: String): VulkanSnapshot? {
     val root = JSONObject(json)
+    if (!root.has("loader_present")) return null
 
     val devices = root.optJSONArray("devices")?.mapObjects { device ->
         VulkanDevice(
@@ -155,8 +172,11 @@ internal fun parseVulkan(json: String): VulkanSnapshot {
             pipelineCacheUuid = device.stringOrNull("pipeline_cache_uuid"),
             driverId = device.intOrNull("driver_id"),
             driverIdName = device.stringOrNull("driver_id_name"),
-            driverName = device.stringOrNull("driver_name"),
-            driverInfo = device.stringOrNull("driver_info"),
+            driverQueryAvailable = device.optBoolean("driver_query_available"),
+            // Blank is not a name: a driver that fills the structure with an empty string has
+            // reported nothing, and a row rendered from one is an empty row under a label.
+            driverName = device.stringOrNull("driver_name")?.takeIf { it.isNotBlank() },
+            driverInfo = device.stringOrNull("driver_info")?.takeIf { it.isNotBlank() },
             conformanceVersion = device.stringOrNull("conformance_version"),
             limits = device.longMap("limits"),
             memoryHeaps = device.optJSONArray("memory_heaps")?.mapObjects { heap ->

--- a/app/src/main/java/com/aoscoremonitor/ui/components/RefreshFab.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/components/RefreshFab.kt
@@ -1,0 +1,58 @@
+package com.aoscoremonitor.ui.components
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.aoscoremonitor.R
+
+/**
+ * Asks for a new reading, and shows that one is being taken.
+ *
+ * The screens that use this do not poll, so a tap is the only thing that produces a new reading —
+ * and the readings behind it are slow enough to be waited on: four AAudio streams opened and closed,
+ * or a Vulkan instance created and destroyed. Without the spinner the button answers a tap with
+ * nothing at all for about a second, and since the view models drop taps that arrive while a read is
+ * in flight, tapping again does not help either. The state is the one honest thing to show there.
+ *
+ * The label changes with it rather than only the icon: a spinner that replaces an icon is invisible
+ * to TalkBack, which would go on offering "Refresh" for a button that has stopped accepting taps.
+ */
+@Composable
+fun RefreshFab(onRefresh: () -> Unit, isRefreshing: Boolean, modifier: Modifier = Modifier) {
+    val description = stringResource(if (isRefreshing) R.string.action_refreshing else R.string.action_refresh)
+    FloatingActionButton(
+        // FloatingActionButton has no enabled parameter, so being unavailable has to be said twice:
+        // the tap is swallowed here rather than sent to the view model to be dropped there, and the
+        // semantics carry `disabled` so that TalkBack and Switch Access stop offering a button that
+        // would do nothing. Without the second half the spinner is invisible to them and the
+        // control still reads as actionable.
+        onClick = { if (!isRefreshing) onRefresh() },
+        modifier = modifier.semantics {
+            contentDescription = description
+            if (isRefreshing) disabled()
+        }
+    ) {
+        if (isRefreshing) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(24.dp),
+                // The container's own content colour: the default is the theme's primary, which is
+                // what the container is painted in.
+                color = LocalContentColor.current,
+                strokeWidth = 2.dp
+            )
+        } else {
+            Icon(imageVector = Icons.Default.Refresh, contentDescription = null)
+        }
+    }
+}

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/AudioPathScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/AudioPathScreen.kt
@@ -10,9 +10,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.GraphicEq
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -36,6 +33,7 @@ import com.aoscoremonitor.ui.components.MonitorCard
 import com.aoscoremonitor.ui.components.MonitorScaffold
 import com.aoscoremonitor.ui.components.MonitorTag
 import com.aoscoremonitor.ui.components.ReadingStatus
+import com.aoscoremonitor.ui.components.RefreshFab
 import com.aoscoremonitor.ui.components.SectionHeader
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
 import com.aoscoremonitor.ui.theme.MonitorPreviews
@@ -65,12 +63,7 @@ private fun AudioPathContent(uiState: AudioPathUiState, onNavigateBack: () -> Un
         floatingActionButton = {
             // Worth offering here in a way it is not on the other native screens: what the system
             // grants depends on what else is playing, so the answer can change between taps.
-            FloatingActionButton(onClick = onRefresh) {
-                Icon(
-                    imageVector = Icons.Default.Refresh,
-                    contentDescription = stringResource(R.string.action_refresh)
-                )
-            }
+            RefreshFab(onRefresh = onRefresh, isRefreshing = uiState.isRefreshing)
         }
     ) { innerPadding ->
         val snapshot = uiState.audio
@@ -296,6 +289,16 @@ private fun HardwareBlock(hardware: AudioHardware, isResampled: Boolean, isForma
     if (hardware.formatUnnameable) {
         Text(
             text = stringResource(R.string.audio_format_unnameable),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+    // The same rule one level up. The collector writes this object whenever the device is new
+    // enough for the questions to be put, and a HAL that answers none of them leaves every row
+    // above unrendered — a heading with nothing under it, which reads as though nobody looked.
+    if (!hardware.hasReadings) {
+        Text(
+            text = stringResource(R.string.audio_hardware_unanswered),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/LoadedLibrariesScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/LoadedLibrariesScreen.kt
@@ -11,9 +11,6 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Layers
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -32,6 +29,7 @@ import com.aoscoremonitor.diagnostics.jni.ModuleSnapshot
 import com.aoscoremonitor.ui.components.FullScreenMessage
 import com.aoscoremonitor.ui.components.MonitorCard
 import com.aoscoremonitor.ui.components.MonitorScaffold
+import com.aoscoremonitor.ui.components.RefreshFab
 import com.aoscoremonitor.ui.components.SectionHeader
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
 import com.aoscoremonitor.ui.theme.MonitorPreviews
@@ -66,12 +64,7 @@ private fun LoadedLibrariesContent(
         floatingActionButton = {
             // This screen does not poll — the loaded set barely changes — so taking a new reading
             // has to be something the user can ask for.
-            FloatingActionButton(onClick = onRefresh) {
-                Icon(
-                    imageVector = Icons.Default.Refresh,
-                    contentDescription = stringResource(R.string.action_refresh)
-                )
-            }
+            RefreshFab(onRefresh = onRefresh, isRefreshing = uiState.isRefreshing)
         }
     ) { innerPadding ->
         val snapshot = uiState.modules

--- a/app/src/main/java/com/aoscoremonitor/ui/screens/VulkanScreen.kt
+++ b/app/src/main/java/com/aoscoremonitor/ui/screens/VulkanScreen.kt
@@ -9,10 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.ViewInAr
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,6 +25,7 @@ import com.aoscoremonitor.diagnostics.formatBytes
 import com.aoscoremonitor.diagnostics.jni.VulkanDevice
 import com.aoscoremonitor.diagnostics.jni.VulkanDeviceType
 import com.aoscoremonitor.diagnostics.jni.VulkanMemoryHeap
+import com.aoscoremonitor.diagnostics.jni.VulkanMemoryType
 import com.aoscoremonitor.diagnostics.jni.VulkanQueueFamily
 import com.aoscoremonitor.diagnostics.jni.VulkanSnapshot
 import com.aoscoremonitor.ui.components.ExpandableTextCard
@@ -36,6 +34,7 @@ import com.aoscoremonitor.ui.components.LabeledValue
 import com.aoscoremonitor.ui.components.MonitorCard
 import com.aoscoremonitor.ui.components.MonitorScaffold
 import com.aoscoremonitor.ui.components.MonitorTag
+import com.aoscoremonitor.ui.components.RefreshFab
 import com.aoscoremonitor.ui.components.SectionHeader
 import com.aoscoremonitor.ui.theme.AOSCoreMonitorTheme
 import com.aoscoremonitor.ui.theme.MonitorPreviews
@@ -64,12 +63,7 @@ private fun VulkanContent(uiState: VulkanUiState, onNavigateBack: () -> Unit, on
         modifier = modifier,
         floatingActionButton = {
             // Nothing here changes while the app runs, so a new reading has to be asked for.
-            FloatingActionButton(onClick = onRefresh) {
-                Icon(
-                    imageVector = Icons.Default.Refresh,
-                    contentDescription = stringResource(R.string.action_refresh)
-                )
-            }
+            RefreshFab(onRefresh = onRefresh, isRefreshing = uiState.isRefreshing)
         }
     ) { innerPadding ->
         // Checked here rather than folded into unavailableMessage, so that the compiler carries the
@@ -190,6 +184,20 @@ private fun DeviceCard(device: VulkanDevice, modifier: Modifier = Modifier) {
             valueStyle = MonitorTypography.machineText
         )
 
+        // The reading this screen exists for. Nothing in the Java API distinguishes a Qualcomm
+        // driver from a Mesa one, and the driver name below it is vendor-formatted prose that a
+        // driver may leave empty; the id is the one answer with a fixed meaning.
+        if (device.driverId != null) {
+            LabeledValue(
+                label = stringResource(R.string.vulkan_device_driver_id),
+                // Named where this app has a name for the id, and the number where it does not: an
+                // id registered after this build is still an answer, and it is not "unknown".
+                value = device.driverIdName
+                    ?: stringResource(R.string.vulkan_device_driver_id_unnamed, device.driverId),
+                valueStyle = MonitorTypography.machineText
+            )
+        }
+
         if (device.driverName != null) {
             LabeledValue(
                 label = stringResource(R.string.vulkan_device_driver),
@@ -238,11 +246,18 @@ private fun DeviceCard(device: VulkanDevice, modifier: Modifier = Modifier) {
             )
         }
 
-        // Said rather than left blank: the driver identity query reached core in Vulkan 1.2, so a
-        // 1.1 device is silent here for a reason the screen can name.
-        if (device.driverName == null) {
+        // Said rather than left blank, and worded from what was measured rather than from a version
+        // nobody read: an implementation without the properties query was never asked for a driver
+        // id, and one that has the query and reported none was asked and did not answer.
+        if (device.driverId == null) {
             Text(
-                text = stringResource(R.string.vulkan_device_no_driver_properties),
+                text = stringResource(
+                    if (device.driverQueryAvailable) {
+                        R.string.vulkan_device_driver_not_reported
+                    } else {
+                        R.string.vulkan_device_driver_query_absent
+                    }
+                ),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -277,7 +292,55 @@ private fun MemoryCard(device: VulkanDevice, modifier: Modifier = Modifier) {
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
+        device.memoryTypes.forEach { type -> MemoryTypeRow(type) }
     }
+}
+
+@Composable
+private fun MemoryTypeRow(type: VulkanMemoryType, modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = Spacing.ExtraSmall),
+        horizontalArrangement = Arrangement.spacedBy(Spacing.Small)
+    ) {
+        Text(
+            text = stringResource(R.string.vulkan_memory_type, type.index, type.heapIndex),
+            style = MonitorTypography.machineText
+        )
+        Text(
+            text = type.describeProperties(),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+/**
+ * The properties that make one type different from another on the same heap.
+ *
+ * Two types over one heap — which is what a phone reports — are the same memory reached on
+ * different terms, and these flags are the terms: whether the CPU can map it, whether a map needs
+ * flushing, whether it is reserved for protected content. A count of types says none of that.
+ *
+ * Written as words rather than pills: six flags is more than a row of tags fits on a phone, and a
+ * pill says nothing to a screen reader that the word does not.
+ */
+@Composable
+private fun VulkanMemoryType.describeProperties(): String {
+    val properties = buildList {
+        if (isDeviceLocal) add(R.string.vulkan_property_device_local)
+        if (isHostVisible) add(R.string.vulkan_property_host_visible)
+        if (isHostCoherent) add(R.string.vulkan_property_host_coherent)
+        if (isHostCached) add(R.string.vulkan_property_host_cached)
+        if (isLazilyAllocated) add(R.string.vulkan_property_lazily_allocated)
+        if (isProtected) add(R.string.vulkan_property_protected)
+    }
+    // A type with no flags set is legal and means something — plain device memory the CPU cannot
+    // reach — so it is named rather than left as an empty half of the row.
+    if (properties.isEmpty()) return stringResource(R.string.vulkan_property_none)
+    return properties.map { stringResource(it) }.joinToString(separator = ", ")
 }
 
 @Composable
@@ -291,7 +354,7 @@ private fun HeapRow(heap: VulkanMemoryHeap, modifier: Modifier = Modifier) {
             style = MonitorTypography.machineText
         )
         Row(horizontalArrangement = Arrangement.spacedBy(Spacing.Small)) {
-            if (heap.isDeviceLocal) MonitorTag(stringResource(R.string.vulkan_heap_device_local))
+            if (heap.isDeviceLocal) MonitorTag(stringResource(R.string.vulkan_property_device_local))
             Text(
                 text = formatBytes(heap.sizeBytes),
                 style = MaterialTheme.typography.bodyMedium,
@@ -337,6 +400,18 @@ private fun QueueFamilyRow(family: VulkanQueueFamily, modifier: Modifier = Modif
         if (family.sparseBinding) MonitorTag(stringResource(R.string.vulkan_queue_sparse))
         if (family.protectedMemory) MonitorTag(stringResource(R.string.vulkan_queue_protected))
     }
+    // Zero is a statement about the family rather than a missing reading: a queue with no valid
+    // timestamp bits cannot be profiled with timestamp queries at all, and which families can is
+    // not the same on every family of one device.
+    Text(
+        text = if (family.timestampBits > 0) {
+            stringResource(R.string.vulkan_queue_timestamps, family.timestampBits)
+        } else {
+            stringResource(R.string.vulkan_queue_no_timestamps)
+        },
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
 }
 
 @Composable
@@ -404,6 +479,7 @@ private fun VulkanPreview() {
                             pipelineCacheUuid = "1d3f5e0a9c4b2761d8e0f3a4b5c60718",
                             driverId = 8,
                             driverIdName = "qualcomm_proprietary",
+                            driverQueryAvailable = true,
                             driverName = "Qualcomm Technologies Inc. Adreno Vulkan Driver",
                             driverInfo = "Vulkan 1.3.275 (Adreno 740)",
                             conformanceVersion = "1.3.6.3",
@@ -417,6 +493,16 @@ private fun VulkanPreview() {
                             ),
                             memoryHeaps = listOf(
                                 VulkanMemoryHeap(index = 0, sizeBytes = 11_453_246_976, isDeviceLocal = true)
+                            ),
+                            memoryTypes = listOf(
+                                VulkanMemoryType(index = 0, heapIndex = 0, isDeviceLocal = true),
+                                VulkanMemoryType(
+                                    index = 1,
+                                    heapIndex = 0,
+                                    isDeviceLocal = true,
+                                    isHostVisible = true,
+                                    isHostCoherent = true
+                                )
                             ),
                             queueFamilies = listOf(
                                 VulkanQueueFamily(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="action_expand">Show all</string>
     <string name="action_collapse">Show less</string>
     <string name="action_refresh">Take a new reading</string>
+    <string name="action_refreshing">Taking a reading…</string>
     <string name="sample_data_label">Sample data</string>
     <string name="status_supported">Supported</string>
     <string name="status_not_supported">Not supported</string>
@@ -581,7 +582,7 @@
     <!-- Vulkan -->
     <string name="vulkan_title">Vulkan</string>
     <string name="vulkan_loading">Asking the Vulkan loader what this device has…</string>
-    <string name="vulkan_unavailable">The native library did not load, so Vulkan cannot be asked.</string>
+    <string name="vulkan_unavailable">The Vulkan reading could not be taken: either the native library did not load, or the collector stopped before it reported anything. Logcat carries the reason.</string>
     <string name="vulkan_no_loader">This device has no Vulkan loader, so there is nothing to ask.</string>
     <string name="vulkan_instance_failed">The loader is here, but no Vulkan instance could be created: %1$s.</string>
     <string name="vulkan_instance_failed_code">The loader is here, but no Vulkan instance could be created (VkResult %1$d).</string>
@@ -592,6 +593,8 @@
         <item quantity="other">%1$d devices · instance %2$s</item>
     </plurals>
     <string name="vulkan_device_api">API version</string>
+    <string name="vulkan_device_driver_id">Driver id</string>
+    <string name="vulkan_device_driver_id_unnamed">id %1$d, which this app has no name for</string>
     <string name="vulkan_device_driver">Driver</string>
     <string name="vulkan_device_driver_version">Driver version</string>
     <string name="vulkan_device_driver_version_value">%1$s · raw %2$d</string>
@@ -599,7 +602,8 @@
     <string name="vulkan_device_ids_value">%1$s · %2$s</string>
     <string name="vulkan_device_conformance">Conformance</string>
     <string name="vulkan_device_cache_uuid">Pipeline cache UUID</string>
-    <string name="vulkan_device_no_driver_properties">This device implements Vulkan 1.1, which predates the query that names a driver.</string>
+    <string name="vulkan_device_driver_not_reported">This driver was asked which driver it is and did not say: the query that names one reached core in Vulkan 1.2, and a driver may answer the surrounding call without filling it in.</string>
+    <string name="vulkan_device_driver_query_absent">This device\'s Vulkan implementation has no properties query, so it was never asked which driver is behind it. That query reached core in Vulkan 1.1.</string>
     <string name="vulkan_type_integrated">Integrated GPU</string>
     <string name="vulkan_type_discrete">Discrete GPU</string>
     <string name="vulkan_type_virtual">Virtual GPU</string>
@@ -612,7 +616,14 @@
         <item quantity="other">%1$d heaps · %2$s in total</item>
     </plurals>
     <string name="vulkan_heap">Heap %1$d</string>
-    <string name="vulkan_heap_device_local">device local</string>
+    <string name="vulkan_memory_type">Type %1$d · heap %2$d</string>
+    <string name="vulkan_property_device_local">device local</string>
+    <string name="vulkan_property_host_visible">host visible</string>
+    <string name="vulkan_property_host_coherent">host coherent</string>
+    <string name="vulkan_property_host_cached">host cached</string>
+    <string name="vulkan_property_lazily_allocated">lazily allocated</string>
+    <string name="vulkan_property_protected">protected</string>
+    <string name="vulkan_property_none">no properties, so the CPU cannot reach it</string>
     <plurals name="vulkan_memory_types">
         <item quantity="one">%1$d memory type</item>
         <item quantity="other">%1$d memory types</item>
@@ -628,6 +639,8 @@
     <string name="vulkan_queue_transfer">transfer</string>
     <string name="vulkan_queue_sparse">sparse</string>
     <string name="vulkan_queue_protected">protected</string>
+    <string name="vulkan_queue_timestamps">%1$d valid timestamp bits</string>
+    <string name="vulkan_queue_no_timestamps">No valid timestamp bits, so this family cannot be profiled with timestamp queries.</string>
     <string name="vulkan_limits_section">Limits</string>
     <string name="vulkan_limit_image_2d">Max 2D image</string>
     <string name="vulkan_limit_descriptor_sets">Bound descriptor sets</string>
@@ -670,6 +683,7 @@
     <string name="audio_row_buffer">Buffer</string>
     <string name="audio_row_device">Output device</string>
     <string name="audio_row_hardware">Hardware underneath</string>
+    <string name="audio_hardware_unanswered">This device can be asked what the hardware runs at, and its audio HAL answered none of the three questions for this stream. That is common on a stream that did not take the MMAP path.</string>
     <string name="audio_hz">%1$d Hz</string>
     <string name="audio_buffer_value">%1$d of %2$d frames</string>
     <string name="audio_sharing_exclusive">exclusive</string>

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/AudioPathParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/AudioPathParsingTest.kt
@@ -2,6 +2,7 @@ package com.aoscoremonitor.diagnostics.jni
 
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -168,6 +169,34 @@ class AudioPathParsingTest {
         assertFalse(probe.grantedAsRequested)
         // Nothing to compare against, so a refusal must not read as a resampled path.
         assertFalse(probe.isResampled)
+    }
+
+    /**
+     * A query that was put and answered nothing is not a query that was never put.
+     *
+     * The collector opens the hardware object whenever the device is new enough to be asked, and a
+     * HAL that implements none of the three leaves it empty — which is what a legacy shared stream
+     * does. The object arriving says the questions were asked; [AudioHardware.hasReadings] is what
+     * the screen needs to avoid printing a heading with nothing under it.
+     */
+    @Test
+    fun aHardwareObjectWithNoReadingsSaysTheQueriesWentUnanswered() {
+        val snapshot = parseAudioPath(
+            """
+            {"hardware_query_available":true,"probes":[
+              {"label":"default_shared","requested":{"performance_mode":"none","sharing_mode":"shared"},
+               "open_ok":true,
+               "granted":{"performance_mode":"none","sharing_mode":"shared","format":"pcm_float",
+                          "sample_rate":48000},
+               "hardware":{}}]}
+            """.trimIndent()
+        )
+
+        val probe = snapshot.probes.single()
+        assertNotNull("The query was put, so the object must survive the parse", probe.hardware)
+        assertFalse("Nothing was answered, so there is nothing to show", probe.hardware!!.hasReadings)
+        assertFalse(probe.isResampled)
+        assertFalse(probe.isFormatConverted)
     }
 
     /** Below API 34 the hardware readings do not exist, which is not the same as matching. */

--- a/app/src/test/java/com/aoscoremonitor/diagnostics/jni/VulkanParsingTest.kt
+++ b/app/src/test/java/com/aoscoremonitor/diagnostics/jni/VulkanParsingTest.kt
@@ -10,7 +10,7 @@ class VulkanParsingTest {
 
     @Test
     fun readsADeviceAndItsDriver() {
-        val snapshot = parseVulkan(
+        val snapshot = requireVulkan(
             """
             {"loader_present":true,"instance_version":"1.3.275","instance_ok":true,"devices":[
               {"name":"Adreno (TM) 740","type":"integrated_gpu","api_version":"1.3.275",
@@ -39,15 +39,16 @@ class VulkanParsingTest {
         assertEquals("512.780.0", device.driverVersion)
     }
 
-    /** A 1.1 device answers the properties query and says nothing about its driver. */
+    /** A 1.1 device without the extension was never asked, and says so. */
     @Test
     fun aDeviceWithoutDriverPropertiesReportsNoneRatherThanAnEmptyString() {
-        val snapshot = parseVulkan(
+        val snapshot = requireVulkan(
             """
             {"loader_present":true,"instance_ok":true,"devices":[
               {"name":"Mali-G78","type":"integrated_gpu","api_version":"1.1.128",
                "vendor_id":"0x13b5","device_id":"0x70930000",
-               "driver_version_raw":1,"driver_version":"0.0.1"}]}
+               "driver_version_raw":1,"driver_version":"0.0.1",
+               "driver_query_available":false}]}
             """.trimIndent()
         )
 
@@ -56,11 +57,41 @@ class VulkanParsingTest {
         assertNull(device.driverId)
         assertNull(device.driverName)
         assertNull(device.conformanceVersion)
+        assertFalse(device.driverQueryAvailable)
+    }
+
+    /**
+     * Whether the driver could be asked is a fact about one device, not about the instance.
+     *
+     * The query needs Vulkan 1.2 or `VK_KHR_driver_properties`, and both are reported by the
+     * physical device. Two devices behind one loader — a GPU and a software rasteriser, which is
+     * what an emulator shows — can differ, and a flag carried once for the instance could not say
+     * that the first was asked and answered while the second was never asked at all.
+     */
+    @Test
+    fun theDriverQueryIsAnsweredPerDeviceRatherThanPerInstance() {
+        val snapshot = requireVulkan(
+            """
+            {"loader_present":true,"instance_ok":true,"devices":[
+              {"name":"Adreno","type":"integrated_gpu","api_version":"1.3.275","vendor_id":"0x1",
+               "device_id":"0x2","driver_version_raw":1,"driver_version":"0.0.1",
+               "driver_query_available":true,"driver_id":8,"driver_id_name":"qualcomm_proprietary"},
+              {"name":"Mali-G78","type":"integrated_gpu","api_version":"1.1.128","vendor_id":"0x3",
+               "device_id":"0x4","driver_version_raw":1,"driver_version":"0.0.1",
+               "driver_query_available":false}]}
+            """.trimIndent()
+        )
+
+        val (asked, notAsked) = snapshot.devices
+        assertTrue(asked.driverQueryAvailable)
+        assertEquals("qualcomm_proprietary", asked.driverIdName)
+        assertFalse(notAsked.driverQueryAvailable)
+        assertNull(notAsked.driverId)
     }
 
     @Test
     fun readsHeapsTypesAndQueueFamilies() {
-        val snapshot = parseVulkan(
+        val snapshot = requireVulkan(
             """
             {"loader_present":true,"instance_ok":true,"devices":[
               {"name":"g","type":"integrated_gpu","api_version":"1.3.0","vendor_id":"0x1",
@@ -88,7 +119,7 @@ class VulkanParsingTest {
 
     @Test
     fun extensionsArriveSorted() {
-        val snapshot = parseVulkan(
+        val snapshot = requireVulkan(
             """
             {"loader_present":true,"instance_ok":true,"devices":[
               {"name":"g","type":"cpu","api_version":"1.0.0","vendor_id":"0x1","device_id":"0x2",
@@ -112,7 +143,7 @@ class VulkanParsingTest {
      */
     @Test
     fun aDeviceWithNoLoaderSaysSoRatherThanReportingNoDevices() {
-        val snapshot = parseVulkan("""{"loader_present":false}""")
+        val snapshot = requireVulkan("""{"loader_present":false}""")
 
         assertFalse(snapshot.loaderPresent)
         assertFalse(snapshot.instanceCreated)
@@ -122,7 +153,7 @@ class VulkanParsingTest {
 
     @Test
     fun aFailedInstanceCarriesTheResultThatStoppedIt() {
-        val snapshot = parseVulkan(
+        val snapshot = requireVulkan(
             """{"loader_present":true,"instance_version":"1.1.0","instance_ok":false,
                 "instance_error":"incompatible_driver"}"""
         )
@@ -136,7 +167,7 @@ class VulkanParsingTest {
     /** A result this app has no name for crosses as its number rather than as a wrong name. */
     @Test
     fun anUnnamedResultCarriesItsCode() {
-        val snapshot = parseVulkan(
+        val snapshot = requireVulkan(
             """{"loader_present":true,"instance_ok":false,"instance_error_code":-13}"""
         )
 
@@ -146,7 +177,7 @@ class VulkanParsingTest {
 
     @Test
     fun anInstanceThatEnumeratedNothingIsNotAFailure() {
-        val snapshot = parseVulkan("""{"loader_present":true,"instance_ok":true,"devices":[]}""")
+        val snapshot = requireVulkan("""{"loader_present":true,"instance_ok":true,"devices":[]}""")
 
         assertTrue(snapshot.instanceCreated)
         assertTrue(snapshot.devices.isEmpty())
@@ -154,7 +185,7 @@ class VulkanParsingTest {
 
     @Test
     fun anUnnamedDeviceTypeIsUnknownRatherThanAGuess() {
-        val snapshot = parseVulkan(
+        val snapshot = requireVulkan(
             """
             {"loader_present":true,"instance_ok":true,"devices":[
               {"name":"g","type":"quantum_gpu","api_version":"1.3.0","vendor_id":"0x1",
@@ -164,4 +195,39 @@ class VulkanParsingTest {
 
         assertEquals(VulkanDeviceType.Unknown, snapshot.devices.single().type)
     }
+
+    /**
+     * A collector that produced nothing is not a device with nothing.
+     *
+     * `ReturnJson` hands back an empty object when a collector throws, and a snapshot built from one
+     * would carry `loaderPresent = false` — the screen would then tell the user this phone has no
+     * Vulkan loader, which is the app describing its own failure as a fact about the device.
+     */
+    @Test
+    fun anEmptyDocumentIsNoReadingRatherThanADeviceWithNoLoader() {
+        assertNull(parseVulkan("{}"))
+    }
+
+    /** A driver that fills its name in with nothing has reported nothing. */
+    @Test
+    fun aBlankDriverNameIsNoNameRatherThanAnEmptyRow() {
+        val snapshot = requireVulkan(
+            """
+            {"loader_present":true,"instance_ok":true,"driver_query_available":true,"devices":[
+              {"name":"g","type":"integrated_gpu","api_version":"1.3.0","vendor_id":"0x1",
+               "device_id":"0x2","driver_version_raw":1,"driver_version":"0.0.1",
+               "driver_id":6,"driver_id_name":"mesa_turnip","driver_name":"","driver_info":"  "}]}
+            """.trimIndent()
+        )
+
+        val device = snapshot.devices.single()
+        assertNull(device.driverName)
+        assertNull(device.driverInfo)
+        // The id survives it: that is the reading, and it is there whether or not the prose is.
+        assertEquals("mesa_turnip", device.driverIdName)
+    }
+
+    /** The parser answers for a document; a null one means the collector produced none. */
+    private fun requireVulkan(json: String): VulkanSnapshot =
+        requireNotNull(parseVulkan(json)) { "parseVulkan returned no reading for: $json" }
 }


### PR DESCRIPTION
## Correctness

- **Never `dlclose` libvulkan.** The loader was reopened and closed on every
  reading. A driver leaves helper threads and TLS destructors behind after
  `vkDestroyInstance`, so unmapping it could crash on a thread this app does
  not own — after the screen loaded, or on the next refresh.
- **`VK_INCOMPLETE` is not a failure** when enumerating device extensions,
  any more than it is for physical devices. It was dropping the whole list.
- **Resolve `vkDestroyInstance` first** and build the scope guard from it
  immediately, with a `dlsym` fallback, so no path can strand an instance.
- **Ask per physical device whether the driver id can be queried.** It needs
  Vulkan 1.2 or `VK_KHR_driver_properties` — both device properties, not
  instance ones — so the structure is chained only where that holds, and two
  devices behind one loader can differ.
- **An empty collector document is no reading.** `{}` used to parse to
  `loaderPresent = false`, so a collector that threw made the screen state
  that the device has no Vulkan loader.

## What the screens now say

The driver id, the memory type properties, and queue timestamp bits were
collected, parsed and never rendered. They are shown. The driver note is
worded from what was measured — asked and unanswered, or never asked — in
place of a hardcoded "Vulkan 1.1" that could contradict the API version two
rows above it. The audio card says so when the HAL answers none of the
hardware queries, instead of leaving a heading with nothing under it.

`isRefreshing` was in both new UI states and read by neither screen. A shared
`RefreshFab` shows a spinner and carries `disabled` semantics while a reading
is in flight, so the state reaches TalkBack and Switch Access too.